### PR TITLE
Allow flexible post-processing for larger segmentations

### DIFF
--- a/micro_sam/automatic_segmentation.py
+++ b/micro_sam/automatic_segmentation.py
@@ -131,15 +131,7 @@ def automatic_instance_segmentation(
             # whether the predictions from 'generate' are list of dict,
             # which contains additional info req. for post-processing, eg. area per object.
             if len(masks) == 0:
-                # instance segmentation can have no masks, hence we just save empty labels.
-                if isinstance(segmenter, InstanceSegmentationWithDecoder):
-                    this_shape = segmenter._foreground.shape
-                elif isinstance(segmenter, AMGBase):
-                    this_shape = segmenter._original_size
-                else:
-                    this_shape = image_data.shape[-2:]
-
-                instances = np.zeros(this_shape, dtype="uint32")
+                instances = np.zeros(image_data.shape[-2:], dtype="uint32")
             else:
                 instances = mask_data_to_segmentation(masks, with_background=True, min_object_size=0)
         else:

--- a/micro_sam/automatic_segmentation.py
+++ b/micro_sam/automatic_segmentation.py
@@ -128,9 +128,10 @@ def automatic_instance_segmentation(
         masks = segmenter.generate(**generate_kwargs)
 
         if isinstance(masks, list):
-            # whether the predictions from 'generate' are list of dict
+            # whether the predictions from 'generate' are list of dict,
+            # which contains additional info req. for post-processing, eg. area per object.
             if len(masks) == 0:
-                # instance segmentation can have no masks, hence we just save empty labels
+                # instance segmentation can have no masks, hence we just save empty labels.
                 if isinstance(segmenter, InstanceSegmentationWithDecoder):
                     this_shape = segmenter._foreground.shape
                 elif isinstance(segmenter, AMGBase):
@@ -142,7 +143,7 @@ def automatic_instance_segmentation(
             else:
                 instances = mask_data_to_segmentation(masks, with_background=True, min_object_size=0)
         else:
-            # if predictions provided, store them as it is w/o further post-processing (eg. area-based filtering, etc.)
+            # if (raw) predictions provided, store them as it is w/o further post-processing.
             instances = masks
 
     else:


### PR DESCRIPTION
I realized that there are some further post-processing steps (two to be precise), which are tricky for larger segmentations:
- There's one in `generate` method for automatic segmentation, where it does relabelling and some other stuff. This can be overridden by setting `output_mode` to `None` (passed to the generate method) via the automatic segmentation functionality.
- There is another one after the segmentations are returned and some filtering based on area per object is done (intended for AMG mostly).

This PR takes care of making the second point flexible. GTG from my side!