### PR TITLE
Update model choice design in annotator tools

### DIFF
--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -953,6 +953,9 @@ class EmbeddingWidget(_WidgetBase):
         if "segment_nd" in state.widgets:
             vutil._sync_ndsegment_widget(state.widgets["segment_nd"], self.model_type, self.custom_weights)
 
+    def _update_model_type(self):
+        self.model_type = "vit_" + self.model_size[0] + self.supported_dropdown_maps[self.model_family]
+
     def _create_model_section(self):
         self.model_family = "Default"
 
@@ -974,6 +977,7 @@ class EmbeddingWidget(_WidgetBase):
             "model_family", self.model_family, list(self.supported_dropdown_maps.keys()),
             title="Model:", layout=layout, tooltip=get_tooltip("embedding", "model")
         )
+        self.model_family_dropdown.currentTextChanged.connect(self._update_model_type)
         return layout
 
     def _create_settings_widget(self):
@@ -1006,6 +1010,7 @@ class EmbeddingWidget(_WidgetBase):
             "model_size", self.model_size, self.model_size_options,
             title="model size:", tooltip=get_tooltip("embedding", "model"),
         )
+        self.model_size_dropdown.currentTextChanged.connect(self._update_model_type)
         setting_values.layout().addLayout(layout)
 
         # Now that all parameters in place, let's get them all into one `model_type`.

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -959,7 +959,7 @@ class EmbeddingWidget(_WidgetBase):
         layout = QtWidgets.QVBoxLayout()
 
         # NOTE: We stick to the base variant for each model family.
-        # i.e. 'Default', 'Light Microscopy', 'EM_Organelles', 'Medical_Imaging', 'Histopathology'.
+        # i.e. 'Default', 'Light Microscopy', 'Electron Microscopy', 'Medical_Imaging', 'Histopathology'.
 
         # Create a list of support dropdown values and correspond them to suffixes.
         self.supported_dropdown_maps = {

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -958,21 +958,21 @@ class EmbeddingWidget(_WidgetBase):
         current_selection = self.model_size_dropdown.currentText()
         self._get_model_size_options()  # Update model size options dynamically
 
-        # NOTE: We prevent recursive updates for this step temporarily.
+        # NOTE: We need to prevent recursive updates for this step temporarily.
         self.model_size_dropdown.blockSignals(True)
 
         # Let's clear and recreate the dropdown.
         self.model_size_dropdown.clear()
         self.model_size_dropdown.addItems(self.model_size_options)
 
-        # Restore previous selection, if still valid.
+        # We restore the previous selection, if still valid.
         if current_selection in self.model_size_options:
             self.model_size = current_selection
         else:
             if self.model_size_options:  # Default to the first available model size
                 self.model_size = self.model_size_options[0]
 
-        # Let's map the selection to the correct model type (e.g., "tiny" -> "vit_t")
+        # Let's map the selection to the correct model type (eg. "tiny" -> "vit_t")
         size_key = next(
             (k for k, v in {"t": "tiny", "b": "base", "l": "large", "h": "huge"}.items() if v == self.model_size), "b"
         )
@@ -980,16 +980,17 @@ class EmbeddingWidget(_WidgetBase):
 
         self.model_size_dropdown.setCurrentText(self.model_size)  # Apply the selected text to the dropdown
 
-        # We need to force a refresh for UI.
+        # We force a refresh for UI here.
         self.model_size_dropdown.update()
 
-        # NOTE: We should re-enable signals again.
+        # NOTE: And finally, we should re-enable signals again.
         self.model_size_dropdown.blockSignals(False)
 
     def _get_model_size_options(self):
         size_map = {"t": "tiny", "b": "base", "l": "large", "h": "huge"}
-        self.model_size_mapping = {}  # We store the actual model names mapped to UI labels.
 
+        # We store the actual model names mapped to UI labels.
+        self.model_size_mapping = {}
         if self.model_family == "Default":
             self.model_size_options = list(size_map.values())
             self.model_size_mapping = {size_map[k]: f"vit_{k}" for k in size_map.keys()}

--- a/micro_sam/sam_annotator/util.py
+++ b/micro_sam/sam_annotator/util.py
@@ -685,6 +685,7 @@ def _sync_embedding_widget(widget, model_type, save_path, checkpoint_path, devic
     for k, v in supported_dropdown_maps.items():
         if model_type.endswith(k):
             model_family = v
+            break
 
     index = widget.model_family_dropdown.findText(model_family)
     if index > 0:

--- a/micro_sam/sam_annotator/util.py
+++ b/micro_sam/sam_annotator/util.py
@@ -672,10 +672,31 @@ def track_from_prompts(
 
 
 def _sync_embedding_widget(widget, model_type, save_path, checkpoint_path, device, tile_shape, halo):
-    widget.model_type = model_type
-    index = widget.model_dropdown.findText(model_type)
+
+    # Update the index for model family, eg. 'Default', 'Light Microscopy', etc.
+    supported_dropdown_maps = {
+        "lm": "Light Microscopy",
+        "em_organelles": "Electron Microscopy",
+        "medical_imaging": "Medical Imaging",
+        "histopathology": "Histopathology",
+    }
+
+    model_family = "Default"  # If no suffix patterns match, stick to the model being 'Default'.
+    for k, v in supported_dropdown_maps.items():
+        if model_type.endswith(k):
+            model_family = v
+
+    index = widget.model_family_dropdown.findText(model_family)
     if index > 0:
-        widget.model_dropdown.setCurrentIndex(index)
+        widget.model_family_dropdown.setCurrentIndex(index)
+
+    # Update the index for model size, eg. 'base', 'tiny', etc.
+    size_map = {"t": "tiny", "b": "base", "l": "large", "h": "huge"}
+    model_size = size_map[model_type[4]]
+
+    index = widget.model_size_dropdown.findText(model_size)
+    if index > 0:
+        widget.model_size_dropdown.setCurrentIndex(index)
 
     if save_path is not None and isinstance(save_path, str):
         widget.embeddings_save_path_param.setText(str(save_path))


### PR DESCRIPTION
WIP!

This PR updates the GUI structure of model choice, by exposing the 'base' variants for all domains, and moving other size options to the advanced embedding settings. I am missing two thing atm:
- Dynamic change of model sizes, eg. `Default` should show tiny-huge (all 4), and `Medical Imaging` should show only base.
- The `model_type` is not getting updated somehow. I will investigate closely what's going on!