### PR TITLE
Overwrite existing keybindings to avoid error when re-opening plugin widgets

### DIFF
--- a/micro_sam/sam_annotator/_annotator.py
+++ b/micro_sam/sam_annotator/_annotator.py
@@ -75,24 +75,24 @@ class _AnnotatorBase(Container):
         self.extend(widget_list)
 
     def _create_keybindings(self):
-        @self._viewer.bind_key("s")
+        @self._viewer.bind_key("s", overwrite=True)
         def _segment(viewer):
             self._segment_widget(viewer)
 
-        @self._viewer.bind_key("c")
+        @self._viewer.bind_key("c", overwrite=True)
         def _commit(viewer):
             self._commit_widget(viewer)
 
-        @self._viewer.bind_key("t")
+        @self._viewer.bind_key("t", overwrite=True)
         def _toggle_label(event=None):
             vutil.toggle_label(self._point_prompt_layer)
 
-        @self._viewer.bind_key("Shift-C")
+        @self._viewer.bind_key("Shift-C", overwrite=True)
         def _clear_annotations(viewer):
             self._clear_widget(viewer)
 
         if hasattr(self, "_segment_nd_widget"):
-            @self._viewer.bind_key("Shift-S")
+            @self._viewer.bind_key("Shift-S", overwrite=True)
             def _seg_nd(viewer):
                 self._segment_nd_widget(viewer)
 

--- a/micro_sam/sam_annotator/image_series_annotator.py
+++ b/micro_sam/sam_annotator/image_series_annotator.py
@@ -142,7 +142,7 @@ def image_series_annotator(
 
     viewer.window.add_dock_widget(next_image)
 
-    @viewer.bind_key("n")
+    @viewer.bind_key("n", overwrite=True)
     def _next_image(viewer):
         next_image(viewer)
 


### PR DESCRIPTION
Found a bug. If I open the 2D micro-sam plugin widget, then close the widget, and later re-open the 3D plugin widget from the plugin menu, and error appears. The error says the "S" key already has a keybinding command attached to it. This happens because micro-sam runs the keybinding commands whenever a plugin widget is launched.

To avoid this problem, I've used the `overwrite=True` keyword argument for all out keybind commands.


Advantages:
* We no longer see the above error, and can open and re-open micro-sam plugin widgets as many times as we like in the same napari session.

Disadvantages:
* If some other plugin has already used a keybinding for any of the key combinations we use, it will be overwritten silently. This may be confusing for users. 
    * However, I'm not sure how we could reasonably avoid this situation. 
    * And if it *did* happen, we're back to the same situation as described in the bug above, which is something we want to avoid anyway.
