### PR TITLE
Change keybinding for volume segmentation (remove clash with napari layer visibility keybinding)

### DIFF
--- a/doc/annotation_tools.md
+++ b/doc/annotation_tools.md
@@ -100,7 +100,7 @@ Most elements are the same as in [the 2d annotator](#annotator-2d):
 2. The prompt menu.
 3. The menu with tracking settings: `track_state` is used to indicate that the object you are tracking is dividing in the current frame. `track_id` is used to select which of the tracks after division you are following.
 4. The menu for interactive segmentation.
-5. The tracking menu. Press `Track Object` (or `v`) to track the current object across time.
+5. The tracking menu. Press `Track Object` (or `Shift-S`) to segment the current object across time.
 6. The menu for committing the current tracking result.
 7. The menu for clearing the current annotations.
 

--- a/doc/annotation_tools.md
+++ b/doc/annotation_tools.md
@@ -76,7 +76,7 @@ Most elements are the same as in [the 2d annotator](#annotator-2d):
 1. The napari layers that contain the image, segmentation and prompts. Same as for [the 2d annotator](#annotator-2d) but without the `auto_segmentation` layer.
 2. The prompt menu.
 3. The menu for interactive segmentation.
-4. The 3d segmentation menu. Pressing `Segment Volume` (or `v`) will extend the segmentation for the current object across the volume.
+4. The 3d segmentation menu. Pressing `Segment All Slices` (or `Shift-S`) will extend the segmentation for the current object across the volume.
 5. The menu for committing the segmentation.
 6. The menu for clearing the current annotations.
 

--- a/micro_sam/sam_annotator/annotator_3d.py
+++ b/micro_sam/sam_annotator/annotator_3d.py
@@ -104,7 +104,7 @@ def _segment_volume_for_auto_segmentation(
 
 
 @magicgui(
-    call_button="Segment Volume [Shift-S]",
+    call_button="Segment All Slices [Shift-S]",
     layer={"choices": ["current_object", "auto_segmentation"]},
     projection={"choices": ["default", "bounding_box", "mask", "points"]},
 )

--- a/micro_sam/sam_annotator/annotator_3d.py
+++ b/micro_sam/sam_annotator/annotator_3d.py
@@ -104,7 +104,7 @@ def _segment_volume_for_auto_segmentation(
 
 
 @magicgui(
-    call_button="Segment Volume [V]",
+    call_button="Segment Volume [Shift-S]",
     layer={"choices": ["current_object", "auto_segmentation"]},
     projection={"choices": ["default", "bounding_box", "mask", "points"]},
 )
@@ -307,7 +307,7 @@ def annotator_3d(
     def _seg_slice(v):
         _segment_slice_wigdet(v)
 
-    @v.bind_key("v")
+    @v.bind_key("Shift-s")
     def _seg_volume(v):
         _segment_volume_widget(v)
 

--- a/micro_sam/sam_annotator/annotator_tracking.py
+++ b/micro_sam/sam_annotator/annotator_tracking.py
@@ -218,8 +218,8 @@ def _segment_frame_wigdet(v: Viewer) -> None:
     v.layers["current_track"].refresh()
 
 
-@magicgui(call_button="Track Object [V]", projection={"choices": ["default", "bounding_box", "mask"]})
-def _track_objet_widget(
+@magicgui(call_button="Track Object [Shift-S]", projection={"choices": ["default", "bounding_box", "mask"]})
+def _track_object_widget(
     v: Viewer, iou_threshold: float = 0.5, projection: str = "default",
     motion_smoothing: float = 0.5, box_extension: float = 0.1,
 ) -> None:
@@ -503,7 +503,7 @@ def annotator_tracking(
     v.window.add_dock_widget(TRACKING_WIDGET)
 
     v.window.add_dock_widget(_segment_frame_wigdet)
-    v.window.add_dock_widget(_track_objet_widget)
+    v.window.add_dock_widget(_track_object_widget)
     v.window.add_dock_widget(_commit_tracking_widget)
     v.window.add_dock_widget(_save_lineage_widget)
     v.window.add_dock_widget(_clear_widget_tracking)
@@ -516,9 +516,9 @@ def annotator_tracking(
     def _seg_slice(v):
         _segment_frame_wigdet(v)
 
-    @v.bind_key("v")
+    @v.bind_key("Shift-S")
     def _track_object(v):
-        _track_objet_widget(v)
+        _track_object_widget(v)
 
     @v.bind_key("t")
     def _toggle_label(event=None):


### PR DESCRIPTION
Closes https://github.com/computational-cell-analytics/micro-sam/issues/195

Now:
* `S` <- segment a single slice (same as before)
* `Shift-S` <- segment all slices (previously `V` for volume segmentation)

I like `S` / `Shift-S` for segment one slice / segment all slices. 
I feel this pattern matches keybinding pattern we see in other places like the points layer, which has `A` / `Shift-A` for select all points in this slice / select all points in the whole volume.

Other alternatives we considered:
* `V` <- our current situation, is no good because this clashes with 
* `Control-V` <- also clashes with napari built in keybindings
* `Shift-V`, `Alt-V`, etc. <- might have worked, but seemed less easy to remember than the `S` / `Shift-S` combination.

Note: something weird has happened with the napari built in keybinding. At some point it looks like the `V` keybinding was accidentally changed to `G`. I don't think this affects actual released versions of napari, but I thought I'd mention it in case you do see it. https://github.com/napari/napari/pull/6261