### PR TITLE
End: ensure the return of `_to_image` is a np.array (allows dask layers to work)

### DIFF
--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -567,7 +567,9 @@ def _to_image(input_):
     else:
         raise ValueError(f"Invalid input image of shape {input_.shape}. Expect either 2D grayscale or 3D RGB image.")
 
-    return image
+    # explicitly return a numpy array for compatibility with torchvision
+    # because the input_ array could be something like dask array
+    return np.array(image)
 
 
 def _compute_tiled_features_2d(predictor, input_, tile_shape, halo, f, pbar_init, pbar_update):


### PR DESCRIPTION
When using a layer that was loaded as a dask array by a plugin, I got a traceback because `torchvision` could not accept a dask array:
```
File ~/micromamba/envs/micro-sam/lib/python3.11/site-packages/torchvision/transforms/functional.py:268, in to_pil_image(pic=dask.array<getitem, shape=(1024, 1024, 3), dtype...unksize=(1024, 1024, 3), chunktype=numpy.ndarray>, mode=None)
    266     pic = pic.numpy(force=True)
    267 elif not isinstance(pic, np.ndarray):
--> 268     raise TypeError(f"pic should be Tensor or ndarray. Got {type(pic)}.")
        pic = dask.array<getitem, shape=(1024, 1024, 3), dtype=uint8, chunksize=(1024, 1024, 3), chunktype=numpy.ndarray>
        type(pic) = <class 'dask.array.core.Array'>
    270 if pic.ndim == 2:
    271     # if 2D image, add channel dimension (HWC)
    272     pic = np.expand_dims(pic, 2)

TypeError: pic should be Tensor or ndarray. Got <class 'dask.array.core.Array'>.
```

This PR ensures that `utils._to_image` returns a numpy array.

If the user has a truly large image, they are probably using tiles, so the tiles max at 1024x1024, so converting to numpy isn't going to do anything bad and will enable the embedding to work. If their array is larger than memory and they *don't* tile, then converting to numpy could result in memory issues? But this seems like a rare case. One could followup with handling the downsampling using dask before passing to torchvision.

I'm happy to include a test, but not sure what the best way to do that would be.
I've tested locally with some middle levels of a WSI loaded using dask.array.from_zarr() (so not a multiscale layer)