### PR TITLE
Randomize colourmap to make it easier to see when objects are committed

### DIFF
--- a/micro_sam/sam_annotator/annotator_2d.py
+++ b/micro_sam/sam_annotator/annotator_2d.py
@@ -73,6 +73,7 @@ def annotator_2d(raw, embedding_path=None, show_embeddings=False, segmentation_r
         v.add_labels(data=np.zeros(shape, dtype="uint32"), name="committed_objects")
     else:
         v.add_labels(segmentation_result, name="committed_objects")
+    v.layers["committed_objects"].new_colormap()  # randomize colors so it is easy to see when object committed
     v.add_labels(data=np.zeros(shape, dtype="uint32"), name="current_object")
 
     # show the PCA of the image embeddings

--- a/micro_sam/sam_annotator/annotator_3d.py
+++ b/micro_sam/sam_annotator/annotator_3d.py
@@ -197,6 +197,7 @@ def annotator_3d(raw, embedding_path=None, show_embeddings=False, segmentation_r
     else:
         assert segmentation_result.shape == raw.shape
         v.add_labels(data=segmentation_result, name="committed_objects")
+    v.layers["committed_objects"].new_colormap()  # randomize colors so it is easy to see when object committed
     v.add_labels(data=np.zeros(raw.shape, dtype="uint32"), name="current_object")
 
     # show the PCA of the image embeddings

--- a/micro_sam/sam_annotator/annotator_tracking.py
+++ b/micro_sam/sam_annotator/annotator_tracking.py
@@ -368,6 +368,7 @@ def annotator_tracking(raw, embedding_path=None, show_embeddings=False, tracking
     else:
         assert tracking_result.shape == raw.shape
         v.add_labels(data=tracking_result, name="committed_tracks")
+    v.layers["committed_tracks"].new_colormap()  # randomize colors so it is easy to see when object committed
     v.add_labels(data=np.zeros(raw.shape, dtype="uint32"), name="current_track")
 
     # show the PCA of the image embeddings


### PR DESCRIPTION
Closes https://github.com/computational-cell-analytics/micro-sam/issues/31

I can't see how to pass a specific random seed value to the new_colormap function, so we really do get a totally new and random color mapping each time.

Because I made this change in three places, maybe this section of the code should be refactored into a new function in micro_sam/sam_annotator/util.py?