### PR TITLE
Update example scripts to include data download

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.egg-info/
 *.pth
 *.tif
+examples/data/*

--- a/environment_cpu.yaml
+++ b/environment_cpu.yaml
@@ -6,6 +6,7 @@ name:
 dependencies:
     - cpuonly
     - napari
+    - pooch
     - python-elf
     - pytorch
     - torchvision

--- a/environment_gpu.yaml
+++ b/environment_gpu.yaml
@@ -6,6 +6,7 @@ name:
     sam
 dependencies:
     - napari
+    - pooch
     - python-elf
     - pytorch
     - pytorch-cuda>=11.7  # you may need to update the cuda version to match your system

--- a/examples/sam_annotator_3d.py
+++ b/examples/sam_annotator_3d.py
@@ -21,8 +21,8 @@ def fetch_example_data(save_directory):
         os.makedirs(save_directory)
         print("Created new folder for example data downloads.")
     print("Example data directory is:", save_directory.resolve())
-    lucchi_filenames =[os.path.join("Lucchi++/Test_In/", f"mask{str(i).zfill(4)}.png") for i in range(165)]
-    unpack = pooch.Unzip(members=lucchi_filenames)
+    unpack_filenames =[os.path.join("Lucchi++", "Test_In", f"mask{str(i).zfill(4)}.png") for i in range(165)]
+    unpack = pooch.Unzip(members=unpack_filenames)
     fnames = pooch.retrieve(
         url="http://www.casser.io/files/lucchi_pp.zip",
         known_hash="770ce9e98fc6f29c1b1a250c637e6c5125f2b5f1260e5a7687b55a79e2e8844d",

--- a/examples/sam_annotator_3d.py
+++ b/examples/sam_annotator_3d.py
@@ -1,14 +1,38 @@
+import os
+from pathlib import Path
+
 from elf.io import open_file
+import pooch
 from micro_sam.sam_annotator import annotator_3d
 
 
-# Lucchi++ Data from: https://casser.io/connectomics/
 def main():
-    input_path = "./data/Lucchi++/Test_In"
-    with open_file(input_path) as f:
+    example_data_directory = "./data"
+    with open_file(fetch_example_data(example_data_directory)) as f:
         raw = f["*.png"][:]
     embedding_path = "./embeddings/embeddings-lucchi.zarr"
     annotator_3d(raw, embedding_path, show_embeddings=False)
+
+
+def fetch_example_data(save_directory):
+    # Lucchi++ Data from: https://casser.io/connectomics/
+    save_directory = Path(save_directory)
+    if not save_directory.exists():
+        os.makedirs(save_directory)
+        print("Created new folder for example data downloads.")
+    print("Example data directory is:", save_directory.resolve())
+    lucchi_filenames =[os.path.join("Lucchi++/Test_In/", f"mask{str(i).zfill(4)}.png") for i in range(165)]
+    unpack = pooch.Unzip(members=lucchi_filenames)
+    fnames = pooch.retrieve(
+        url="http://www.casser.io/files/lucchi_pp.zip",
+        known_hash="770ce9e98fc6f29c1b1a250c637e6c5125f2b5f1260e5a7687b55a79e2e8844d",
+        fname="lucchi_pp.zip",
+        path="data",
+        progressbar=True,
+        processor=unpack,
+    )
+    lucchi_testin_dir = save_directory.joinpath("lucchi_pp.zip.unzip", "Lucchi++", "Test_In")
+    return lucchi_testin_dir
 
 
 if __name__ == "__main__":

--- a/examples/sam_annotator_3d.py
+++ b/examples/sam_annotator_3d.py
@@ -27,7 +27,7 @@ def fetch_example_data(save_directory):
         url="http://www.casser.io/files/lucchi_pp.zip",
         known_hash="770ce9e98fc6f29c1b1a250c637e6c5125f2b5f1260e5a7687b55a79e2e8844d",
         fname="lucchi_pp.zip",
-        path="data",
+        path=save_directory,
         progressbar=True,
         processor=unpack,
     )

--- a/examples/sam_annotator_tracking.py
+++ b/examples/sam_annotator_tracking.py
@@ -1,21 +1,46 @@
+import os
+from pathlib import Path
+
 from elf.io import open_file
+import pooch
 from micro_sam.sam_annotator import annotator_tracking
 
 
-# This runs the interactive tracking annotator for data from the cell tracking challenge:
-# It uses the training data for the HeLA dataset. You can download the data from
-# http://data.celltrackingchallenge.net/training-datasets/DIC-C2DH-HeLa.zip
 def track_ctc_data():
-    path = "./data/DIC-C2DH-HeLa/train/01"
-    with open_file(path, mode="r") as f:
+    example_data_directory = "./data"
+    with open_file(fetch_example_data(example_data_directory), mode="r") as f:
         timeseries = f["*.tif"][:50]
     annotator_tracking(timeseries, embedding_path="./embeddings/embeddings-ctc.zarr")
 
 
-def main():
-    # run interactive tracking for data from the cell tracking challenge
-    track_ctc_data()
+def fetch_example_data(save_directory):
+    """Cell tracking challenge dataset DIC-C2DH-HeLa.
+
+    Cell tracking challenge webpage: http://data.celltrackingchallenge.net
+    HeLa cells on a flat glass
+    Dr. G. van Cappellen. Erasmus Medical Center, Rotterdam, The Netherlands
+    Training dataset: http://data.celltrackingchallenge.net/training-datasets/DIC-C2DH-HeLa.zip (37 MB)
+    Challenge dataset: http://data.celltrackingchallenge.net/challenge-datasets/DIC-C2DH-HeLa.zip (41 MB)
+    """
+    save_directory = Path(save_directory)
+    if not save_directory.exists():
+        os.makedirs(save_directory)
+        print("Created new folder for example data downloads.")
+    print("Example data directory is:", save_directory.resolve())
+    unpack_filenames =[os.path.join("DIC-C2DH-HeLa", "01", f"t{str(i).zfill(3)}.tif") for i in range(84)]
+    unpack = pooch.Unzip(members=unpack_filenames)
+    fnames = pooch.retrieve(
+        url="http://data.celltrackingchallenge.net/training-datasets/DIC-C2DH-HeLa.zip",  # 37 MB
+        known_hash="fac24746fa0ad5ddf6f27044c785edef36bfa39f7917da4ad79730a7748787af",
+        fname="DIC-C2DH-HeLa.zip",
+        path=save_directory,
+        progressbar=True,
+        processor=unpack,
+    )
+    cell_tracking_directory = save_directory.joinpath("DIC-C2DH-HeLa", "01")
+    return cell_tracking_directory
 
 
 if __name__ == "__main__":
-    main()
+    # run interactive tracking for data from the cell tracking challenge
+    track_ctc_data()

--- a/examples/sam_annotator_tracking.py
+++ b/examples/sam_annotator_tracking.py
@@ -9,7 +9,7 @@ from micro_sam.sam_annotator import annotator_tracking
 def track_ctc_data():
     example_data_directory = "./data"
     with open_file(fetch_example_data(example_data_directory), mode="r") as f:
-        timeseries = f["*.tif"][:50]
+        timeseries = f["*.tif"]
     annotator_tracking(timeseries, embedding_path="./embeddings/embeddings-ctc.zarr")
 
 


### PR DESCRIPTION
Right now it is a little difficult for new users to run the example scripts, because the example data is not included.

This PR updates the scripts so that the example data is automatically downloaded if it doesn't already exist. 

I've used [pooch](https://www.fatiando.org/pooch/latest/) to manage the example data download. Pooch has several nice features, including checking whether the data already exists before downloading, progress bars, checking the MD5 file hash for security, unzipping only the exact files we need from a zip bundle, etc. I like it a lot.

Some points:
* The sam_annotator_2d.py example uses a single tiff file from the [LiveCell dataset](https://sartorius-research.github.io/LIVECell/). I cannot figure out how to download just that file, is this possible? 
    * It is impractical to download the entire 1.3 GB images.zip so we can extract only one image. The LiveCell dataset license is Creative Commons by attribution - I think this means it should be possible to host the single file we need somewhere on the internet. That would be much easier. 
* Pooch doesn't currently allow you to delete the zip archives it downloads (you can, but this means it will automatically re-download them, even if the unpacked files still exist). [Relevant issue here](https://github.com/fatiando/pooch/issues/158)
