### PR TITLE
Fixes for test_training.py failures

### DIFF
--- a/micro_sam/training/util.py
+++ b/micro_sam/training/util.py
@@ -11,9 +11,9 @@ from .trainable_sam import TrainableSAM
 
 def get_trainable_sam_model(
     model_type: str = "vit_h",
+    device: Optional[str] = None,
     checkpoint_path: Optional[Union[str, os.PathLike]] = None,
     freeze: Optional[List[str]] = None,
-    device: Optional[Union[str, torch.device]] = None,
 ) -> TrainableSAM:
     """Get the trainable sam model.
 
@@ -29,7 +29,7 @@ def get_trainable_sam_model(
     """
     # set the device here so that the correct one is passed to TrainableSAM below
     device = _get_device(device)
-    _, sam = get_sam_model(device, model_type, checkpoint_path, return_sam=True)
+    _, sam = get_sam_model(model_type=model_type, device=device, checkpoint_path=checkpoint_path, return_sam=True)
 
     # freeze components of the model if freeze was passed
     # ideally we would want to add components in such a way that:

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -146,8 +146,8 @@ def _get_device(device):
 
 
 def get_sam_model(
-    device: Optional[str] = None,
     model_type: str = _DEFAULT_MODEL,
+    device: Optional[str] = None,
     checkpoint_path: Optional[Union[str, os.PathLike]] = None,
     return_sam: bool = False,
 ) -> SamPredictor:
@@ -203,8 +203,8 @@ class _CustomUnpickler(pickle.Unpickler):
 
 def get_custom_sam_model(
     checkpoint_path: Union[str, os.PathLike],
-    device: Optional[str] = None,
     model_type: str = "vit_h",
+    device: Optional[str] = None,
     return_sam: bool = False,
     return_state: bool = False,
 ) -> SamPredictor:

--- a/test/test_training.py
+++ b/test/test_training.py
@@ -70,14 +70,13 @@ class TestTraining(unittest.TestCase):
         )
         return loader
 
-    def _train_model(self, model_type):
+    def _train_model(self, model_type, device):
         import micro_sam.training as sam_training
 
         batch_size = 1
         n_sub_iteration = 4
         patch_shape = (512, 512)
         n_objects_per_batch = 2
-        device = torch.device("cpu")
 
         # Get the dataloaders.
         train_loader = self._get_dataloader("train", patch_shape, batch_size)
@@ -144,9 +143,10 @@ class TestTraining(unittest.TestCase):
         import micro_sam.evaluation as evaluation
 
         model_type = "vit_t"
+        device = "cpu"
 
         # Fine-tune the model.
-        self._train_model(model_type)
+        self._train_model(model_type=model_type, device=device)
         checkpoint_path = os.path.join(self.tmp_folder, "checkpoints", "test", "best.pt")
         self.assertTrue(os.path.exists(checkpoint_path))
 


### PR DESCRIPTION
We've been seeing CI failures related to the `test_training.py` script. 

I've investigated, and found:
1. The major cause was that micro-sam genrally expects the `device` variable to be a string (eg: `"cpu"`, `"cuda"`, or `"mps"`), but the training script had it set as a PyTorch object `device = torch.device(type="cpu")`. 
2. There was another problem, not noticeable on the CI, where we did not correctly set the backend device for *everything*. Having some things on the cpu, and some on a different pytorch backend means we can't perform the computations. This problem was not noticeable on the CI since it is cpu only, but it was very noticeable when I tried to run the tests locally (where I have another backend available that is higher-priority than the cpu).

This PR addresses both issues. Most lines of code relate to problem 2.

`pytest test/test_training.py` now passes locally on my machine. The CI job should run the tests for this branch once I submit the PR.