### PR TITLE
Implement tiled prediction for image encoder

### DIFF
--- a/development/annotator_2d_tiled.py
+++ b/development/annotator_2d_tiled.py
@@ -1,0 +1,61 @@
+import imageio.v3 as imageio
+from micro_sam.sam_annotator import annotator_2d
+
+
+def annotator_with_tiling():
+    # whole slide image data from the neurips cell seg challenge
+    im = imageio.imread(
+        "/home/pape/Work/data/neurips-cell-seg/TrainUnlabeled_WholeSlide/whole_slide_00002.tiff"
+    )
+
+    # TODO make sure that it also works with RGB data
+    # im = im[..., -1]
+    im = im[:4096, :4096, -1]
+    print(im.shape)
+
+    # import napari
+    # v = napari.Viewer()
+    # v.add_image(im)
+    # napari.run()
+
+    embedding_path = "./embeddings/embeddings-tiled.zarr"
+    annotator_2d(im, embedding_path, tile_shape=(512, 512), halo=(64, 64))
+
+
+def debug():
+    import numpy as np
+    import micro_sam.util as util
+    from micro_sam.segment_from_prompts import segment_from_points, segment_from_box
+
+    im = imageio.imread(
+        "/home/pape/Work/data/neurips-cell-seg/TrainUnlabeled_WholeSlide/whole_slide_00002.tiff"
+    )
+    im = im[:4096, :4096, -1]
+
+    embedding_path = "./embeddings/embeddings-tiled.zarr"
+    predictor = util.get_sam_model(model_type="vit_h", return_sam=False)
+    image_embeddings = util.precompute_image_embeddings(
+        predictor, im, save_path=embedding_path, ndim=2, tile_shape=(512, 512), halo=(64, 64)
+    )
+
+    if False:
+        points = np.array([
+            [1718.7391402, 708.53708524],
+            [1759.25543047, 698.75729103],
+            [1715.94491328, 663.82945459],
+            [1665.64882881, 720.41254963]
+        ])
+        labels = np.array([1, 0, 0, 0])
+        segment_from_points(predictor, points, labels, image_embeddings)
+
+    if True:
+        box = np.array([2056.1861078, 1560.13288731, 2114.97895827, 1646.06089954])
+        segment_from_box(predictor, box, image_embeddings)
+
+
+def main():
+    # debug()
+    annotator_with_tiling()
+
+
+main()

--- a/development/annotator_2d_tiled.py
+++ b/development/annotator_2d_tiled.py
@@ -10,7 +10,7 @@ def annotator_with_tiling():
 
     # TODO make sure that it also works with RGB data
     # im = im[..., -1]
-    im = im[:4096, :4096, -1]
+    im = im[:4096, :4096, :]
     print(im.shape)
 
     # import napari

--- a/development/annotator_3d_tiled.py
+++ b/development/annotator_3d_tiled.py
@@ -1,0 +1,17 @@
+import z5py
+from micro_sam.sam_annotator import annotator_3d
+
+
+def annotator_with_tiling():
+    with z5py.File("/home/pape/Work/data/cremi/sampleA.n5", "r") as f:
+        raw = f["volumes/raw/s0"][:25]
+
+    embedding_path = "./embeddings/embeddings-tiled_3d.zarr"
+    annotator_3d(raw, embedding_path, tile_shape=(512, 512), halo=(64, 64))
+
+
+def main():
+    annotator_with_tiling()
+
+
+main()

--- a/development/annotator_tracking_tiled.py
+++ b/development/annotator_tracking_tiled.py
@@ -1,0 +1,15 @@
+from micro_sam.sam_annotator import annotator_tracking
+
+
+# TODO find a suitable larger 2d dataset from the ctc for this
+def annotator_with_tiling():
+    timeseries = ""
+    annotator_tracking(timeseries, embedding_path="./embeddings/embeddings-tiled_tracking.zarr",
+                       tile_shape=(512, 512), halo=(64, 64))
+
+
+def main():
+    annotator_with_tiling()
+
+
+main()

--- a/micro_sam/sam_annotator/annotator_2d.py
+++ b/micro_sam/sam_annotator/annotator_2d.py
@@ -38,7 +38,7 @@ def segment_wigdet(v: Viewer):
     v.layers["current_object"].refresh()
 
 
-# TODO this needs to be adapted if we ran tiled prediction
+# FIXME this needs to be updated for tiled prediction
 # TODO expose more parameters
 @magicgui(call_button="Segment All Objects", method={"choices": ["default", "sam", "embeddings"]})
 def autosegment_widget(v: Viewer, method: str = "default", with_background: bool = True):
@@ -201,6 +201,12 @@ def main():
     parser.add_argument(
         "--model_type", default="vit_h", help="The segment anything model that will be used, one of vit_h,l,b."
     )
+    parser.add_argument(
+        "--tile_shape", nargs="+", type=int, help="The tile shape for using tiled prediction", default=None
+    )
+    parser.add_argument(
+        "--halo", nargs="+", type=int, help="The halo for using tiled prediction", default=None
+    )
 
     args = parser.parse_args()
     raw = util.load_image_data(args.input, ndim=2, key=args.key)
@@ -216,5 +222,5 @@ def main():
     annotator_2d(
         raw, embedding_path=args.embedding_path,
         show_embeddings=args.show_embeddings, segmentation_result=segmentation_result,
-        model_type=args.model_type,
+        model_type=args.model_type, tile_shape=args.tile_shape, halo=args.halo,
     )

--- a/micro_sam/sam_annotator/annotator_3d.py
+++ b/micro_sam/sam_annotator/annotator_3d.py
@@ -317,6 +317,12 @@ def main():
     parser.add_argument(
         "--model_type", default="vit_h", help="The segment anything model that will be used, one of vit_h,l,b."
     )
+    parser.add_argument(
+        "--tile_shape", nargs="+", type=int, help="The tile shape for using tiled prediction", default=None
+    )
+    parser.add_argument(
+        "--halo", nargs="+", type=int, help="The halo for using tiled prediction", default=None
+    )
 
     args = parser.parse_args()
     raw = util.load_image_data(args.input, ndim=3, key=args.key)
@@ -332,5 +338,5 @@ def main():
     annotator_3d(
         raw, embedding_path=args.embedding_path,
         show_embeddings=args.show_embeddings, segmentation_result=segmentation_result,
-        model_type=args.model_type,
+        model_type=args.model_type, tile_shape=args.tile_shape, halo=args.halo,
     )

--- a/micro_sam/sam_annotator/annotator_3d.py
+++ b/micro_sam/sam_annotator/annotator_3d.py
@@ -176,11 +176,16 @@ def segment_volume_widget(v: Viewer, iou_threshold: float = 0.8, projection: str
     v.layers["current_object"].refresh()
 
 
-def annotator_3d(raw, embedding_path=None, show_embeddings=False, segmentation_result=None, model_type="vit_h"):
+def annotator_3d(
+    raw, embedding_path=None, show_embeddings=False, segmentation_result=None,
+    model_type="vit_h", tile_shape=None, halo=None,
+):
     # for access to the predictor and the image embeddings in the widgets
     global PREDICTOR, IMAGE_EMBEDDINGS, DEFAULT_PROJECTION
     PREDICTOR = util.get_sam_model(model_type=model_type)
-    IMAGE_EMBEDDINGS = util.precompute_image_embeddings(PREDICTOR, raw, save_path=embedding_path)
+    IMAGE_EMBEDDINGS = util.precompute_image_embeddings(
+        PREDICTOR, raw, save_path=embedding_path, tile_shape=tile_shape, halo=halo
+    )
 
     # the mask projection currently only works for square images
     DEFAULT_PROJECTION = "mask" if raw.shape[1] == raw.shape[2] else "bounding_box"

--- a/micro_sam/sam_annotator/annotator_tracking.py
+++ b/micro_sam/sam_annotator/annotator_tracking.py
@@ -345,13 +345,18 @@ def commit_tracking_widget(v: Viewer, layer: str = "current_track"):
     clear_all_prompts(v)
 
 
-def annotator_tracking(raw, embedding_path=None, show_embeddings=False, tracking_result=None, model_type="vit_h"):
+def annotator_tracking(
+    raw, embedding_path=None, show_embeddings=False, tracking_result=None, model_type="vit_h",
+    tile_shape=None, halo=None,
+):
     # global state
     global PREDICTOR, IMAGE_EMBEDDINGS, CURRENT_TRACK_ID, LINEAGE
     global TRACKING_WIDGET
 
     PREDICTOR = util.get_sam_model(model_type=model_type)
-    IMAGE_EMBEDDINGS = util.precompute_image_embeddings(PREDICTOR, raw, save_path=embedding_path)
+    IMAGE_EMBEDDINGS = util.precompute_image_embeddings(
+        PREDICTOR, raw, save_path=embedding_path, tile_shape=tile_shape, halo=halo
+    )
 
     CURRENT_TRACK_ID = 1
     LINEAGE = {1: []}
@@ -423,7 +428,7 @@ def annotator_tracking(raw, embedding_path=None, show_embeddings=False, tracking
     # add the widgets
     #
 
-    # TODO add (optional) auto-segmentation functionality
+    # TODO add (optional) auto-segmentation and tracking functionality
 
     prompt_widget = create_prompt_menu(prompts, labels)
     v.window.add_dock_widget(prompt_widget)
@@ -512,6 +517,12 @@ def main():
     parser.add_argument(
         "--model_type", default="vit_h", help="The segment anything model that will be used, one of vit_h,l,b."
     )
+    parser.add_argument(
+        "--tile_shape", nargs="+", type=int, help="The tile shape for using tiled prediction", default=None
+    )
+    parser.add_argument(
+        "--halo", nargs="+", type=int, help="The halo for using tiled prediction", default=None
+    )
 
     args = parser.parse_args()
     raw = util.load_image_data(args.input, ndim=3, key=args.key)
@@ -527,4 +538,5 @@ def main():
     annotator_tracking(
         raw, embedding_path=args.embedding_path, show_embeddings=args.show_embeddings,
         tracking_result=tracking_result, model_type=args.model_type,
+        tile_shape=args.tile_shape, halo=args.halo,
     )

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -278,7 +278,7 @@ def precompute_image_embeddings(
         halo [tuple] - additional overlap of the tiles for tiled prediction. (default: None)
     """
     ndim = input_.ndim if ndim is None else ndim
-    if tile_shape is None:
+    if tile_shape is not None:
         assert save_path is None, "Tiled prediction is only supported when the embeddings are saved to file."
 
     if ndim == 2:

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -126,7 +126,11 @@ def _precompute_tiled_2d(predictor, input_, tile_shape, halo, f, verbose=True):
     tiling = blocking([0, 0], input_.shape, tile_shape)
     n_tiles = tiling.numberOfBlocks
 
-    features = f.create_group("features")
+    f.attrs["input_size"] = None
+    f.attrs["original_size"] = None
+
+    features = f.require_group("features")
+    features.attrs["shape"] = input_.shape
     features.attrs["tile_shape"] = tile_shape
     features.attrs["halo"] = halo
 
@@ -312,7 +316,7 @@ def set_precomputed(predictor, image_embeddings, i=None):
 
     if i is None:
         predictor.features = features.to(device) if torch.is_tensor(features) else \
-            torch.from_numpy(features).to(device)
+            torch.from_numpy(features[:]).to(device)
     else:
         predictor.features = features[i].to(device) if torch.is_tensor(features) else \
             torch.from_numpy(features[i]).to(device)

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -123,14 +123,14 @@ def _to_image(input_):
 
 
 def _precompute_tiled_2d(predictor, input_, tile_shape, halo, f, verbose=True):
-    tiling = blocking([0, 0], input_.shape, tile_shape)
+    tiling = blocking([0, 0], input_.shape[:2], tile_shape)
     n_tiles = tiling.numberOfBlocks
 
     f.attrs["input_size"] = None
     f.attrs["original_size"] = None
 
     features = f.require_group("features")
-    features.attrs["shape"] = input_.shape
+    features.attrs["shape"] = input_.shape[:2]
     features.attrs["tile_shape"] = tile_shape
     features.attrs["halo"] = halo
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -1,9 +1,20 @@
+import os
 import unittest
+from shutil import rmtree
 
 import numpy as np
+import zarr
 
 
 class TestUtil(unittest.TestCase):
+    tmp_folder = "tmp-files"
+
+    def setUp(self):
+        os.makedirs(self.tmp_folder, exist_ok=True)
+
+    def tearDown(self):
+        rmtree(self.tmp_folder)
+
     def test_compute_iou(self):
         from micro_sam.util import compute_iou
 
@@ -18,6 +29,21 @@ class TestUtil(unittest.TestCase):
         for _ in range(n_samples):
             x1, x2 = (np.random.rand(32, 32) > 0.5), (np.random.rand(32, 32) > 0.5)
             self.assertTrue(0.0 < compute_iou(x1, x2) < 1.0)
+
+    def test_tiled_prediction(self):
+        from micro_sam.util import precompute_image_embeddings, get_sam_model
+
+        predictor = get_sam_model(model_type="vit_b")
+
+        tile_shape, halo = (256, 256), (16, 16)
+        input_ = np.random.rand(512, 512).astype("float32")
+        save_path = os.path.join(self.tmp_folder, "emebd.zarr")
+        precompute_image_embeddings(predictor, input_, save_path=save_path, tile_shape=tile_shape, halo=halo)
+
+        self.assertTrue(os.path.exists(save_path))
+        with zarr.open(save_path, "r") as f:
+            self.assertIn("features", f)
+            self.assertEqual(len(f["features"]), 4)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR implements tiled prediction for the image encoder and support for this feature in the annotator tools:

- [x] Implement tiled pre-computation and prediction from tiles in `segment_from_prompts` 
- [x] Support tiled prediction and prompts in 2d annotator
- [x] Support tiled prediction and prompts in 3d annotator
- [ ] Adapt auto segmentation in 2d annotator to tiled prediction
- [x] Support tiled prediction and prompts in tracking annotator
