### PR TITLE
Update Prompted Generator - Add Box Prompts

### DIFF
--- a/micro_sam/prompt_generators.py
+++ b/micro_sam/prompt_generators.py
@@ -4,12 +4,15 @@ from scipy.ndimage import binary_dilation
 
 class PointAndBoxPromptGenerator:
     def __init__(self, n_positive_points, n_negative_points, dilation_strength,
-                 get_point_prompts=False, get_box_prompts=False):
+                 get_point_prompts=True, get_box_prompts=False):
         self.n_positive_points = n_positive_points
         self.n_negative_points = n_negative_points
         self.dilation_strength = dilation_strength
         self.get_box_prompts = get_box_prompts
         self.get_point_prompts = get_point_prompts
+
+        if self.get_point_prompts is False and self.get_box_prompts is False:
+            raise ValueError("You need to request for box/point prompts or both")
 
     def __call__(self, gt, gt_id, center_coordinates, bbox_coordinates):
         """
@@ -80,7 +83,7 @@ class PointAndBoxPromptGenerator:
                 coord_list.append(negative_coordinates)
                 label_list.append(0)
 
-        # returns object-level masks per instance for cross-verification (fix it later)
+        # returns object-level masks per instance for cross-verification (TODO: fix it later)
         if self.get_point_prompts is True and self.get_box_prompts is True:  # we want points and box
             return coord_list, label_list, bbox_list, object_mask
 
@@ -89,6 +92,3 @@ class PointAndBoxPromptGenerator:
 
         elif self.get_point_prompts is False and self.get_box_prompts is True:  # we want only boxes
             return None, None, bbox_list, object_mask
-        else:
-            assert self.get_point_prompts is False and self.get_box_prompts is False, \
-                "You need to request for box/point prompts or both"

--- a/micro_sam/prompt_generators.py
+++ b/micro_sam/prompt_generators.py
@@ -2,11 +2,12 @@ import numpy as np
 from scipy.ndimage import binary_dilation
 
 
-class PointPromptGenerator:
-    def __init__(self, n_positive_points, n_negative_points, dilation_strength):
+class PointAndBoxPromptGenerator:
+    def __init__(self, n_positive_points, n_negative_points, dilation_strength, get_box_prompts=False):
         self.n_positive_points = n_positive_points
         self.n_negative_points = n_negative_points
         self.dilation_strength = dilation_strength
+        self.get_box_prompts = get_box_prompts
 
     def __call__(self, gt, gt_id, center_coordinates, bbox_coordinates):
         """
@@ -20,8 +21,11 @@ class PointPromptGenerator:
         label_list = []
 
         # getting the center coordinate as the first positive point
-        coord_list.append(tuple(map(int, center_coordinates)))
+        coord_list.append(tuple(map(int, center_coordinates)))  # to get int coords instead of float
         label_list.append(1)
+
+        if self.get_box_prompts:
+            bbox_list = [bbox_coordinates]
 
         object_mask = gt == gt_id + 1  # alloting a label id to obtain the coordinates of desired seeds
 
@@ -72,4 +76,8 @@ class PointPromptGenerator:
                 coord_list.append(negative_coordinates)
                 label_list.append(0)
 
-        return coord_list, label_list, None, object_mask
+        # returns object-level masks per instance for cross-verification (fix it later)
+        if self.get_box_prompts:
+            return coord_list, label_list, bbox_list, object_mask
+        else:
+            return coord_list, label_list, None, object_mask

--- a/micro_sam/prompt_generators.py
+++ b/micro_sam/prompt_generators.py
@@ -56,8 +56,10 @@ class PointAndBoxPromptGenerator:
         dilated_object = binary_dilation(object_mask, iterations=self.dilation_strength)
         background_mask = np.zeros(gt.shape)
         background_mask[bbox_coordinates[0]:bbox_coordinates[2], bbox_coordinates[1]:bbox_coordinates[3]] = 1
-        background_mask = abs(background_mask - dilated_object)
         background_mask = binary_dilation(background_mask, iterations=self.dilation_strength)
+        background_mask = abs(
+            background_mask.astype(np.float32) - dilated_object.astype(np.float32)
+        )  # casting booleans to do subtraction
 
         n_negative_remaining = self.n_negative_points
         if n_negative_remaining > 0:


### PR DESCRIPTION
- The prompt generator now gives box prompts on top of point prompts too!

Question:
(There are two ways I thought of approaching the prompt generator class, I'll mention both below)
- One could be two separate classes (one for `PointPromptGenerator` and another for `PointAndBoxPromptGenerator`) (the differences are super slim, but might be an open utility for all purposes)
- Other could be (current PR) one class (`PointAndBoxPromptGenerator`) which returns box prompts subjected to `get_box_prompts` argument else stays consistent to just prompts (returning "None" for boxes - see [here](https://github.com/computational-cell-analytics/micro-sam/commit/3abcbd04e95aac7eee3c7c2ad977763c77824993#diff-6fe0fbcb1f8365acc6bd99b3d6125aa2ab6a1eafb20786a2b40aa1eabf4a2d90R80-R83))

Which one do you recommend?