### PR TITLE
Fix pyqt error on macos-14 (macos-latest)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,16 +42,6 @@ jobs:
         shell: bash -l {0}
         run: pip install --no-deps -e .
 
-      - name: which python, which pip, which conda
-        run: |
-          which python
-          which pip
-          pip list
-          which conda
-
-      - name: conda list
-        run: conda list
-
       - name: Run tests
         uses: aganders3/headless-gui@v2
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -42,6 +42,12 @@ jobs:
         shell: bash -l {0}
         run: pip install --no-deps -e .
 
+      - name: which python, which pip, which conda
+        run: |
+          which python
+          which pip
+          which conda
+
       - name: conda list
         run: conda list
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,7 +31,7 @@ jobs:
         with:
           environment-file: environment_cpu.yaml
 
-      # Setup Qt libraries for GUI testing
+      # Setup Qt libraries for GUI testing on Linux
       - uses: tlambert03/setup-qt-libs@v1
 
       - name: Install additional dev requirements
@@ -41,6 +41,9 @@ jobs:
       - name: Install micro-sam
         shell: bash -l {0}
         run: pip install --no-deps -e .
+
+      - name: conda list
+        run: conda list
 
       - name: Run tests
         uses: aganders3/headless-gui@v2

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -46,6 +46,7 @@ jobs:
         run: |
           which python
           which pip
+          pip list
           which conda
 
       - name: conda list

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,5 @@
 coverage
 line-profiler
-napari[all]
 pdoc
 pytest
 pytest-cov


### PR DESCRIPTION
## Problem
Closes https://github.com/computational-cell-analytics/micro-sam/issues/558

Tests were failing on the macos-latest github runner (which currently runs the macos-14 M1 Mac image). The cause of this appears to be that pyqt was first being installed by conda/micromamba, then pip was uninstalling that and re-installing another pyqt. Something is wrong with the pyqt from pip, and it causes errors on M1 Mac machines.

## Fix
The simplest solution is to remove `napari[all]` from the `requirements-dev.txt` file, so that pip does not try to uninstall the existing version of pyqt. All the github actions tests now finish without errors.