### PR TITLE
Add Condition for Background Points

### DIFF
--- a/micro_sam/prompt_generators.py
+++ b/micro_sam/prompt_generators.py
@@ -43,17 +43,16 @@ class PointAndBoxPromptGenerator:
             # ([x1, x2, ...], [y1, y2, ...])
             n_coordinates = len(object_coordinates[0])
 
-            if n_coordinates > n_positive_remaining:  # for some cases, there aren't many forground object_coordinates
-                # randomly sampling n_positive_remaining_points from these coordinates
-                positive_indices = np.random.choice(n_coordinates, replace=False, size=n_positive_remaining)
-                for positive_index in positive_indices:
-                    positive_coordinates = int(object_coordinates[0][positive_index]), \
-                        int(object_coordinates[1][positive_index])
+            # randomly sampling n_positive_remaining_points from these coordinates
+            positive_indices = np.random.choice(n_coordinates, replace=False,
+                                                size=min(n_positive_remaining, n_coordinates)  # handles the cases with insufficient fg pixels
+                                                )
+            for positive_index in positive_indices:
+                positive_coordinates = int(object_coordinates[0][positive_index]), \
+                    int(object_coordinates[1][positive_index])
 
-                    coord_list.append(positive_coordinates)
-                    label_list.append(1)
-            else:
-                print(f"{n_coordinates} foreground pixel spotted..")
+                coord_list.append(positive_coordinates)
+                label_list.append(1)
 
         # getting the negative points
         # for this we do the opposite and we set the mask to the bounding box - the object mask
@@ -74,17 +73,16 @@ class PointAndBoxPromptGenerator:
             # ([x1, x2, ...], [y1, y2, ...])
             n_coordinates = len(background_coordinates[0])
 
-            if n_coordinates > n_negative_remaining:  # for some cases, there aren't many background object_coordinates
-                # randomly sample n_positive_remaining_points from these coordinates
-                negative_indices = np.random.choice(n_coordinates, replace=False, size=n_negative_remaining)
-                for negative_index in negative_indices:
-                    negative_coordinates = int(background_coordinates[0][negative_index]), \
-                        int(background_coordinates[1][negative_index])
+            # randomly sample n_positive_remaining_points from these coordinates
+            negative_indices = np.random.choice(n_coordinates, replace=False,
+                                                size=min(n_negative_remaining, n_coordinates)  # handles the cases with insufficient bg pixels
+                                                )
+            for negative_index in negative_indices:
+                negative_coordinates = int(background_coordinates[0][negative_index]), \
+                    int(background_coordinates[1][negative_index])
 
-                    coord_list.append(negative_coordinates)
-                    label_list.append(0)
-            else:
-                print(f"{n_coordinates} background pixel spotted..")
+                coord_list.append(negative_coordinates)
+                label_list.append(0)
 
         # returns object-level masks per instance for cross-verification (TODO: fix it later)
         if self.get_point_prompts is True and self.get_box_prompts is True:  # we want points and box

--- a/micro_sam/prompt_generators.py
+++ b/micro_sam/prompt_generators.py
@@ -43,7 +43,7 @@ class PointAndBoxPromptGenerator:
             # ([x1, x2, ...], [y1, y2, ...])
             n_coordinates = len(object_coordinates[0])
 
-            if n_coordinates > n_positive_remaining:  # for some cases, there aren't any forground object_coordinates
+            if n_coordinates > n_positive_remaining:  # for some cases, there aren't many forground object_coordinates
                 # randomly sampling n_positive_remaining_points from these coordinates
                 positive_indices = np.random.choice(n_coordinates, replace=False, size=n_positive_remaining)
                 for positive_index in positive_indices:
@@ -53,7 +53,7 @@ class PointAndBoxPromptGenerator:
                     coord_list.append(positive_coordinates)
                     label_list.append(1)
             else:
-                print(f"{n_coordinates} fg spotted..")
+                print(f"{n_coordinates} foreground pixel spotted..")
 
         # getting the negative points
         # for this we do the opposite and we set the mask to the bounding box - the object mask
@@ -74,14 +74,17 @@ class PointAndBoxPromptGenerator:
             # ([x1, x2, ...], [y1, y2, ...])
             n_coordinates = len(background_coordinates[0])
 
-            # randomly sample n_positive_remaining_points from these coordinates
-            negative_indices = np.random.choice(n_coordinates, replace=False, size=n_negative_remaining)
-            for negative_index in negative_indices:
-                negative_coordinates = int(background_coordinates[0][negative_index]), \
-                    int(background_coordinates[1][negative_index])
+            if n_coordinates > n_negative_remaining:  # for some cases, there aren't many background object_coordinates
+                # randomly sample n_positive_remaining_points from these coordinates
+                negative_indices = np.random.choice(n_coordinates, replace=False, size=n_negative_remaining)
+                for negative_index in negative_indices:
+                    negative_coordinates = int(background_coordinates[0][negative_index]), \
+                        int(background_coordinates[1][negative_index])
 
-                coord_list.append(negative_coordinates)
-                label_list.append(0)
+                    coord_list.append(negative_coordinates)
+                    label_list.append(0)
+            else:
+                print(f"{n_coordinates} background pixel spotted..")
 
         # returns object-level masks per instance for cross-verification (TODO: fix it later)
         if self.get_point_prompts is True and self.get_box_prompts is True:  # we want points and box


### PR DESCRIPTION
Similar to the positive points' [condition](https://github.com/computational-cell-analytics/micro-sam/blob/master/micro_sam/prompt_generators.py#L46), the (correct version) background points' has cases (for bg expected around 8/16) might not have enough pixels sometimes (although for bgs it can be fixed by a higher dilation), hence adding the same condition as for positives. Thanks. 