### PR TITLE
Add implementation for Late PEFT

### DIFF
--- a/finetuning/livecell_finetuning.py
+++ b/finetuning/livecell_finetuning.py
@@ -72,7 +72,9 @@ def finetune_livecell(args):
         save_root=args.save_root,
         scheduler_kwargs=scheduler_kwargs,
         save_every_kth_epoch=args.save_every_kth_epoch,
-        peft_kwargs={"rank": args.lora_rank, "start_layer": 10} if args.lora_rank is not None else None,
+        peft_kwargs={
+            "rank": args.lora_rank, "attention_layers_to_update": [9, 10, 11]
+        } if args.lora_rank is not None else None,
     )
 
     if args.export_path is not None:

--- a/finetuning/livecell_finetuning.py
+++ b/finetuning/livecell_finetuning.py
@@ -56,6 +56,12 @@ def finetune_livecell(args):
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
     scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10, "verbose": True}
 
+    # freeze encoder: 35.02 GB
+    # late lora 50% classic: 43.142 GB
+    # late FT 50%: 42.87 GB
+    # lora classic: 48.46 GB
+    # full ft: 49.35
+
     # Run training.
     sam_training.train_sam(
         name=checkpoint_name,

--- a/finetuning/livecell_finetuning.py
+++ b/finetuning/livecell_finetuning.py
@@ -56,19 +56,6 @@ def finetune_livecell(args):
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
     scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10, "verbose": True}
 
-    # NOTE: memory req. for all vit_b models (compared on A100 80GB)
-    # vit_b
-    # freeze_encoder: ~ 33.89 GB
-    # QLoRA: ~48.54 GB
-    # LoRA: ~48.62 GB
-    # FFT: ~49.56 GB
-
-    # vit_h
-    # freeze_encoder: ~36.05 GB
-    # QLoRA: ~ 65.68 GB
-    # LoRA: ~ 67.14 GB
-    # FFT: ~72.34 GB
-
     # Run training.
     sam_training.train_sam(
         name=checkpoint_name,
@@ -85,7 +72,7 @@ def finetune_livecell(args):
         save_root=args.save_root,
         scheduler_kwargs=scheduler_kwargs,
         save_every_kth_epoch=args.save_every_kth_epoch,
-        peft_kwargs={"rank": args.lora_rank, "quantize": True} if args.lora_rank is not None else None,
+        peft_kwargs={"rank": args.lora_rank, "start_layer": 10} if args.lora_rank is not None else None,
     )
 
     if args.export_path is not None:

--- a/micro_sam/models/peft_sam.py
+++ b/micro_sam/models/peft_sam.py
@@ -375,8 +375,16 @@ class PEFT_Sam(nn.Module):
         if issubclass(self.peft_module, SSFSurgery):
             self.peft_blocks.append(self.peft_module(rank=rank, block=model.image_encoder.patch_embed))
 
+        start_layer = module_kwargs.pop("start_layer", None)
+
         for t_layer_i, blk in enumerate(model.image_encoder.blocks):
             # If we only want specific layers with PEFT instead of all
+
+            # For late lora, we only apply lora on the layers after a certain "start layer".
+            if start_layer is not None:
+                if t_layer_i < start_layer:
+                    continue
+
             if t_layer_i not in self.peft_layers:
                 continue
 

--- a/micro_sam/models/peft_sam.py
+++ b/micro_sam/models/peft_sam.py
@@ -377,8 +377,9 @@ class PEFT_Sam(nn.Module):
             self.peft_blocks.append(self.peft_module(rank=rank, block=model.image_encoder.patch_embed))
 
         # If specified, the attention layers to update should match the available blocks.
-        _all_layers_match = (set(attention_layers_to_update) - set(list(range(len(model.image_encoder.blocks)))))
-        if attention_layers_to_update and _all_layers_match:
+        if attention_layers_to_update and (
+            set(attention_layers_to_update) - set(list(range(len(model.image_encoder.blocks))))
+        ):
             raise ValueError("The chosen layer(s) to apply PEFT method is not a valid transformer block id.")
 
         for t_layer_i, blk in enumerate(model.image_encoder.blocks):

--- a/micro_sam/models/peft_sam.py
+++ b/micro_sam/models/peft_sam.py
@@ -307,6 +307,9 @@ class PEFT_Sam(nn.Module):
         peft_module: Wrapper to operate on the image encoder blocks for the PEFT method.
         attention_layers_to_update: Which specific layers we apply PEFT methods to.
         quantize: Whether to quantize the model for lower precision training.
+        start_layer: The layer from which we start applying PEFT methods.
+            For reference, the total number of blocks for 'vit_b' is 12, for 'vit_l' is 24 and for 'vit_h' is 32.
+            So, `start_layer=10` for 'vit_b' model means, PEFT methods are applied to blocks [10, 12].
     """
 
     def __init__(
@@ -316,6 +319,7 @@ class PEFT_Sam(nn.Module):
         peft_module: nn.Module = LoRASurgery,
         attention_layers_to_update: Union[List[int]] = None,
         quantize: bool = False,
+        start_layer: Optional[int] = None,
         **module_kwargs
     ):
         super().__init__()
@@ -375,16 +379,17 @@ class PEFT_Sam(nn.Module):
         if issubclass(self.peft_module, SSFSurgery):
             self.peft_blocks.append(self.peft_module(rank=rank, block=model.image_encoder.patch_embed))
 
-        start_layer = module_kwargs.pop("start_layer", None)
+        # The starting layer cannot be greater than the total number of blocks.
+        if start_layer and start_layer > len(model.image_encoder.blocks):
+            raise ValueError("The chosen layer to start PEFT method is greater than the total transformer blocks.")
 
-        for t_layer_i, blk in enumerate(model.image_encoder.blocks):
+        for t_layer_i, blk in enumerate(model.image_encoder.blocks, start=1):
+
+            # For late lora, we only apply lora on the layers after a certain "start_layer".
+            if start_layer and t_layer_i < start_layer:
+                continue
+
             # If we only want specific layers with PEFT instead of all
-
-            # For late lora, we only apply lora on the layers after a certain "start layer".
-            if start_layer is not None:
-                if t_layer_i < start_layer:
-                    continue
-
             if t_layer_i not in self.peft_layers:
                 continue
 


### PR DESCRIPTION
I made the most straight forward implementation of 'late lora'  by simply applying lora as it is (no additional adapters) to a selection of encoder blocks, specified in peft_kwargs by 'start_layer'. 


Late LoRA Tests (for convenience on OrgaSegment with n_objects set to 5):

regular lora: 12202MiB, ~16.27M Params
apply lora to layer 6-11: 10268MiB, ~15.68M Params
apply lora to layer 8-11: 8754MiB, ~15.49M Params
apply lora to only the last layer: 7924MiB, ~15.19M Params