### PR TITLE
Minor update to move edge-related attributes to border

### DIFF
--- a/micro_sam/sam_annotator/_annotator.py
+++ b/micro_sam/sam_annotator/_annotator.py
@@ -29,15 +29,15 @@ class _AnnotatorBase(QtWidgets.QScrollArea):
         self._point_prompt_layer = self._viewer.add_points(
             name="point_prompts",
             property_choices={"label": self._point_labels},
-            edge_color="label",
-            edge_color_cycle=vutil.LABEL_COLOR_CYCLE,
+            border_color="label",
+            border_color_cycle=vutil.LABEL_COLOR_CYCLE,
             symbol="o",
             face_color="transparent",
-            edge_width=0.5,
+            border_width=0.5,
             size=12,
             ndim=self._ndim,
         )
-        self._point_prompt_layer.edge_color_mode = "cycle"
+        self._point_prompt_layer.border_color_mode = "cycle"
 
         # Add the shape layer for box and other shape prompts.
         self._viewer.add_shapes(

--- a/micro_sam/sam_annotator/annotator_tracking.py
+++ b/micro_sam/sam_annotator/annotator_tracking.py
@@ -109,16 +109,16 @@ class AnnotatorTracking(_AnnotatorBase):
                 "state": self._track_state_labels,
                 "track_id": ["1"],  # we use string to avoid pandas warning
             },
-            edge_color="label",
-            edge_color_cycle=vutil.LABEL_COLOR_CYCLE,
+            border_color="label",
+            border_color_cycle=vutil.LABEL_COLOR_CYCLE,
             symbol="o",
             face_color="state",
             face_color_cycle=STATE_COLOR_CYCLE,
-            edge_width=0.4,
+            border_width=0.4,
             size=12,
             ndim=self._ndim,
         )
-        self._point_prompt_layer.edge_color_mode = "cycle"
+        self._point_prompt_layer.border_color_mode = "cycle"
         self._point_prompt_layer.face_color_mode = "cycle"
 
         # Using the box layer to set divisions currently doesn't work.
@@ -132,9 +132,9 @@ class AnnotatorTracking(_AnnotatorBase):
             edge_color="green",
             property_choices={"track_id": ["1"]},
             # property_choces={"track_id": ["1"], "state": self._track_state_labels},
-            # edge_color_cycle=STATE_COLOR_CYCLE,
+            # border_color_cycle=STATE_COLOR_CYCLE,
         )
-        # self._box_prompt_layer.edge_color_mode = "cycle"
+        # self._box_prompt_layer.border_color_mode = "cycle"
 
         # Add the label layers for the current object, the automatic segmentation and the committed segmentation.
         dummy_data = np.zeros(self._shape, dtype="uint32")

--- a/test/test_prompt_generators.py
+++ b/test/test_prompt_generators.py
@@ -34,15 +34,15 @@ class TestPromptGenerators(unittest.TestCase):
                 data=coordinates,
                 name="prompts",
                 properties={"label": labels},
-                edge_color="label",
-                edge_color_cycle=["#00FF00", "#FF0000"],
+                border_color="label",
+                border_color_cycle=["#00FF00", "#FF0000"],
                 symbol="o",
                 face_color="transparent",
-                edge_width=0.5,
+                border_width=0.5,
                 size=5,
                 ndim=2
             )  # this function helps to view the (colored) background/foreground points
-            prompts.edge_color_mode = "cycle"
+            prompts.border_color_mode = "cycle"
 
         if deformed_mask is not None:
             v.add_labels(deformed_mask.astype("uint8"), name="deformed mask / prediction")


### PR DESCRIPTION
While testing a new build, I spotted napari returning a few `FutureWarnings` on edge-related attributes (eg. `edge_color`, `edge_color_mode`, `edge_width`) and recommends to move them to border-related attributes (just replaces the edge keyword with border in all attributes). I quickly tested it, looks like it works just fine!