### PR TITLE
Refactor predictor initialization in segment_from_prompts

### DIFF
--- a/development/annotator_2d_tiled.py
+++ b/development/annotator_2d_tiled.py
@@ -8,10 +8,7 @@ def annotator_with_tiling():
         "/home/pape/Work/data/neurips-cell-seg/TrainUnlabeled_WholeSlide/whole_slide_00002.tiff"
     )
 
-    # TODO make sure that it also works with RGB data
-    # im = im[..., -1]
     im = im[:4096, :4096, :]
-    print(im.shape)
 
     # import napari
     # v = napari.Viewer()


### PR DESCRIPTION
to avoid code duplication in how tiles are selected (in case of tiled embeddings)