### PR TITLE
Update napari.yaml, include napari-hub category labels

### DIFF
--- a/micro_sam/napari.yaml
+++ b/micro_sam/napari.yaml
@@ -1,8 +1,9 @@
 name: micro-sam
 display_name: SegmentAnything for Microscopy
+# see https://napari.org/stable/plugins/manifest.html for valid categories
+categories: ["Segmentation", "Annotation"]
 contributions:
   commands:
-
     # Commands for sample data.
     # We don't provide the sample data for image series via napari for now,
     # because the image series annotator cannot be called for image layers in napari (yet),


### PR DESCRIPTION
Adds "Segmentation" and "Annotation" category labels for our future napari-hub plugin page.

See https://napari.org/stable/plugins/manifest.html for valid categories. 
Currently allowed categories are: Acquisition, Annotation, Dataset, Image Processing, IO, Measurement, Segmentation, Simulation, Themes, Transformations, Utilities, Visualization

Related to (but does not close issue) https://github.com/computational-cell-analytics/micro-sam/issues/530