### PR TITLE
Extend support for GUI training on RGB images

### DIFF
--- a/micro_sam/sam_annotator/training_ui.py
+++ b/micro_sam/sam_annotator/training_ui.py
@@ -171,8 +171,12 @@ class TrainingWidget(widgets._WidgetBase):
 
         patch_shape = (self.patch_x, self.patch_y)
         dataset = default_sam_dataset(
-            str(self.raw_path), self.raw_key, str(self.label_path), self.label_key,
-            patch_shape=patch_shape, with_segmentation_decoder=self.with_segmentation_decoder,
+            raw_paths=str(self.raw_path),
+            raw_key=self.raw_key,
+            label_paths=str(self.label_path),
+            label_key=self.label_key,
+            patch_shape=patch_shape,
+            with_segmentation_decoder=self.with_segmentation_decoder,
         )
 
         raw_path_val, label_path_val = self.raw_path_val, self.label_path_val
@@ -183,8 +187,12 @@ class TrainingWidget(widgets._WidgetBase):
         else:
             train_dataset = dataset
             val_dataset = default_sam_dataset(
-                str(raw_path_val), self.raw_key, str(label_path_val), self.label_key,
-                patch_shape=patch_shape, with_segmentation_decoder=self.with_segmentation_decoder,
+                raw_paths=str(raw_path_val),
+                raw_key=self.raw_key,
+                label_paths=str(label_path_val),
+                label_key=self.label_key,
+                patch_shape=patch_shape,
+                with_segmentation_decoder=self.with_segmentation_decoder,
             )
 
         train_loader = torch_em.segmentation.get_data_loader(

--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -355,12 +355,13 @@ def _update_patch_shape(patch_shape, raw_paths, raw_key, with_channels):
     if raw_key is None:  # If no key is given then we assume it's an image file.
         ndim = imageio.imread(path).ndim
     else:  # Otherwise we try to open the file from key.
-        if "*" in raw_key:  # In that case we read one of the images.
-            image_path = glob(os.path.join(path, raw_key))[0]
-            ndim = imageio.imread(image_path).ndim
-        else:  # Otherwise open it with elf.
+        try:  # First try to open it with elf.
             with open_file(path, "r") as f:
                 ndim = f[raw_key].ndim
+        except ValueError:  # This may fail for images in a folder with different sizes.
+            # In that case we read one of the images.
+            image_path = glob(os.path.join(path, raw_key))[0]
+            ndim = imageio.imread(image_path).ndim
 
     if ndim == 2:
         assert len(patch_shape) == 2

--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -436,15 +436,15 @@ def default_sam_dataset(
             raw_paths = [raw_paths] if isinstance(raw_paths, str) else raw_paths
             label_paths = [label_paths] if isinstance(label_paths, str) else label_paths
 
-            # This is not relevant for 'ImageCollectionDataset'. Hence, we set 'with_channels to 'False'.
+            # This is not relevant for 'ImageCollectionDataset'. Hence, we set 'with_channels' to 'False'.
             with_channels = False if with_channels is None else with_channels
 
-        elif test_raw_inputs.shape[0] == 3:  # i.e. if it is an RGB image and has channels first.
+        elif test_raw_inputs.shape[0] == 3:  # i.e. if it is a RGB image and has 3 channels first.
             # This is relevant for 'SegmentationDataset'. If not provided by the user, we set this to 'True'.
             with_channels = True if with_channels is None else with_channels
 
     # Set 'with_channels' to 'False', i.e. the default behavior of 'default_segmentation_dataset'
-    # Otherwise, let the user / data-heuristic make the choice.
+    # Otherwise, let the user make the choice as priority, else set this to our suggested default.
     with_channels = False if with_channels is None else with_channels
 
     # Set the data transformations.

--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -418,21 +418,21 @@ def default_sam_dataset(
 
     # By default, let the 'default_segmentation_dataset' heuristic decide for itself.
     is_seg_dataset = None
-    # Check if the raw inputs are RGB or not. If yes, use 'ImageCollectionDataset'.
-    if raw_paths is not None:
-        # Get valid raw paths to make checks possible.
-        if raw_key is None:
-            rpath = raw_paths if isinstance(raw_paths, str) else raw_paths[0]
-        else:
-            rpath = glob(os.path.join(raw_paths if isinstance(raw_paths, str) else raw_paths[0], raw_key))[0]
 
-        # Load one of the raw inputs to validate whether it is RGB or not.
-        test_raw_inputs = load_data(path=rpath, key=raw_key if raw_key and "*" not in raw_key else None)
-        if test_raw_inputs.ndim == 3 and test_raw_inputs.shape[-1] == 3:  # i.e. if it is an RGB image.
-            is_seg_dataset = False
-            # Provide list of inputs to 'ImageCollectionDataset' in this case.
-            raw_paths = [raw_paths] if isinstance(raw_paths, str) else raw_paths
-            label_paths = [label_paths] if isinstance(label_paths, str) else label_paths
+    # Check if the raw inputs are RGB or not. If yes, use 'ImageCollectionDataset'.
+    # Get valid raw paths to make checks possible.
+    if raw_key is None:
+        rpath = raw_paths if isinstance(raw_paths, str) else raw_paths[0]
+    else:
+        rpath = glob(os.path.join(raw_paths if isinstance(raw_paths, str) else raw_paths[0], raw_key))[0]
+
+    # Load one of the raw inputs to validate whether it is RGB or not.
+    test_raw_inputs = load_data(path=rpath, key=raw_key if raw_key and "*" not in raw_key else None)
+    if test_raw_inputs.ndim == 3 and test_raw_inputs.shape[-1] == 3:  # i.e. if it is an RGB image.
+        is_seg_dataset = False
+        # Provide list of inputs to 'ImageCollectionDataset' in this case.
+        raw_paths = [raw_paths] if isinstance(raw_paths, str) else raw_paths
+        label_paths = [label_paths] if isinstance(label_paths, str) else label_paths
 
     # Set the data transformations.
     if raw_transform is None:


### PR DESCRIPTION
Closes https://github.com/computational-cell-analytics/micro-sam/issues/765.

This PR makes our backbone a bit more flexible to adapt to RGB images (it did not work in it's current state for several reasons), the most important one being the segmentation dataset being chosen for RGB images.

TLDR fix: I make the judgement based on provided images, and allow switching to `ImageCollectionDataset` for RGB images.

GTG from my side! 