### PR TITLE
CI testing - automatic code coverage reports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.xml
           verbose: false
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -25,7 +25,8 @@ jobs:
       - name: Install pytest
         shell: bash -l {0}
         run: |
-          pip install pytest
+          python -m pip install pytest
+          python -m pip install pytest-cov
 
       - name: Install package
         shell: bash -l {0}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,7 +33,6 @@ jobs:
         shell: bash -l {0}
         run: |
           pip install pytest
-          pip install pytest-qt
 
       - name: Install package
         shell: bash -l {0}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,6 @@ jobs:
         run: pytest
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -37,6 +37,9 @@ jobs:
         run: pytest
 
       - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v3
+        with:
+          file: ./coverage.xml
+          verbose: true
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,6 +1,14 @@
 name: test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - dev
+    tags:
+      - "v*" # Push events to matching v*, i.e. v1.0, v20.15.10
+  pull_request:  # run CI on commits to any open PR
+  workflow_dispatch:  # can manually trigger CI from GitHub actions tab
 
 jobs:
   test:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v1
         with:
-          environment-file: environment_cpu.yml
+          environment-file: environment_cpu.yaml
 
       - name: Install pytest
         shell: bash -l {0}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,6 @@ jobs:
         uses: mamba-org/setup-micromamba@v1
         with:
           environment-file: environment_cpu.yml
-          python-version: ${{ matrix.python-version }}
 
       - name: Install pytest
         shell: bash -l {0}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: pytest --cov=micro_sam --cov-report xml:cov.xml
+        run: pytest
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,10 +29,16 @@ jobs:
         env:
           ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
+      - name: Install pytest
+        shell: bash -l {0}
+        run: |
+          pip install pytest
+          pip install pytest-qt
+
       - name: Install package
         shell: bash -l {0}
         run: pip install --no-deps -e .
 
       - name: Run tests
         shell: bash -l {0}
-        run: python -m unittest discover -s test -v
+        run: pytest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,7 +42,11 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: pytest
+        run: |
+          pwd
+          ls
+          pytest
+          ls
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,4 +33,9 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: pytest
+        run: pytest --cov-report xml:cov.xml 
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v3
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,16 +42,12 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: |
-          pwd
-          ls
-          pytest
-          ls
+        run: pytest
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3
         with:
           file: ./coverage.xml
-          verbose: true
+          verbose: false
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run tests
         shell: bash -l {0}
-        run: pytest --cov-report xml:cov.xml 
+        run: pytest --cov=micro_sam --cov-report xml:cov.xml
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -3,6 +3,7 @@ name: test
 on:
   push:
     branches:
+      - master
       - main
       - dev
     tags:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,17 +17,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup miniconda
-        uses: conda-incubator/setup-miniconda@v2
+      - name: Setup micromamba
+        uses: mamba-org/setup-micromamba@v1
         with:
-          activate-environment: sam
-          mamba-version: "*"
-          auto-update-conda: true
-          environment-file: environment_cpu.yaml
+          environment-file: environment_cpu.yml
           python-version: ${{ matrix.python-version }}
-          auto-activate-base: false
-        env:
-          ACTIONS_ALLOW_UNSECURE_COMMANDS: true
 
       - name: Install pytest
         shell: bash -l {0}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,7 +23,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup micromamba
         uses: mamba-org/setup-micromamba@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 coverage.xml
+.coverage
 __pycache__/
 *.egg-info/
 *.pth

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+coverage.xml
 __pycache__/
 *.egg-info/
 *.pth

--- a/environment_cpu.yaml
+++ b/environment_cpu.yaml
@@ -1,8 +1,7 @@
+name: sam
 channels:
     - pytorch
     - conda-forge
-name:
-    sam
 dependencies:
     - cpuonly
     - napari

--- a/environment_gpu.yaml
+++ b/environment_gpu.yaml
@@ -1,9 +1,8 @@
+name: sam
 channels:
     - pytorch
     - nvidia
     - conda-forge
-name:
-    sam
 dependencies:
     - napari
     - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]
-addopts = "--cov=micro_sam --cov-report xml:coverage.xml"
+addopts = "-v --cov=micro_sam --cov-report xml:coverage.xml --cov-report term"
 
 [tool.black]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool.pytest]
+[tool.pytest.ini_options]
 addopts = "--cov=micro_sam --cov-report xml:coverage.xml"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool:pytest]
-addopts = "--cov=micro_sam --cov-report xml:cov.xml"
+addopts = "--cov=micro_sam --cov-report xml:coverage.xml"
 
 [tool.black]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,11 +2,12 @@
 requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
+[tool:pytest]
+addopts = --cov=micro_sam --cov-report xml:cov.xml
 
 [tool.black]
 line-length = 79
 target-version = ['py38', 'py39', 'py310']
-
 
 [tool.ruff]
 line-length = 79

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
-[tool:pytest]
+[tool.pytest]
 addopts = "--cov=micro_sam --cov-report xml:coverage.xml"
 
 [tool.black]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=42.0.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool:pytest]
-addopts = --cov=micro_sam --cov-report xml:cov.xml
+addopts = "--cov=micro_sam --cov-report xml:cov.xml"
 
 [tool.black]
 line-length = 79


### PR DESCRIPTION
This PR investigates adding code coverage reports to the CI.

Included in this PR:
* Switch to pytest (previously unittest was used)
* Generate code coverage reports (using pytest-cov)
* Uploads code coverage to codecov.io
* Reduces duplication of CI runs, by adjusting the triggers for the github actions workflow
* Switches to micromamba for the CI (instead of miniconda combined with mamba). This creates our test environment in about half the time that miniconda did. It saves about a quarter of the overall CI job time (there aren't a lot of tests right now, so the environment setup is a large proportion of the CI runtime)

When this PR is ready to merge:
1. We'll need to add a secret key to the repository, so the upload to codecov.io can happen automatically, and
2. We should absolutely consider squash merging this PR, the commit history is very messy 