### PR TITLE
Documenation build script - add check for missing docs files

### DIFF
--- a/.github/workflows/build_docs.yaml
+++ b/.github/workflows/build_docs.yaml
@@ -43,11 +43,11 @@ jobs:
       # We use a custom build script for pdoc itself, ideally you just run `pdoc -o docs/ ...` here.
       - name: Run pdoc
         shell: bash -l {0}
-        run: pdoc --docformat google --logo "https://raw.githubusercontent.com/computational-cell-analytics/micro-sam/master/doc/images/micro-sam-logo.png" -o docs/ micro_sam
+        run: python build_doc.py --out
 
       - uses: actions/upload-pages-artifact@v1
         with:
-          path: docs/
+          path: tmp/
 
   # Deploy the artifact to GitHub pages.
   # This is a separate job so that only actions/deploy-pages has the necessary permissions.

--- a/build_doc.py
+++ b/build_doc.py
@@ -1,17 +1,44 @@
 import argparse
+import glob
+import os
 from subprocess import run
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--out", "-o", action="store_true")
-args = parser.parse_args()
 
-logo_url = "https://raw.githubusercontent.com/computational-cell-analytics/micro-sam/master/doc/images/micro-sam-logo.png"
-cmd = ["pdoc", "--docformat", "google", "--logo", logo_url]
+def check_docs_completeness():
+    """@private
+    All markdown and RST documentation files **MUST** be included in the module
+    docstring at micro_sam/__init__.py
+    """
+    import micro_sam
 
-if args.out:
-    cmd.extend(["--out", "tmp/"])
-cmd.append("micro_sam")
+    markdown_doc_files = glob.glob("doc/**/*.md", recursive=True)
+    rst_doc_files = glob.glob("doc/**/*.rst", recursive=True)
+    all_doc_files = markdown_doc_files + rst_doc_files
+    missing_from_docs = [f for f in all_doc_files if os.path.basename(f) not in micro_sam.__doc__]
+    if len(missing_from_docs) > 0:
+        raise RuntimeError(
+            "Documentation files missing! Please add include statements "
+            "to the docstring in micro_sam/__init__.py for every file, eg:"
+            "'.. include:: ../doc/filename.md'. "
+            "List of missing files: "
+            f"{missing_from_docs}"
+        )
 
-run(cmd)
 
-# pdoc --docformat google --logo "https://raw.githubusercontent.com/computational-cell-analytics/micro-sam/master/doc/images/micro-sam-logo.png" micro_sam
+if __name__=="__main__":
+    check_docs_completeness()
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--out", "-o", action="store_true")
+    args = parser.parse_args()
+
+    logo_url = "https://raw.githubusercontent.com/computational-cell-analytics/micro-sam/master/doc/images/micro-sam-logo.png"
+    cmd = ["pdoc", "--docformat", "google", "--logo", logo_url]
+
+    if args.out:
+        cmd.extend(["--out", "tmp/"])
+    cmd.append("micro_sam")
+
+    run(cmd)
+
+    # pdoc --docformat google --logo "https://raw.githubusercontent.com/computational-cell-analytics/micro-sam/master/doc/images/micro-sam-logo.png" micro_sam

--- a/doc/band.md
+++ b/doc/band.md
@@ -3,14 +3,14 @@
 BAND is a service offered by EMBL Heidelberg that gives access to a virtual desktop for image analysis tasks. It is free to use and `micro_sam` is installed there.
 In order to use BAND and start `micro_sam` on it follow these steps:
 
-**Start BAND**
+## Start BAND
 - Go to https://band.embl.de/ and click **Login**. If you have not used BAND before you will need to register for BAND. Currently you can only sign up via a google account.
 - Launch a BAND desktop with sufficient resources. It's particularly important to select a GPU. The settings from the image below are a good choice.
 - Go to the desktop by clicking **GO TO DESKTOP** in the **Running Desktops** menu. See also the screenshot below.
 
 ![image](https://github.com/computational-cell-analytics/micro-sam/assets/4263537/f965fce2-b924-4fc8-871b-f3201e502138)
 
-**Start micro_sam in BAND**
+## Start micro_sam in BAND
 - Select **Applications->Image Analysis->uSAM** (see screenshot)
 ![image](https://github.com/computational-cell-analytics/micro-sam/assets/4263537/5daeafb3-119b-4104-8708-aab2960cb21c)
 - This will open the micro_sam menu, where you can select the tool you want to use (see screenshot). Note: this may take a few minutes.
@@ -20,7 +20,7 @@ In order to use BAND and start `micro_sam` on it follow these steps:
 ![image](https://github.com/computational-cell-analytics/micro-sam/assets/4263537/5fbd1c53-2ba1-47d4-ae50-dfab890ac9d3)
 - Then press **2d annotator** and the tool will start.
 
-**Transfering data to BAND**
+## Transfering data to BAND
 
 To copy data to and from BAND you can use any cloud storage, e.g. ownCloud, dropbox or google drive. For this, it's important to note that copy and paste, which you may need for accessing links on BAND, works a bit different in BAND:
 - To copy text into BAND you first need to copy it on your computer (e.g. via selecting it + `ctrl + c`).

--- a/micro_sam/__init__.py
+++ b/micro_sam/__init__.py
@@ -1,9 +1,11 @@
 """
 .. include:: ../doc/start_page.md
 .. include:: ../doc/installation.md
+.. include:: ../doc/band.md
 .. include:: ../doc/annotation_tools.md
 .. include:: ../doc/python_library.md
 .. include:: ../doc/finetuned_models.md
+.. include:: ../doc/development.md
 """
 import os
 


### PR DESCRIPTION
I've noticed that it's very easy to add a new documentation page and then forget to include it in the `micro_sam/__init__.py` module docstring. This means `pdoc` can't find it, and it will never appear on the website.

This PR:
1. Adds a check to the build_docs.py script, that looks for any missing markdown or RST files that exist in the "doc" folder but are not included in the `micro_sam/__init__.py` docstring. It raises a RuntimeError if any missing files are found, with instructions on how to fix it.
2. Edits the `.github/workflows/build_docs.yaml` script so that it uses the same `build_docs.py` script to generate the documentation. Advantages: (i) we can use the same check for missing files automatically, and (ii) it's simpler to use the same process everywhere
3. Adds the currently missing doc files `band.md` and `development.md` to the docstring in `micro_sam/__init__.py`. Now, `pdoc` will be able to find this content and include it on the website
4. Changed the heading levels the markdown file `band.md`. By making the subsections have level 2 markdown headings, instead of just bold text, the different sections will appear in the left hand sidebar menu of the website, and people can click on them to go directly to that section.