### PR TITLE
Fix Bounding Box Sorting

### DIFF
--- a/micro_sam/training/util.py
+++ b/micro_sam/training/util.py
@@ -86,8 +86,8 @@ class ConvertToSamInputs:
             sampled_cell_ids = np.random.choice(cell_ids, size=min(n_samples, len(cell_ids)), replace=False)
             sampled_cell_ids = np.sort(sampled_cell_ids)
 
-            # only keep the bounding boxes for sampled cell ids
-            bbox_coordinates = [bbox_coordinates[sampled_id] for sampled_id in sampled_cell_ids]
+        # only keep the bounding boxes for sampled cell ids
+        bbox_coordinates = [bbox_coordinates[sampled_id] for sampled_id in sampled_cell_ids]
 
         # convert the gt to the one-hot-encoded masks for the sampled cell ids
         object_masks = segmentation_to_one_hot(gt, None if n_samples is None else sampled_cell_ids)


### PR DESCRIPTION
Observed that when we expect bounding boxes for all objects in an image, there was a minor fix expected (see [here](https://github.com/computational-cell-analytics/micro-sam/pull/256)). Will test with it if the finetuning still works (in theory it should but just in case)