### PR TITLE
Remove device input for TrainableSAM

### DIFF
--- a/micro_sam/training/sam_trainer.py
+++ b/micro_sam/training/sam_trainer.py
@@ -283,7 +283,7 @@ class SamTrainer(torch_em.trainer.DefaultTrainer):
         # number of objects across the batch.
         n_objects = min(len(ids) for ids in sampled_ids)
 
-        y = y.to(self.device)
+        y = y.to(self.device, non_blocking=True)
         # Compute the one hot targets for the seg-id.
         y_one_hot = torch.stack([
             torch.stack([target == seg_id for seg_id in ids[:n_objects]])

--- a/micro_sam/training/trainable_sam.py
+++ b/micro_sam/training/trainable_sam.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Tuple
 
 import torch
 from torch import nn
@@ -14,16 +14,13 @@ class TrainableSAM(nn.Module):
 
     Args:
         sam: The SegmentAnything Model.
-        device: The device for training.
     """
     def __init__(
         self,
         sam: Sam,
-        device: Union[str, torch.device],
     ) -> None:
         super().__init__()
         self.sam = sam
-        self.device = device
         self.transform = ResizeLongestSide(sam.image_encoder.img_size)
 
     def preprocess(self, x: torch.Tensor) -> Tuple[torch.Tensor, Tuple[int, int]]:
@@ -54,7 +51,7 @@ class TrainableSAM(nn.Module):
     def image_embeddings_oft(self, batched_inputs):
         # Compute the input images.
         input_images, input_size = self.preprocess(
-            torch.stack([x["image"] for x in batched_inputs], dim=0).to(self.device)
+            torch.stack([x["image"] for x in batched_inputs], dim=0).to(self.sam.device, non_blocking=True)
         )
         # Update the input size for each input in the batch.
         for i in range(len(batched_inputs)):
@@ -83,17 +80,20 @@ class TrainableSAM(nn.Module):
         outputs = []
         for image_record, curr_embedding in zip(batched_inputs, image_embeddings):
             if "point_coords" in image_record:
-                points = (image_record["point_coords"].to(self.device), image_record["point_labels"].to(self.device))
+                points = (
+                    image_record["point_coords"].to(self.sam.device, non_blocking=True),
+                    image_record["point_labels"].to(self.sam.device, non_blocking=True)
+                )
             else:
                 points = None
 
             if "boxes" in image_record:
-                boxes = image_record.get("boxes").to(self.device)
+                boxes = image_record.get("boxes").to(self.sam.device, non_blocking=True)
             else:
                 boxes = None
 
             if "mask_inputs" in image_record:
-                masks = image_record.get("mask_inputs").to(self.device)
+                masks = image_record.get("mask_inputs").to(self.sam.device, non_blocking=True)
             else:
                 masks = None
 

--- a/micro_sam/training/util.py
+++ b/micro_sam/training/util.py
@@ -81,7 +81,7 @@ def get_trainable_sam_model(
                     param.requires_grad = False
 
     # convert to trainable sam
-    trainable_sam = TrainableSAM(sam, device)
+    trainable_sam = TrainableSAM(sam)
     if return_state:
         return trainable_sam, state
     return trainable_sam


### PR DESCRIPTION
This PR addresses:
- Removing `device` input argument for `TrainableSAM`. The device is now fetched automatically from `self.sam`.
- Adds `non_blocking=True` for moving objects across devices (speeds up the processes by a bit)