### PR TITLE
Add CLI for training SAM

### DIFF
--- a/micro_sam/sam_annotator/training_ui.py
+++ b/micro_sam/sam_annotator/training_ui.py
@@ -11,30 +11,10 @@ import torch_em
 
 import micro_sam.util as util
 import micro_sam.sam_annotator._widgets as widgets
+from micro_sam.training.training import _find_best_configuration
 from micro_sam.training import default_sam_dataset, train_sam_for_configuration, CONFIGURATIONS
 
 from ._tooltips import get_tooltip
-
-
-def _find_best_configuration():
-    if torch.cuda.is_available():
-
-        # Check how much memory we have and select the best matching GPU
-        # for the available VRAM size.
-        _, vram = torch.cuda.mem_get_info()
-        vram = vram / 1e9  # in GB
-
-        # Maybe we can get more configurations in the future.
-        if vram > 80:  # More than 80 GB: use the A100 configurations.
-            return "A100"
-        elif vram > 30:  # More than 30 GB: use the V100 configurations.
-            return "V100"
-        elif vram > 14:  # More than 14 GB: use the RTX5000 configurations.
-            return "rtx5000"
-        else:  # Otherwise: not enough memory to train on the GPU, use CPU instead.
-            return "CPU"
-    else:
-        return "CPU"
 
 
 class TrainingWidget(widgets._WidgetBase):
@@ -274,7 +254,7 @@ class TrainingWidget(widgets._WidgetBase):
                         image, label_image = next(iter(val_loader))
                         image, label_image = image.cpu().numpy().squeeze(), label_image.cpu().numpy().squeeze()
 
-                    # Select the last channel of the label image if we have a channel axis.
+                    # Select the first channel of the label image if we have a channel axis.
                     # (This contains the labels.)
                     if label_image.ndim == 3:
                         label_image = label_image[0]

--- a/micro_sam/sam_annotator/training_ui.py
+++ b/micro_sam/sam_annotator/training_ui.py
@@ -250,7 +250,10 @@ class TrainingWidget(widgets._WidgetBase):
                 # we just export the checkpoint.
                 if os.path.splitext(self.output_path)[1] in (".pt", ".pth"):
                     util.export_custom_sam_model(
-                        checkpoint_path=export_checkpoint, model_type=model_type, save_path=self.output_path,
+                        checkpoint_path=export_checkpoint,
+                        model_type=model_type,
+                        save_path=self.output_path,
+                        with_segmentation_decoder=self.with_segmentation_decoder,
                     )
 
                 # Otherwise we export it as bioimage.io model.

--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -738,15 +738,8 @@ def main():
     train_images, train_gt, train_image_key, train_gt_key = args.images, args.labels, args.image_key, args.label_key
     val_images, val_gt, val_image_key, val_gt_key = args.val_images, args.val_labels, args.val_image_key, args.val_label_key  # noqa
 
-    # Make sure that raw and label paths passed are valid.
-    if [p for p in train_images if not os.path.exists(p)]:
-        raise FileNotFoundError("The path to image data does not exist.")
-    if [p for p in train_gt if not os.path.exists(p)]:
-        raise FileNotFoundError("The path to label data does not exist.")
-    if val_images is not None and [p for p in val_images if not os.path.exists(p)]:
-        raise FileNotFoundError("The path to validation image data does not exist.")
-    if val_gt is not None and [p for p in val_gt if not os.path.exists(p)]:
-        raise FileNotFoundError("The path to validation label data does not exist.")
+    print(train_images, train_gt, train_image_key, train_gt_key)
+    print(val_images, val_gt, val_image_key, val_gt_key)
 
     # 2. Prepare the dataloaders.
 
@@ -792,6 +785,8 @@ def main():
 
     if model_type is None:  # If user does not specify the model, we use the default model corresponding to the config.
         model_type = CONFIGURATIONS[config]["model_type"]
+
+    print(model_type, config)
 
     train_sam_for_configuration(
         name=checkpoint_name,

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -455,7 +455,10 @@ def _handle_checkpoint_loading(sam, model_state):
 
 
 def export_custom_sam_model(
-    checkpoint_path: Union[str, os.PathLike], model_type: str, save_path: Union[str, os.PathLike],
+    checkpoint_path: Union[str, os.PathLike],
+    model_type: str,
+    save_path: Union[str, os.PathLike],
+    with_segmentation_decoder: bool = False,
 ) -> None:
     """Export a finetuned Segment Anything Model to the standard model format.
 
@@ -465,6 +468,7 @@ def export_custom_sam_model(
         checkpoint_path: The path to the corresponding checkpoint if not in the default model folder.
         model_type: The Segment Anything Model type corresponding to the checkpoint (vit_h, vit_b, vit_l or vit_t).
         save_path: Where to save the exported model.
+        with_segmentation_decoder: Whether to store the decoder state in the model checkpoint as well.
     """
     _, state = get_sam_model(
         model_type=model_type, checkpoint_path=checkpoint_path, return_state=True, device="cpu",
@@ -474,7 +478,18 @@ def export_custom_sam_model(
     model_state = OrderedDict(
         [(k[len(prefix):] if k.startswith(prefix) else k, v) for k, v in model_state.items()]
     )
-    torch.save(model_state, save_path)
+
+    # Store the 'decoder_state' as well, if desired.
+    if with_segmentation_decoder:
+        if "decoder_state" not in state:
+            raise RuntimeError(f"'decoder_state' is not found in the model at '{checkpoint_path}'.")
+
+        decoder_state = state["decoder_state"]
+        save_state = {"model_state": model_state, "decoder_state": decoder_state}
+    else:
+        save_state = model_state
+
+    torch.save(save_state, save_path)
 
 
 def export_custom_qlora_model(

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -469,6 +469,7 @@ def export_custom_sam_model(
         model_type: The Segment Anything Model type corresponding to the checkpoint (vit_h, vit_b, vit_l or vit_t).
         save_path: Where to save the exported model.
         with_segmentation_decoder: Whether to store the decoder state in the model checkpoint as well.
+            If set to 'True', the model checkpoint will not be compatible with other tools besides 'micro-sam'.
     """
     _, state = get_sam_model(
         model_type=model_type, checkpoint_path=checkpoint_path, return_state=True, device="cpu",

--- a/setup.cfg
+++ b/setup.cfg
@@ -50,6 +50,7 @@ console_scripts =
     micro_sam.precompute_embeddings = micro_sam.precompute_state:main
     micro_sam.automatic_segmentation = micro_sam.automatic_segmentation:main
     micro_sam.benchmark_sam = micro_sam.evaluation.benchmark_datasets:main
+    micro_sam.train = micro_sam.training.training:main
 
 # make sure it gets included in your package
 [options.package_data]


### PR DESCRIPTION
This PR adds a new CLI for finetuning SAM on custom data. This is still a WIP, and can be fully tested once https://github.com/computational-cell-analytics/micro-sam/pull/859 is merged! (I will work on finalizing that first)

Once finished, this resolves https://github.com/computational-cell-analytics/micro-sam/issues/836

PS. 1) I moved a few functions around files to dodge circular imports, and 2) I made an optional change in export scripts, where the exported model checkpoints would now also have the decoder state, allowing users to run AIS with exported models.