### PR TITLE
Implement prototype for segmentation of complex shapes

### DIFF
--- a/micro_sam/prompt_based_segmentation.py
+++ b/micro_sam/prompt_based_segmentation.py
@@ -354,7 +354,7 @@ def segment_from_mask(
             tile_id_box, tile, box = _box_to_tile(box, shape, tile_shape, halo)
             if tile_id_box != tile_id:
                 raise RuntimeError(f"Inconsistent tile ids for mask and box prompts: {tile_id_box} != {tile_id}.")
-        return tile_id, tile, (box, points, labels)
+        return tile_id, tile, (mask, box, points, labels)
 
     predictor, tile, prompts, shape = _initialize_predictor(predictor, image_embeddings, i, prompts, _to_tile)
     mask, box, points, labels = prompts

--- a/micro_sam/prompt_based_segmentation.py
+++ b/micro_sam/prompt_based_segmentation.py
@@ -125,6 +125,7 @@ def _process_box(box, shape, original_size=None, box_extension=0):
         max(box[1] - extension_x, 0), max(box[0] - extension_y, 0),
         min(box[3] + extension_x, shape[1]), min(box[2] + extension_y, shape[0]),
     ])
+
     if original_size is not None:
         trafo = ResizeLongestSide(max(original_size))
         box = trafo.apply_boxes(box[None], (256, 256)).squeeze()

--- a/micro_sam/sam_annotator/annotator_2d.py
+++ b/micro_sam/sam_annotator/annotator_2d.py
@@ -20,8 +20,8 @@ def _segment_widget(v: Viewer, box_extension: float = 0.1) -> None:
     shape = v.layers["current_object"].data.shape
 
     # get the current box and point prompts
-    boxes, masks = vutil.shape_layer_to_prompts(v.layers["box_prompts"], shape)
-    points, labels = vutil.point_layer_to_prompts(v.layers["prompts"])
+    boxes, masks = vutil.shape_layer_to_prompts(v.layers["prompts"], shape)
+    points, labels = vutil.point_layer_to_prompts(v.layers["point_prompts"], with_stop_annotation=False)
 
     if IMAGE_EMBEDDINGS["original_size"] is None:  # tiled prediction
         seg = vutil.prompt_segmentation(
@@ -118,7 +118,7 @@ def _initialize_viewer(raw, segmentation_result, tile_shape, show_embeddings):
     labels = ["positive", "negative"]
     prompts = v.add_points(
         data=[[0.0, 0.0], [0.0, 0.0]],  # FIXME workaround
-        name="prompts",
+        name="point_prompts",
         properties={"label": labels},
         edge_color="label",
         edge_color_cycle=vutil.LABEL_COLOR_CYCLE,
@@ -131,7 +131,7 @@ def _initialize_viewer(raw, segmentation_result, tile_shape, show_embeddings):
     prompts.edge_color_mode = "cycle"
 
     v.add_shapes(
-        face_color="transparent", edge_color="green", edge_width=4, name="box_prompts"
+        face_color="transparent", edge_color="green", edge_width=4, name="prompts"
     )
 
     #


### PR DESCRIPTION
I started to implement a prototype for the segmentation of complex shapes, see #185.

I thought about this, and the easiest way to implement this would just be to use the `box_prompt` layer and enable segmentation from `polygon` and `ellipse` shapes in addition to `rectangle`. I think this is the best solution both in terms of implementation (it's fairly simple) and also UI (we don't need to add any new layers).
See how it works:

https://github.com/computational-cell-analytics/micro-sam/assets/4263537/8a7067e4-c381-4651-a336-9022c654d7d3

The current status: it's implemented only for the 2d annotation tool, but would be easy to enable for the volumetric segmentation and tracking tool as well.

@GenevieveBuckley would be great if you can give this a try at some point and see if this works for your data with complex shapes.

If we decide to go ahead with this I still need to:
- enable this for 3d and tracking annotator
- check that tiled segmentation also works with this (I also had to do one change that might affect this with box prompts)
- maybe: disable the `path` and `line` options in the `box_prompt` shape layer (because it cannot be used for prompts, but I am not quite sure if it's simple to do this with the napari shape layer)
- maybe: rename the "box_prompts" layer (because we now also support the other shapes)