### PR TITLE
Update dropout defaults for FacT finetuning method

### DIFF
--- a/micro_sam/models/peft_sam.py
+++ b/micro_sam/models/peft_sam.py
@@ -70,7 +70,7 @@ class FacTSurgery(nn.Module):
         self,
         rank: int,
         block: nn.Module,
-        dropout: Optional[float] = None,
+        dropout: Optional[float] = 0.1,
     ):
         super().__init__()
         self.qkv_proj = block.attn.qkv
@@ -104,7 +104,6 @@ class FacTSurgery(nn.Module):
         new_v = self.FacTv(new_v)
 
         # NOTE : Scaling Factor was set to 1 as it can be tuned via the learning rate
-        # Does it make sense to include it, in order to have similar learning rate as the original model?
         qkv[:, :, :, : self.dim] += new_q
         qkv[:, :, :, -self.dim:] += new_v
 


### PR DESCRIPTION
I updated the default value for dropout (from our initial experiments, looks like dropout 0.1 works better compared to no dropout or other dropout values).

cc: @caroteu - I also removed the comment for the scaling factor as we discussed.