### PR TITLE
Implement RLE computation with numba

### DIFF
--- a/development/benchmark.py
+++ b/development/benchmark.py
@@ -51,8 +51,9 @@ def _add_result(benchmark_results, model_type, device, name, runtimes):
     return benchmark_results
 
 
-def benchmark_embeddings(image, predictor, n=3):
+def benchmark_embeddings(image, predictor, n):
     print("Running benchmark_embeddings ...")
+    n = 3 if n is None else n
     times = []
     for _ in range(n):
         t0 = time.time()
@@ -62,8 +63,9 @@ def benchmark_embeddings(image, predictor, n=3):
     return ["embeddings"], [runtime]
 
 
-def benchmark_prompts(image, predictor, n=10):
+def benchmark_prompts(image, predictor, n):
     print("Running benchmark_prompts ...")
+    n = 10 if n is None else n
     names, runtimes = [], []
 
     embeddings = util.precompute_image_embeddings(predictor, image)
@@ -143,8 +145,9 @@ def benchmark_prompts(image, predictor, n=10):
     return names, runtimes
 
 
-def benchmark_amg(image, predictor, n=1):
+def benchmark_amg(image, predictor, n):
     print("Running benchmark_amg ...")
+    n = 1 if n is None else n
     embeddings = util.precompute_image_embeddings(predictor, image)
     amg = instance_seg.AutomaticMaskGenerator(predictor)
     times = []
@@ -164,6 +167,7 @@ def main():
     parser.add_argument("--benchmark_embeddings", "-e", action="store_false")
     parser.add_argument("--benchmark_prompts", "-p", action="store_false")
     parser.add_argument("--benchmark_amg", "-a", action="store_false")
+    parser.add_argument("-n", "--n", type=int, default=None)
 
     args = parser.parse_args()
 
@@ -176,15 +180,15 @@ def main():
 
     benchmark_results = []
     if args.benchmark_embeddings:
-        name, rt = benchmark_embeddings(image, predictor)
+        name, rt = benchmark_embeddings(image, predictor, args.n)
         benchmark_results = _add_result(benchmark_results, model_type, device, name, rt)
 
     if args.benchmark_prompts:
-        name, rt = benchmark_prompts(image, predictor)
+        name, rt = benchmark_prompts(image, predictor, args.n)
         benchmark_results = _add_result(benchmark_results, model_type, device, name, rt)
 
     if args.benchmark_amg:
-        name, rt = benchmark_amg(image, predictor)
+        name, rt = benchmark_amg(image, predictor, args.n)
         benchmark_results = _add_result(benchmark_results, model_type, device, name, rt)
 
     benchmark_results = pd.concat(benchmark_results)

--- a/micro_sam/_vendored.py
+++ b/micro_sam/_vendored.py
@@ -12,6 +12,8 @@ from typing import Any, Dict, List
 import torch
 
 from numba import njit
+# NEW IMPLEMENTED FUNCTION, NOT YET RELEASED
+# from nifty.tools import computeRLE
 
 
 def batched_mask_to_box(masks: torch.Tensor) -> torch.Tensor:
@@ -108,6 +110,7 @@ def mask_to_rle_pytorch(tensor: torch.Tensor) -> List[Dict[str, Any]]:
     for mask in tensor:
 
         counts = _compute_rle(mask)
+        # counts = computeRLE(mask)
 
         # diffs = mask[1:] != mask[:-1]  # pairwise unequal (string safe)
         # indices = np.append(np.where(diffs), n - 1)  # must include last element position


### PR DESCRIPTION
Unfortunately the current attempt is slower than the previous implementation:

**numba implementation:**

| model   | device   | benchmark   |   runtime |                                                                                                        
|:--------|:---------|:------------|----------:|                                                                                                        
| vit_h   | cpu      | amg         |   95.0089 | 
                                                                                                       
**previous implementation:**
     
| model   | device   | benchmark   |   runtime |                                                                                             
|:--------|:---------|:------------|----------:|                                                                                                        
| vit_h   | cpu      | amg         |   80.4364 |