### PR TITLE
Update dice weight constraints for flexible loss weighting

### DIFF
--- a/micro_sam/training/semantic_sam_trainer.py
+++ b/micro_sam/training/semantic_sam_trainer.py
@@ -70,9 +70,6 @@ class SemanticSamTrainer(DefaultTrainer):
         self.compute_ce_loss = nn.CrossEntropyLoss()
         self.dice_weight = dice_weight
 
-        if self.dice_weight is not None:
-            assert self.dice_weight > 0 and self.dice_weight < 1, "The weight factor should lie between 0 and 1."
-
         self._kwargs = kwargs
 
     def _compute_loss(self, y, masks):

--- a/micro_sam/training/semantic_sam_trainer.py
+++ b/micro_sam/training/semantic_sam_trainer.py
@@ -70,6 +70,9 @@ class SemanticSamTrainer(DefaultTrainer):
         self.compute_ce_loss = nn.CrossEntropyLoss()
         self.dice_weight = dice_weight
 
+        if self.dice_weight is not None and (self.dice_weight < 0 or self.dice_weight > 1):
+            raise ValueError("The weight factor should lie between 0 and 1.")
+
         self._kwargs = kwargs
 
     def _compute_loss(self, y, masks):


### PR DESCRIPTION
This PR makes the loss weighting for semantic segmentation trainer a bit more flexible (to choose 1 and 0 for working with either/or losses as well). I'll go ahead and merge this once the tests pass!