### PR TITLE
PyPI deployment (so micro-sam can be listed on napari-hub)

### DIFF
--- a/.github/workflows/release_drafter.yaml
+++ b/.github/workflows/release_drafter.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 2
   
@@ -57,3 +57,32 @@ jobs:
           tag: "${{ steps.tag-version.outputs.new_tag }}"
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+  deploy:
+    # This will upload a Python Package using Twine when a release is created
+    # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
+    #
+    # This job will run when you have tagged a commit, starting with "v*"
+    # or created a release in GitHub which includes a tag starting with "v*"
+    # and requires that you have put your twine API key in your
+    # github secrets (see readme for details)
+    needs: [update_release_draft]
+    runs-on: ubuntu-latest
+    if: contains(github.ref, 'tags')
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build twine
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python -m build
+        twine upload dist/*

--- a/doc/faq.md
+++ b/doc/faq.md
@@ -41,12 +41,14 @@ Having a GPU will significantly speed up the annotation tools and especially the
 
 ### 5. I am missing a few packages (eg. `ModuleNotFoundError: No module named 'elf.io`). What should I do?
 With the latest release 1.0.0, the installation from mamba and source should take care of this and install all the relevant packages for you.
-So please reinstall `micro_sam`.
-
+So please reinstall `micro_sam`, following [the installation guide](#installation).
 
 ### 6. Can I install `micro_sam` using pip?
-The installation is not supported via pip.
+We do *not* recommend installing `micro-sam` with pip. It has several dependencies that are only avaoiable from conda-forge, which will not install correctly via pip.
 
+Please see [the installation guide](#installation) for the recommended way to install `micro-sam`.
+
+The PyPI page for `micro-sam` exists only so that the [napari-hub](https://www.napari-hub.org/) can find it.
 
 ### 7. I get the following error: `importError: cannot import name 'UNETR' from 'torch_em.model'`.
 It's possible that you have an older version of `torch-em` installed. Similar errors could often be raised from other libraries, the reasons being: a) Outdated packages installed, or b) Some non-existent module being called. If the source of such error is from `micro_sam`, then `a)` is most likely the reason . We recommend installing the latest version following the [installation instructions](https://github.com/constantinpape/torch-em?tab=readme-ov-file#installation).

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -7,6 +7,8 @@ There are three ways to install `micro_sam`:
 
 You can find more information on the installation and how to troubleshoot it in [the FAQ section](#installation-questions).
 
+We do *not* recommend installing `micro-sam` with pip.
+
 ## From mamba
 
 [mamba](https://mamba.readthedocs.io/en/latest/) is a drop-in replacement for conda, but much faster.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
+build
 coverage
 line-profiler
 pdoc
@@ -6,3 +7,4 @@ pytest-cov
 pytest-qt
 snakeviz
 tabulate
+twine


### PR DESCRIPTION
Closes https://github.com/computational-cell-analytics/micro-sam/issues/530

The napari-hub discovers napari plugins by scraping PyPI, looking for the napari framework classifier. When it finds a package with the napari classifier, it will automatically populate a page on the napari-hub for that plugin.

This PR:
* Adds a `deploy` job to the `release_drafter.yml` github workflow. This job runs every time the release drafter workflow runs and the `update_release_draft` job finishes. 
* Updates `requirements-dev.txt` to include `build` and `twine` dependencies (this is not required for the `release_drafter.yml` action to work, but they are nice to have if you are testing the build locally)
* Adds a section to the installation docs, discouraging users from installing `micro-sam` with pip. As previously discussed [here](https://forum.image.sc/t/publish-napari-plugin-with-conda-dependencies/65653) and [here](https://github.com/computational-cell-analytics/micro-sam/issues/530#issuecomment-2099933748), if users `pip install micro-sam` then not all of the dependencies will be correctly installed. Some of our dependencies, like [affogato](https://github.com/constantinpape/affogato) are only available from conda-forge. However, we think the benefit of being searchable on napari-hub outweighs this downside.

Still to do:
@constantinpape will need to
- [ ] Set up an API token for PyPI, see https://pypi.org/help/#apitoken
- [ ] Add the token as github secrets named `PYPI_USERNAME` and `PYPI_PASSWORD` in the settings of this repository, see https://docs.github.com/en/actions/security-guides/using-secrets-in-github-actions#creating-secrets-for-a-repository 


