### PR TITLE
Using predictor device when setting image embedding

### DIFF
--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -560,7 +560,7 @@ def set_precomputed(
         i: Index for the image data. Required if `image` has three spatial dimensions
             or a time dimension and two spatial dimensions.
     """
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = predictor.device
     features = image_embeddings["features"]
 
     assert features.ndim in (4, 5)


### PR DESCRIPTION
Hi, @constantinpape,

micro-sam was not working when using a cuda device greater than 0

To reproduce the bug you can run

```python
import napari
from tifffile import imread
from micro_sam import instance_segmentation, util


if __name__ == "__main__":
    image = imread("Fluo-N2DL-HeLa/01/t000.tif")

    predictor = util.get_sam_model(device="cuda:1")
    amg = instance_segmentation.AutomaticMaskGenerator(predictor)

    embeddings = util.precompute_image_embeddings(
        predictor, image,
    )
    amg.initialize(image, embeddings, verbose=True)

    instances_amg = amg.generate(pred_iou_thresh=0.88)
    instances_amg = instance_segmentation.mask_data_to_segmentation(
        instances_amg, shape=image.shape, with_background=True
    )

    v = napari.Viewer()
    v.add_image(image, colormap="magma")
    v.add_labels(instances_amg)

    napari.run()
```

It resulted in 

```python
Traceback (most recent call last):
  File "/home/jordao/Softwares/micro-sam/device_bug.py", line 15, in <module>
    amg.initialize(image, embeddings, verbose=True)
  File "/home/jordao/miniconda3/envs/sam/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/jordao/Softwares/micro-sam/micro_sam/instance_segmentation.py", line 453, in initialize
    crop_data = self._process_crop(
  File "/home/jordao/Softwares/micro-sam/micro_sam/instance_segmentation.py", line 403, in _process_crop
    batch_data = self._process_batch(points, cropped_im_size, crop_box, self.original_size)
  File "/home/jordao/Softwares/micro-sam/micro_sam/instance_segmentation.py", line 371, in _process_batch
    masks, iou_preds, _ = self._predictor.predict_torch(
  File "/home/jordao/miniconda3/envs/sam/lib/python3.10/site-packages/torch/utils/_contextlib.py", line 115, in decorate_context
    return func(*args, **kwargs)
  File "/home/jordao/miniconda3/envs/sam/lib/python3.10/site-packages/segment_anything/predictor.py", line 231, in predict_torch
    low_res_masks, iou_predictions = self.model.mask_decoder(
  File "/home/jordao/miniconda3/envs/sam/lib/python3.10/site-packages/torch/nn/modules/module.py", line 1501, in _call_impl
    return forward_call(*args, **kwargs)
  File "/home/jordao/miniconda3/envs/sam/lib/python3.10/site-packages/segment_anything/modeling/mask_decoder.py", line 94, in forward
    masks, iou_pred = self.predict_masks(
  File "/home/jordao/miniconda3/envs/sam/lib/python3.10/site-packages/segment_anything/modeling/mask_decoder.py", line 127, in predict_masks
    src = src + dense_prompt_embeddings
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cuda:1!
```

This PR fixes this issue.

