### PR TITLE
Add checks for valid values parsed to finetuning CLI arguments

### DIFF
--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -754,7 +754,7 @@ def main():
         return value
 
     parser.add_argument(
-        "--segmentation_decoder", type=none_or_str, default="instances", choices=("instances", None),
+        "--segmentation_decoder", type=none_or_str, default="instances",
         # TODO: in future, we can extend this to semantic seg / or even more advanced stuff.
         help="Whether to finetune Segment Anything Model with additional segmentation decoder for desired targets. "
         "By default, it uses the 'instances' option, i.e. trains with the additional segmentation decoder for "
@@ -825,7 +825,7 @@ def main():
     save_root = args.save_root
     output_path = args.output_path
 
-    if args.segmentation_decoder and args.segmentation_deocder != ["instances"]:
+    if args.segmentation_decoder and args.segmentation_deocder != "instances":
         raise ValueError(
             "The 'segmentation_decoder' argument currently supports 'instances' as input argument only."
         )

--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -747,10 +747,18 @@ def main():
         "--configuration", type=str, default=_find_best_configuration(),
         help=f"The configuration for finetuning the Segment Anything Model, one of {available_configurations}."
     )
+
+    def none_or_str(value):
+        if value.lower() == 'none':
+            return None
+        return value
+
     parser.add_argument(
-        "--segmentation_decoder", type=str, default="instances",  # TODO: in future, we can extend this to semantic seg.
+        "--segmentation_decoder", type=none_or_str, default="instances", choices=("instances", None),
+        # TODO: in future, we can extend this to semantic seg / or even more advanced stuff.
         help="Whether to finetune Segment Anything Model with additional segmentation decoder for desired targets. "
-        "By default, it trains with the additional segmentation decoder for instance segmentation."
+        "By default, it uses the 'instances' option, i.e. trains with the additional segmentation decoder for "
+        "instance segmentation, otherwise pass 'None' for training without the additional segmentation decoder at all."
     )
 
     # Optional advanced settings a user can opt to change the values for.
@@ -761,7 +769,7 @@ def main():
     )
     parser.add_argument(
         "--patch_shape", type=int, nargs="*", default=(512, 512),
-        help="The choice of patch shape for training Segment Anything."
+        help="The choice of patch shape for training Segment Anything Model."
     )
     parser.add_argument(
         "-m", "--model_type", type=str, default=None,
@@ -778,7 +786,8 @@ def main():
     )
     parser.add_argument(
         "--trained_model_name", type=str, default="sam_model",
-        help="The custom name of trained model. Allows users to have several trained models under the same 'save_root'."
+        help="The custom name of trained model sub-folder. Allows users to have several trained models "
+        "under the same 'save_root'."
     )
     parser.add_argument(
         "--output_path", type=str, default=None,
@@ -815,7 +824,12 @@ def main():
     device = args.device
     save_root = args.save_root
     output_path = args.output_path
-    with_segmentation_decoder = (args.segmentation_decoder == "instances")
+
+    if args.segmentation_decoder and args.segmentation_deocder != ["instances"]:
+        raise ValueError(
+            "The 'segmentation_decoder' argument currently supports 'instances' as input argument only."
+        )
+    with_segmentation_decoder = (args.segmentation_decoder is not None)
 
     # Get image paths and corresponding keys.
     train_images, train_gt, train_image_key, train_gt_key = args.images, args.labels, args.image_key, args.label_key

--- a/test/test_sam_annotator/test_annotator_tracking.py
+++ b/test/test_sam_annotator/test_annotator_tracking.py
@@ -10,7 +10,7 @@ from micro_sam._test_util import check_layer_initialization
 
 
 @pytest.mark.gui
-@pytest.mark.skipif(platform.system() in ("Windows", "Linux", "Darwin"), reason="Gui test is not working on windows.")
+@pytest.mark.skipif(platform.system() in ("Windows", "Linux"), reason="Gui test is not working on windows.")
 def test_annotator_tracking(make_napari_viewer_proxy):
     """Integration test for annotator_tracking.
     """

--- a/test/test_sam_annotator/test_annotator_tracking.py
+++ b/test/test_sam_annotator/test_annotator_tracking.py
@@ -10,7 +10,7 @@ from micro_sam._test_util import check_layer_initialization
 
 
 @pytest.mark.gui
-@pytest.mark.skipif(platform.system() in ("Windows", "Linux"), reason="Gui test is not working on windows.")
+@pytest.mark.skipif(platform.system() in ("Windows", "Linux", "Darwin"), reason="Gui test is not working on windows.")
 def test_annotator_tracking(make_napari_viewer_proxy):
     """Integration test for annotator_tracking.
     """


### PR DESCRIPTION
This PR improves the doc for finetuning CLI, makes checks more robust, and simplifies (a bit) the `segmentation_decoder` argument. GTG from my side!