### PR TITLE
Update benchmark.py

### DIFF
--- a/development/benchmark.py
+++ b/development/benchmark.py
@@ -33,7 +33,7 @@ from micro_sam.sample_data import fetch_livecell_example_data
 def _get_image_and_predictor(model_type, device):
     example_data = fetch_livecell_example_data("../examples/data")
     image = imageio.imread(example_data)
-    predictor = util.get_sam_model(device, model_type)
+    predictor = util.get_sam_model(device=device, model_type=model_type)
     return image, predictor
 
 


### PR DESCRIPTION
# Fix Parameter Mix-Up in `benchmark.py`

## Description
Fixes `RuntimeError: Unsupported device: vit_l` in `benchmark.py` due to `model_type` being passed as `device` to `util.get_sam_model()`.

## Changes
- **File**: `benchmark.py`
  - Updated `_get_image_and_predictor()` to use keyword args:
    ```python
    predictor = util.get_sam_model(device=device, model_type=model_type)
    ```

## Testing
- Run: `python benchmark.py --device cuda --model_type vit_l`
- Verify no `RuntimeError` and correct output:
  ```
  Running benchmarks for vit_l
  with device: cuda
  ```