### PR TITLE
Create pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-## 📝 Pull Request (PR) Summary
+## 📝 Description
 
-Please describe the changes this PR introduces.
+Please include a summary of the changes this PR introduces. Please also include relevant motivation and context. And list any (new) dependencies that are required for this change.
 
 ## 🚦 Status
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+## 📝 Pull Request (PR) Summary
+
+Please describe the changes this PR introduces.
+
+## 🚦 Status
+
+<!--Select one by add `x` inside the `[ ]` checkbox: `[x]`. Please add any additional notes, if necessary-->
+
+- [ ] 👀 Ready for review – Please take a look (the GTG stage).
+- [ ] ✅ Ready to merge – Fully complete and approved.
+- [ ] 📣 Attention Needed – Requires input / decision from the developers.
+- [ ] 🚧 WIP (Work in Progress) – Not ready for review.
+- [ ] 🧪 Experimental / Testing: For testing or preview purposes only.
+
+## 🔍 Related Issues
+
+- Closes #123
+- Resolves #456
+- Fixes #789
+
+## ✅ Checklist
+
+<!--Select one by add `x` inside the `[ ]` checkbox: `[x]`. Please add any additional notes, if necessary-->
+
+- [ ] Discussed with developers about the issue / details mentioned in this PR.
+- [ ] Code compiles correctly.
+- [ ] Tests added / updated for new developments.
+- [ ] Documentation updated (if needed).
+- [ ] PR title gives a TL&DR for the changes made.


### PR DESCRIPTION
I found this doc (https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) for creating a pull request template. For us, we can just clean it and make PRs. For contributors, I think it's a nice way to communicate with us first-hand information and ideas. I am not sure how it looks as I haven't seen GitHub repositories use this.