### PR TITLE
Supporting Apple Silicon devices

### DIFF
--- a/micro_sam/__init__.py
+++ b/micro_sam/__init__.py
@@ -5,5 +5,8 @@
 .. include:: ../doc/python_library.md
 .. include:: ../doc/finetuned_models.md
 """
+import os
 
 from .__version__ import __version__
+
+os.environ["PYTORCH_ENABLE_MPS_FALLBACK"] = "1"


### PR DESCRIPTION
As [discussed here](https://github.com/computational-cell-analytics/micro-sam/pull/176#issuecomment-1707524862), the mps torch backend does not support 64 bit tensors. This PR updates @constantinpape's `mps` branch of micro-sam to help fix that problem.

Some notes:
- Apparently the torch nightly version does support 64 bit tensors for the mps backend (Apple Silicon). I haven't tried it yet. I guess you *could* make the nightly torch version a requirement, but this seems like a hassle.
- We don't just have problems in micro-sam, there are also problems with this in the segment-anything repository. There are three options for dealing with this:
   1. **My preferred option:** vendor the function. We can keep an edited copy of the `batched_mask_to_box` function from segment-anything (needed for pre-computing AMG) in the micro-sam repository. Later on, if the bug gets fixed in the upstream repositories, we can remove this from micro-sam.
   2. Ask users to install the nightly version of torch, or wait for that to become available more generally (not ideal, it involves hassle for users, or waiting for a later pytorch release)
   3. Wait for [a PR to be merged](https://github.com/facebookresearch/segment-anything/pull/122) in segment-anything so it can support older versions of torch with the mps backend (also not ideal, it involves a lot of waiting for this to become available to users. Also, I don't think the facebook team are very motivated to merge PRs - because [there is an existing PR with the changes we want](https://github.com/facebookresearch/segment-anything/pull/122) but there has been no activity since June. For this reason, it is my least preferred option.)