### PR TITLE
Minor update to avoid using napari pbar in CLI

### DIFF
--- a/micro_sam/sam_annotator/_state.py
+++ b/micro_sam/sam_annotator/_state.py
@@ -86,6 +86,7 @@ class AnnotatorState(metaclass=Singleton):
         pbar_init=None,
         pbar_update=None,
         skip_load=True,
+        use_cli=False,
     ):
         assert ndim in (2, 3)
 
@@ -98,7 +99,7 @@ class AnnotatorState(metaclass=Singleton):
             self.predictor, state = util.get_sam_model(
                 device=device, model_type=model_type,
                 checkpoint_path=checkpoint_path, return_state=True,
-                progress_bar_factory=progress_bar_factory
+                progress_bar_factory=None if use_cli else progress_bar_factory,
             )
             if prefer_decoder and "decoder_state" in state:
                 self.decoder = get_decoder(

--- a/micro_sam/sam_annotator/annotator_2d.py
+++ b/micro_sam/sam_annotator/annotator_2d.py
@@ -78,7 +78,7 @@ def annotator_2d(
         image, model_type=model_type, save_path=embedding_path,
         halo=halo, tile_shape=tile_shape, precompute_amg_state=precompute_amg_state,
         ndim=2, checkpoint_path=checkpoint_path, device=device, prefer_decoder=prefer_decoder,
-        skip_load=False,
+        skip_load=False, use_cli=True,
     )
 
     if viewer is None:

--- a/micro_sam/sam_annotator/annotator_3d.py
+++ b/micro_sam/sam_annotator/annotator_3d.py
@@ -88,6 +88,7 @@ def annotator_3d(
         image, model_type=model_type, save_path=embedding_path,
         halo=halo, tile_shape=tile_shape, ndim=3, precompute_amg_state=precompute_amg_state,
         checkpoint_path=checkpoint_path, device=device, prefer_decoder=prefer_decoder,
+        use_cli=True,
     )
 
     if viewer is None:

--- a/micro_sam/sam_annotator/annotator_tracking.py
+++ b/micro_sam/sam_annotator/annotator_tracking.py
@@ -231,7 +231,7 @@ def annotator_tracking(
         image, model_type=model_type, save_path=embedding_path,
         halo=halo, tile_shape=tile_shape, prefer_decoder=True,
         ndim=3, checkpoint_path=checkpoint_path, device=device,
-        precompute_amg_state=precompute_amg_state,
+        precompute_amg_state=precompute_amg_state, use_cli=True,
     )
     state.image_shape = image.shape[:-1] if image.ndim == 4 else image.shape
 

--- a/micro_sam/sam_annotator/image_series_annotator.py
+++ b/micro_sam/sam_annotator/image_series_annotator.py
@@ -94,7 +94,7 @@ def _initialize_annotator(
         image, model_type=model_type, save_path=image_embedding_path, halo=halo, tile_shape=tile_shape,
         predictor=predictor, decoder=decoder,
         ndim=3 if is_volumetric else 2, precompute_amg_state=precompute_amg_state,
-        checkpoint_path=checkpoint_path, device=device, skip_load=False,
+        checkpoint_path=checkpoint_path, device=device, skip_load=False, use_cli=True,
     )
     state.image_shape = _get_input_shape(image, is_volumetric)
 


### PR DESCRIPTION
This PR takes care of fixing a minor issue while running the CLI.

In short, when CLIs are run locally to download the models (when they do not exist in cache locally), it throws an error. I just simply add a flag indicating to avoid custom progressbars when working with CLIs.

GTG from my side!