### PR TITLE
244 update release process and add release guide to developer documentation

### DIFF
--- a/.github/release_config.yaml
+++ b/.github/release_config.yaml
@@ -1,0 +1,32 @@
+# see https://github.com/release-drafter/release-drafter
+name-template: 'v$RESOLVED_VERSION 🌈'
+tag-template: 'v$RESOLVED_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels:
+      - 'feature'
+      - 'enhancement'
+  - title: '🐛 Bug Fixes'
+    labels:
+      - 'fix'
+      - 'bugfix'
+      - 'bug'
+  - title: '🧰 Maintenance'
+    label: 'chore'
+change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+  patch:
+    labels:
+      - 'patch'
+  default: patch
+template: |
+  ## Changes
+
+  $CHANGES

--- a/.github/workflows/release_drafter.yaml
+++ b/.github/workflows/release_drafter.yaml
@@ -1,0 +1,59 @@
+name: Release Drafter
+
+on:
+  push:
+    # branches to consider in the event; optional, defaults to all
+    branches:
+      - master
+  # # pull_request event is required only for autolabeler
+  # pull_request:
+  #   # Only following types are handled by the action, but one can default to all as well
+  #   types: all # [opened, reopened, synchronize]
+  # # pull_request_target event is required for autolabeler to support PRs from forks
+  # # pull_request_target:
+  # #   types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+
+jobs:
+  update_release_draft:
+    permissions:
+      # write permission is required to create a github release
+      contents: write
+      # write permission is required for autolabeler
+      # otherwise, read permission is required at least
+      pull-requests: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+  
+      - name: Detect new version
+        id: check-version
+        #if: steps.check-parent-commit.outputs.sha
+        uses: salsify/action-detect-and-tag-new-version@v2.0.1
+        with:
+          create-tag: false
+          version-command: |
+            grep -Eo '^__version__ = \"(.*)\"$' micro_sam/__version__.py | cut -d\" -f2
+
+      - name: Push tag
+        id: tag-version
+        #if: steps.check-version.outputs.previous-version != steps.check-version.outputs.current-version
+        uses: mathieudutour/github-tag-action@v6.1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          custom_tag: ${{ steps.check-version.outputs.current-version }}
+
+      # Drafts your next Release notes as Pull Requests are merged into "master"
+      - name: Publish the release notes
+        uses: release-drafter/release-drafter@v6.0.0
+        with:
+          config-name: release_config.yaml
+          publish: "${{ steps.tag-version.outputs.new_tag != '' }}"
+          tag: "${{ steps.tag-version.outputs.new_tag }}"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/release_drafter.yaml
+++ b/.github/workflows/release_drafter.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Push tag
         id: tag-version
-        #if: steps.check-version.outputs.previous-version != steps.check-version.outputs.current-version
+        if: steps.check-version.outputs.previous-version != steps.check-version.outputs.current-version
         uses: mathieudutour/github-tag-action@v6.1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
@constantinpape 
the workflow `release_drafter.yaml` creates a release plus informations specified in `release_config.yaml`
atm the workflow does not stop when the software version number has not changed. The workflow does not crash but reports errors trying to create a version number already existing. 
I will post the message below...