### PR TITLE
Minor update to prompt-based segmentation

### DIFF
--- a/micro_sam/prompt_based_segmentation.py
+++ b/micro_sam/prompt_based_segmentation.py
@@ -383,7 +383,7 @@ def segment_from_mask(
             raise ValueError("If points are passed you also need to pass labels.")
         point_coords, point_labels = points, labels
 
-    elif use_points and len(np.unique(mask)) > 1:
+    elif use_points and mask.sum() != 0:
         point_coords, point_labels = _compute_points_from_mask(
             mask, original_size=original_size, box_extension=box_extension,
             use_single_point=use_single_point,
@@ -395,7 +395,7 @@ def segment_from_mask(
     if box is None:
         box = _compute_box_from_mask(
             mask, original_size=original_size, box_extension=box_extension
-        ) if use_box and len(np.unique(mask)) > 1 else None
+        ) if use_box and mask.sum() != 0 else None
     else:
         box = _process_box(box, mask.shape, original_size=original_size, box_extension=box_extension)
 

--- a/micro_sam/prompt_based_segmentation.py
+++ b/micro_sam/prompt_based_segmentation.py
@@ -383,7 +383,7 @@ def segment_from_mask(
             raise ValueError("If points are passed you also need to pass labels.")
         point_coords, point_labels = points, labels
 
-    elif use_points:
+    elif use_points and len(np.unique(mask)) > 1:
         point_coords, point_labels = _compute_points_from_mask(
             mask, original_size=original_size, box_extension=box_extension,
             use_single_point=use_single_point,
@@ -395,7 +395,7 @@ def segment_from_mask(
     if box is None:
         box = _compute_box_from_mask(
             mask, original_size=original_size, box_extension=box_extension
-        ) if use_box else None
+        ) if use_box and len(np.unique(mask)) > 1 else None
     else:
         box = _process_box(box, mask.shape, original_size=original_size, box_extension=box_extension)
 


### PR DESCRIPTION
This PR takes care of a corner case where we avoid extracting prompts from labels where there are no masks. I encountered this in 3d interactive segmentation. And this comes across only in places where even the initial prompt does a pretty bad job and we try to extract the first round of prompts (eg. starting with point prompts with MedSAM).

GTG from my side!