### PR TITLE
Switch to PyPI Trusted Publishing, remove twine

### DIFF
--- a/.github/workflows/release_drafter.yaml
+++ b/.github/workflows/release_drafter.yaml
@@ -58,16 +58,16 @@ jobs:
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
 
-  deploy:
-    # This will upload a Python Package using Twine when a release is created
-    # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-    #
-    # This job will run when you have tagged a commit, starting with "v*"
-    # or created a release in GitHub which includes a tag starting with "v*"
-    # and requires that you have put your twine API key in your
-    # github secrets (see readme for details)
+  pypi-publish:
+    # Uploads the new release to PyPI using Trusted Publishing
     needs: [update_release_draft]
     runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    environment:
+      name: pypi
+      url: https://pypi.org/p/<your-pypi-project-name>
     if: contains(github.ref, 'tags')
     steps:
     - uses: actions/checkout@v4
@@ -78,11 +78,9 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install build twine
-    - name: Build and publish
-      env:
-        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: |
-        python -m build
-        twine upload dist/*
+        python -m pip install build
+    - name: Build micro-sam python package
+      run: python -m build
+    - name: Publish package distributions to PyPI
+      # This action uploads everything from the dist/ folder to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,4 +7,3 @@ pytest-cov
 pytest-qt
 snakeviz
 tabulate
-twine


### PR DESCRIPTION
Closes https://github.com/computational-cell-analytics/micro-sam/issues/613

This PR switches to PyPI deployment with Trusted Publishing (see [the announcement](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) and [how trusted publishing works](https://docs.pypi.org/trusted-publishers/internals/)). It removes twine, and also removes the need for PyPI API tokens being used as github secrets.

This PR is not sufficient on its own, we (well, probably Constantin) also need to:
* [Add a trusted publisher to our existing PyPI project](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) (or you can [create a new PyPI project with a trusted publisher](https://docs.pypi.org/trusted-publishers/creating-a-project-through-oidc/)).
* Delete the old PyPI API tokens, from both PyPI and the GitHub repository secrets settings.