### PR TITLE
Add medical imaging models to model registry

### DIFF
--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -926,6 +926,9 @@ class EmbeddingWidget(_WidgetBase):
         # Filter out the decoders from the model list.
         self.model_options = [model for model in self.model_options if not model.endswith("decoder")]
 
+        # NOTE: We currently remove the medical imaging model from displaying it as an option.
+        self.model_options = [model for model in self.model_options if not model.endswith("medical_imaging")]
+
         layout = QtWidgets.QVBoxLayout()
         self.model_dropdown, layout = self._add_choice_param(
             "model_type", self.model_type, self.model_options, title="Model:", layout=layout,

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -116,6 +116,8 @@ def models():
         "vit_b_histopathology": "xxh128:ffd1a2cd84570458b257bd95fdd8f974",
         "vit_l_histopathology": "xxh128:b591833c89754271023e901281dee3f2",
         "vit_h_histopathology": "xxh128:bd1856dafc156a43fb3aa705f1a6e92e",
+        # Medical Imaging models:
+        "vit_b_medical_imaging": "xxh128:5be672f1458263a9edc9fd40d7f56ac1",
     }
     # Additional decoders for instance segmentation.
     decoder_registry = {
@@ -148,6 +150,7 @@ def models():
         "vit_b_histopathology": "https://owncloud.gwdg.de/index.php/s/sBB4H8CTmIoBZsQ/download",
         "vit_l_histopathology": "https://owncloud.gwdg.de/index.php/s/IZgnn1cpBq2PHod/download",
         "vit_h_histopathology": "https://owncloud.gwdg.de/index.php/s/L7AcvVz7DoWJ2RZ/download",
+        "vit_b_medical_imaging": "https://owncloud.gwdg.de/index.php/s/AB69HGhj8wuozXQ/download",
     }
 
     decoder_urls = {


### PR DESCRIPTION
This PR adds our new `MedicoSAM` model, trained on medical imaging datasets to the model registry.

PS: @constantinpape I decided to go ahead with this as this just simplifies the downstream experiments a bit, as we are trying to automate them as much as possible (and this eases our efforts to map checkpoints here and there for QLoRA inference, which has introduced a few additional stuff now). And I have bumped the `vit_b_medical_imaging` model from the model options from the `micro-sam` tool atm.

Let me know what you think about this.