### PR TITLE
Support low rank adaptation for all matrices in attention blocks

### DIFF
--- a/finetuning/livecell_finetuning.py
+++ b/finetuning/livecell_finetuning.py
@@ -56,6 +56,12 @@ def finetune_livecell(args):
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
     scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10, "verbose": True}
 
+    # freeze encoder: 35.02 GB
+    # late lora 50% classic: 43.142 GB
+    # late FT 50%: 42.87 GB
+    # lora classic: 48.46 GB
+    # full ft: 49.35
+
     # Run training.
     sam_training.train_sam(
         name=checkpoint_name,

--- a/micro_sam/models/peft_sam.py
+++ b/micro_sam/models/peft_sam.py
@@ -365,6 +365,20 @@ class LayerNormSurgery(SelectiveSurgery):
         self.allow_gradient_update_for_parameters(infix=["norm1", "norm2"])
 
 
+class ClassicalSurgery(SelectiveSurgery):
+    """Child class for freezing specific blocks"""
+
+    def __init__(self, block: nn.Module):
+        super().__init__(block=block)
+        self.block = block
+
+        for k, v in self.block.named_parameters():
+            v.requires_grad = True
+
+    def forward(self, x):
+        return x
+
+
 class PEFT_Sam(nn.Module):
     """Wraps the Segment Anything model's image encoder to different parameter efficient finetuning methods.
 
@@ -394,7 +408,6 @@ class PEFT_Sam(nn.Module):
         assert issubclass(peft_module, Union[LoRASurgery, FacTSurgery, SelectiveSurgery, SSFSurgery, AdaptFormer]), (
             "Invalid PEFT module"
         )
-
         if attention_layers_to_update:
             self.peft_layers = attention_layers_to_update
         else:   # Applies PEFT to the image encoder by default

--- a/micro_sam/models/peft_sam.py
+++ b/micro_sam/models/peft_sam.py
@@ -35,13 +35,13 @@ class LoRASurgery(nn.Module):
         super().__init__()
         # Check whether all values for "update_matrices" are as expected.
         if set(update_matrices) - set(["q", "k", "v", "mlp"]):
-            raise ValueError()
+            raise ValueError(f"Some of the expected keys for updating matrics in '{update_matrices}' are not expected.")
 
         self.block = block
         block.attn.qkv = AttentionLoRA(rank=rank, block=block.attn.qkv, update_matrices=update_matrices)
 
         if "mlp" in update_matrices:
-            block.mlp = MLPLoRA(rank=rank, mlp_layer=block.mlp)  # TODO
+            block.mlp = MLPLoRA(rank=rank, mlp_layer=block.mlp)
 
     def forward(self, x):
         return x
@@ -53,7 +53,7 @@ class AttentionLoRA(nn.Module):
     Args:
         rank: The rank of the decomposition matrices for updating weights in each attention layer.
         block: The chosen attention blocks for implementing LoRA.
-        update_matrices: Which specific matrices to update in the attention layer. Choice of "q", "k", "v", "mlp".
+        update_matrices: Which specific matrices to update in the attention layer. Choice of "q", "k", "v".
     """
 
     def __init__(self, rank: int, block: nn.Module, update_matrices: List[str] = ["q", "v"]):


### PR DESCRIPTION
@anwai98 
Adding adapters to the key matrices and feed forward layers does not add any significant overload in the memory while increasing the number of trainable parameters. For example if we add late lora to blocks 6-11:

Only on Q, V: 10268MiB, ~15.68M Params
On Q, V, K, MLP: 10296MiB, ~17.45M Params