### PR TITLE
Update Casting of Instance Estimations

### DIFF
--- a/finetuning/livecell_finetuning.py
+++ b/finetuning/livecell_finetuning.py
@@ -23,10 +23,10 @@ def get_dataloaders(patch_shape, data_path, cell_type=None):
     label_transform = torch_em.transform.label.label_consecutive  # to ensure consecutive IDs
     train_loader = get_livecell_loader(path=data_path, patch_shape=patch_shape, split="train", batch_size=2,
                                        num_workers=8, cell_types=cell_type, download=True,
-                                       label_transform=label_transform)
+                                       label_transform=label_transform, shuffle=True)
     val_loader = get_livecell_loader(path=data_path, patch_shape=patch_shape, split="val", batch_size=1,
                                      num_workers=8, cell_types=cell_type, download=True,
-                                     label_transform=label_transform)
+                                     label_transform=label_transform, shuffle=True)
     return train_loader, val_loader
 
 

--- a/micro_sam/training/sam_trainer.py
+++ b/micro_sam/training/sam_trainer.py
@@ -258,6 +258,7 @@ class SamTrainer(torch_em.trainer.DefaultTrainer):
 
     def _update_samples_for_gt_instances(self, y, n_samples):
         num_instances_gt = torch.amax(y, dim=(1, 2, 3))
+        num_instances_gt = num_instances_gt.numpy()
         n_samples = min(num_instances_gt) if n_samples > min(num_instances_gt) else n_samples
         return n_samples
 


### PR DESCRIPTION
- Cast the calculation of the total number of instances to numpy (as suited in the trainer)
- Activate `shuffle` for the livecell specialist training.