### PR TITLE
Minor fix to launching annotator using custom checkpoints

### DIFF
--- a/micro_sam/sam_annotator/_state.py
+++ b/micro_sam/sam_annotator/_state.py
@@ -75,7 +75,8 @@ class AnnotatorState(metaclass=Singleton):
         assert ndim in (2, 3)
         # Initialize the model if necessary.
         if predictor is None:
-            self.predictor = util.get_custom_sam_model(
+            get_model = util.get_sam_model if checkpoint_path is None else util.get_custom_sam_model
+            self.predictor = get_model(
                 device=device, model_type=model_type, checkpoint_path=checkpoint_path,
             )
         else:

--- a/micro_sam/sam_annotator/_state.py
+++ b/micro_sam/sam_annotator/_state.py
@@ -75,7 +75,7 @@ class AnnotatorState(metaclass=Singleton):
         assert ndim in (2, 3)
         # Initialize the model if necessary.
         if predictor is None:
-            self.predictor = util.get_sam_model(
+            self.predictor = util.get_custom_sam_model(
                 device=device, model_type=model_type, checkpoint_path=checkpoint_path,
             )
         else:


### PR DESCRIPTION
This led to errors (deserializing issues from default Segment Anything's way of [initializing](https://github.com/facebookresearch/segment-anything/blob/main/segment_anything/build_sam.py#L105) checkpoints) while using custom checkpoints out-of-the-box.