### PR TITLE
Add dict for saving widgets in state

### DIFF
--- a/micro_sam/sam_annotator/_annotator.py
+++ b/micro_sam/sam_annotator/_annotator.py
@@ -48,10 +48,15 @@ class _AnnotatorBase(Container):
         self._viewer.layers["committed_objects"].new_colormap()
 
     def _create_widgets(self, segment_widget, segment_nd_widget, autosegment_widget, commit_widget, clear_widget):
+        state = AnnotatorState()
+
         self._embedding_widget = widgets.embedding()
         # Connect the call button of the embedding widget with a function
         # that updates all relevant layers when the image changes.
         self._embedding_widget.call_button.changed.connect(self._update_image)
+
+        # Store the embedding widget in the state so that we can modify it easily.
+        state.widgets["embedding_widget"] = self._embedding_widget
 
         self._prompt_widget = widgets.create_prompt_menu(self._point_prompt_layer, self._point_labels)
         self._segment_widget = segment_widget()

--- a/micro_sam/sam_annotator/_state.py
+++ b/micro_sam/sam_annotator/_state.py
@@ -3,7 +3,7 @@ The singleton is implemented following the metaclass design described here:
 https://itnext.io/deciding-the-best-singleton-approach-in-python-65c61e90cdc4
 """
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from typing import Dict, List, Optional, Tuple
 
@@ -49,12 +49,14 @@ class AnnotatorState(metaclass=Singleton):
     amg_state: Optional[Dict] = None
     decoder: Optional[nn.Module] = None
 
-    # current_track_id, lineage, committed_lineages, tracking_widget:
+    # current_track_id, lineage, committed_lineages:
     # State for the tracking annotator to keep track of lineage information.
     current_track_id: Optional[int] = None
     lineage: Optional[Dict] = None
     committed_lineages: Optional[List[Dict]] = None
-    tracking_widget: Optional[Container] = None
+
+    # Dictionary to keep track of all widgets for which we want to change the state.
+    widgets: Dict[str, Container] = field(default_factory=dict)
 
     # z-range to limit the data being committed in 3d / tracking.
     z_range: Optional[Tuple[int, int]] = None
@@ -155,7 +157,7 @@ class AnnotatorState(metaclass=Singleton):
         have_current_track_id = self.current_track_id is not None
         have_lineage = self.lineage is not None
         have_committed_lineages = self.committed_lineages is not None
-        have_tracking_widget = self.tracking_widget is not None
+        have_tracking_widget = "tracking_widget" in self.widgets
         init_sum = sum((have_current_track_id, have_lineage, have_committed_lineages, have_tracking_widget))
         if init_sum == 4:
             return True
@@ -164,7 +166,7 @@ class AnnotatorState(metaclass=Singleton):
         else:
             miss_vars = [
                 name for name, have_name in zip(
-                    ["current_track_id", "lineage", "committed_lineages", "tracking_widget"],
+                    ["current_track_id", "lineage", "committed_lineages", "widgets.tracking_widget"],
                     [have_current_track_id, have_lineage, have_committed_lineages, have_tracking_widget]
                 )
                 if not have_name
@@ -184,5 +186,5 @@ class AnnotatorState(metaclass=Singleton):
         self.current_track_id = None
         self.lineage = None
         self.committed_lineages = None
-        self.tracking_widget = None
+        self.widgets = {}
         self.z_range = None

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -45,8 +45,8 @@ def _reset_tracking_state(viewer):
     viewer.layers["prompts"].property_choices["track_id"] = ["1"]
 
     # Reset the choices in the track_id menu.
-    state.tracking_widget[1].value = "1"
-    state.tracking_widget[1].choices = ["1"]
+    state.widgets["tracking_widget"][1].value = "1"
+    state.widgets["tracking_widget"][1].choices = ["1"]
 
 
 @magic_factory(call_button="Clear Annotations [Shift + C]")
@@ -496,7 +496,7 @@ def _update_lineage(viewer):
     This helper function is needed by 'track_object'.
     """
     state = AnnotatorState()
-    tracking_widget = state.tracking_widget
+    tracking_widget = state.widgets["tracking_widget"]
 
     mother = state.current_track_id
     assert mother in state.lineage

--- a/micro_sam/sam_annotator/annotator_2d.py
+++ b/micro_sam/sam_annotator/annotator_2d.py
@@ -89,6 +89,12 @@ def annotator_2d(
     # And initialize the 'committed_objects' with the segmentation result if it was given.
     annotator._update_image(segmentation_result=segmentation_result)
 
+    # TODO
+    # - we need to update more values here (tile_shape, halo, embedding_path, all if given)
+    # - refactor this into a util function so that it can be used in the other annotator functions
+    # Update the embedding widget to reflect the parameters given to the function.
+    state.widgets["embedding_widget"][2].value = model_type
+
     # Add the annotator widget to the viewer.
     viewer.window.add_dock_widget(annotator)
 

--- a/micro_sam/sam_annotator/annotator_tracking.py
+++ b/micro_sam/sam_annotator/annotator_tracking.py
@@ -169,7 +169,7 @@ class AnnotatorTracking(_AnnotatorBase):
         # in order to update it when the tracking state changes.
         # NOTE: it would be more elegant to do this by emmitting and connecting events,
         # but I don't know how to create custom events.
-        state.tracking_widget = self._tracking_widget
+        state.widgets["tracking_widget"] = self._tracking_widget
 
         # Go to t=0.
         self._viewer.dims.current_step = (0, 0, 0) + tuple(sh // 2 for sh in self._shape[1:])


### PR DESCRIPTION
This adds a dict to the `AnnotatorState` to save widgets, in order to save their values in the program.
We will use this to sync the state of the embedding widget with the parameters passed to the function that start the annotator, and to set model specific default values in the widgets.

I have checked this and it works as expected. I will wait with further implementing the widget update on the current work to make fields in the widgets collabsible by @lufre1. (The changes here don't really interfere with this, but in order to update the values in a widget the layout has to be known and the work by Luca may change that.)