### PR TITLE
Validate model type with model state instead of state

### DIFF
--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -394,7 +394,7 @@ def get_sam_model(
         # To get the model weights, we prioritize having the correct 'checkpoint_path' over 'model_type'
         # It is done to avoid strange parameter mismatch issues while incompatible model type and weights combination.
         from micro_sam.models.build_sam import _validate_model_type
-        _provided_model_type = _validate_model_type(state)
+        _provided_model_type = _validate_model_type(model_state)
 
         # Verify whether the 'abbreviated_model_type' matches the '_provided_model_type'
         # Otherwise replace 'abbreviated_model_type' with the later.


### PR DESCRIPTION
@anwai98 I think we need to use model state instead of state here or else the validation won't work as desired. For instance with a custom checkpoint for a micro-sam model the keys for the state would be "model_state", "decoder_state"... (Same goes for any finetuned checkpoint where the keys include optimizer state, training times, etc. )