### PR TITLE
Fix YAML formatting errors so Github actions will run

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -19,14 +19,7 @@ permissions:
 jobs:
   # Build the documentation and upload the static HTML files as an artifact.
   build:
-	runs-on: ubuntu-latest
-  # runs-on: ${{ matrix.platform }}
-  # strategy:
-  #   matrix:
-  #     platform: [ubuntu-latest]
-  #     python: ["3.10"]
-  # 	backend: [pyqt5`]
-
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
I noticed that the `build_docs.yaml` GitHub action is failing to run, because there is an error in the YAML formatting for that workflow.

https://github.com/computational-cell-analytics/micro-sam/actions/runs/6034379146

>  Invalid workflow file: .github/workflows/build_docs.yaml#L22
> You have an error in your yaml syntax on line 22

This PR fixes the YAML formatting by replacing tab indentation with spaces, and additionally removes some comment lines (I'm not sure if they were also causing formatting errors, but it makes it more difficult to understand whether those lines should actually be included and run or not)