### PR TITLE
Use a consistent cache directory

### DIFF
--- a/micro_sam/sample_data.py
+++ b/micro_sam/sample_data.py
@@ -1,5 +1,15 @@
 """
 Sample microscopy data.
+
+You can change the download location for sample data and model weights
+by setting the environment variable: MICROSAM_CACHEDIR
+
+By default sample data is downloaded to a folder named 'micro_sam/sample_data'
+inside your default cache directory, eg:
+    * Mac: ~/Library/Caches/<AppName>
+    * Unix: ~/.cache/<AppName> or the value of the XDG_CACHE_HOME environment variable, if defined.
+    * Windows: C:\Users\<user>\AppData\Local\<AppAuthor>\<AppName>\Cache
+
 """
 
 import os
@@ -56,7 +66,8 @@ def sample_data_image_series():
     # Check the documentation for more information about the
     # add_image_kwargs
     # https://napari.org/stable/api/napari.Viewer.html#napari.Viewer.add_image
-    default_base_data_dir = pooch.os_cache('micro-sam')
+    _CACHE_DIR = os.environ.get('MICROSAM_CACHEDIR') or pooch.os_cache('micro_sam')
+    default_base_data_dir = os.path.join(_CACHE_DIR, 'sample_data')
     data_directory = fetch_image_series_example_data(default_base_data_dir)
     fnames = os.listdir(data_directory)
     full_filenames = [os.path.join(data_directory, f) for f in fnames]
@@ -97,7 +108,8 @@ def sample_data_wholeslide():
     # Check the documentation for more information about the
     # add_image_kwargs
     # https://napari.org/stable/api/napari.Viewer.html#napari.Viewer.add_image
-    default_base_data_dir = pooch.os_cache('micro-sam')
+    _CACHE_DIR = os.environ.get('MICROSAM_CACHEDIR') or pooch.os_cache('micro_sam')
+    default_base_data_dir = os.path.join(_CACHE_DIR, 'sample_data')
     filename = fetch_wholeslide_example_data(default_base_data_dir)
     data = imageio.imread(filename)
     add_image_kwargs = {"name": "wholeslide"}
@@ -135,7 +147,8 @@ def sample_data_livecell():
     # Check the documentation for more information about the
     # add_image_kwargs
     # https://napari.org/stable/api/napari.Viewer.html#napari.Viewer.add_image
-    default_base_data_dir = pooch.os_cache('micro-sam')
+    _CACHE_DIR = os.environ.get('MICROSAM_CACHEDIR') or pooch.os_cache('micro_sam')
+    default_base_data_dir = os.path.join(_CACHE_DIR, 'sample_data')
     filename = fetch_livecell_example_data(default_base_data_dir)
     data = imageio.imread(filename)
     add_image_kwargs = {"name": "livecell"}
@@ -173,7 +186,8 @@ def sample_data_hela_2d():
     # Check the documentation for more information about the
     # add_image_kwargs
     # https://napari.org/stable/api/napari.Viewer.html#napari.Viewer.add_image
-    default_base_data_dir = pooch.os_cache("micro-sam")
+    _CACHE_DIR = os.environ.get('MICROSAM_CACHEDIR') or pooch.os_cache('micro_sam')
+    default_base_data_dir = os.path.join(_CACHE_DIR, 'sample_data')
     filename = fetch_hela_2d_example_data(default_base_data_dir)
     data = imageio.imread(filename)
     add_image_kwargs = {"name": "hela_2d"}
@@ -216,7 +230,8 @@ def sample_data_3d():
     # Check the documentation for more information about the
     # add_image_kwargs
     # https://napari.org/stable/api/napari.Viewer.html#napari.Viewer.add_image
-    default_base_data_dir = pooch.os_cache("micro-sam")
+    _CACHE_DIR = os.environ.get('MICROSAM_CACHEDIR') or pooch.os_cache('micro_sam')
+    default_base_data_dir = os.path.join(_CACHE_DIR, 'sample_data')
     data_directory = fetch_3d_example_data(default_base_data_dir)
     fnames = os.listdir(data_directory)
     full_filenames = [os.path.join(data_directory, f) for f in fnames]
@@ -266,7 +281,8 @@ def sample_data_tracking():
     # Check the documentation for more information about the
     # add_image_kwargs
     # https://napari.org/stable/api/napari.Viewer.html#napari.Viewer.add_image
-    default_base_data_dir = pooch.os_cache("micro-sam")
+    _CACHE_DIR = os.environ.get('MICROSAM_CACHEDIR') or pooch.os_cache('micro_sam')
+    default_base_data_dir = os.path.join(_CACHE_DIR, 'sample_data')
     data_directory = fetch_tracking_example_data(default_base_data_dir)
     fnames = os.listdir(data_directory)
     full_filenames = [os.path.join(data_directory, f) for f in fnames]
@@ -312,7 +328,8 @@ def sample_data_segmentation():
     # Check the documentation for more information about the
     # add_image_kwargs
     # https://napari.org/stable/api/napari.Viewer.html#napari.Viewer.add_image
-    default_base_data_dir = pooch.os_cache("micro-sam")
+    _CACHE_DIR = os.environ.get('MICROSAM_CACHEDIR') or pooch.os_cache('micro_sam')
+    default_base_data_dir = os.path.join(_CACHE_DIR, 'sample_data')
     data_directory = fetch_tracking_segmentation_data(default_base_data_dir)
     fnames = os.listdir(data_directory)
     full_filenames = [os.path.join(data_directory, f) for f in fnames]

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -12,6 +12,7 @@ from typing import Any, Callable, Dict, Iterable, Optional, Tuple, Union
 
 import imageio.v3 as imageio
 import numpy as np
+import pooch
 import requests
 import torch
 import vigra
@@ -47,7 +48,8 @@ _MODEL_URLS = {
     "vit_h_em": "https://zenodo.org/record/8250291/files/vit_h_em.pth?download=1",
     "vit_b_em": "https://zenodo.org/record/8250260/files/vit_b_em.pth?download=1",
 }
-_CHECKPOINT_FOLDER = os.environ.get("SAM_MODELS", os.path.expanduser("~/.sam_models"))
+_CACHE_DIR = os.environ.get('MICROSAM_CACHEDIR') or pooch.os_cache('micro_sam')
+_CHECKPOINT_FOLDER = os.path.join(_CACHE_DIR, 'models')
 _CHECKSUMS = {
     # the default segment anything models
     "vit_h": "a7bf3b02f3ebf1267aba913ff637d9a2d5c33d3173bb679e46d9f338c26f262e",
@@ -151,11 +153,19 @@ def get_sam_model(
     checkpoint_path: Optional[Union[str, os.PathLike]] = None,
     return_sam: bool = False,
 ) -> SamPredictor:
-    """Get the SegmentAnything Predictor.
+    r"""Get the SegmentAnything Predictor.
 
     This function will download the required model checkpoint or load it from file if it
-    was already downloaded. By default the models are downloaded to '~/.sam_models'.
-    This location can be changed by setting the environment variable SAM_MODELS.
+    was already downloaded.
+    This location can be changed by setting the environment variable: MICROSAM_CACHEDIR.
+
+    By default the models are downloaded to a folder named 'micro_sam/models'
+    inside your default cache directory, eg:
+    * Mac: ~/Library/Caches/<AppName>
+    * Unix: ~/.cache/<AppName> or the value of the XDG_CACHE_HOME environment variable, if defined.
+    * Windows: C:\Users\<user>\AppData\Local\<AppAuthor>\<AppName>\Cache
+    See the pooch.os_cache() documentation for more details:
+    https://www.fatiando.org/pooch/latest/api/generated/pooch.os_cache.html
 
     Args:
         device: The device for the model. If none is given will use GPU if available.


### PR DESCRIPTION
Closes https://github.com/computational-cell-analytics/micro-sam/issues/264

This PR should make the cache directory handling consistent between the model weights and sample data. 
By default, we use:
* default cache dir + 'micro_sam/models'
* default cache dir + 'micro_sam/sample_data`

[From the pooch.os_cache() docs](https://www.fatiando.org/pooch/latest/api/generated/pooch.os_cache.html):
> Default cache location based on the operating system.
>
> The folder locations are defined by the platformdirs package using the user_cache_dir function. Usually, the locations will be following (see the [platformdirs documentation](https://platformdirs.readthedocs.io/)):
>
> * Mac: ~/Library/Caches/<AppName>
> * Unix: ~/.cache/<AppName> or the value of the XDG_CACHE_HOME environment variable, if defined.
> * Windows: C:\Users\<user>\AppData\Local\<AppAuthor>\<AppName>\Cache

Additionally, users can set an environment variable named `MICROSAM_CACHEDIR` to choose a different cache directory somewhere else (not the default cache dir + 'micro_sam').

The documentation for the environment variable cache dir control is a bit hidden, currently it is only mentioned:
* in the module docstring for `micro_sam/sample_data.py`, and 
* in the docstring for `get_sam_model` function in `micro_sam/util.py`.
