### PR TITLE
Minor fix to remove peft kwargs from evaluation scripts

### DIFF
--- a/finetuning/evaluation/cellpose_baseline.py
+++ b/finetuning/evaluation/cellpose_baseline.py
@@ -9,7 +9,7 @@ import imageio.v3 as imageio
 from micro_sam.evaluation.evaluation import run_evaluation
 
 # from util import get_paths   # for hlrn
-from util import get_pred_paths 
+from util import get_pred_paths
 
 
 # EXPERIMENT_ROOT = "/scratch/projects/nim00007/sam/experiments/benchmarking/cellpose"  # for hlrn

--- a/finetuning/evaluation/evaluate_amg.py
+++ b/finetuning/evaluation/evaluate_amg.py
@@ -9,7 +9,7 @@ from util import (
 )
 
 
-def run_amg_inference(dataset_name, model_type, checkpoint, experiment_folder, peft_kwargs):
+def run_amg_inference(dataset_name, model_type, checkpoint, experiment_folder):
     val_image_paths, val_gt_paths = get_paths(dataset_name, split="val")
     test_image_paths, _ = get_paths(dataset_name, split="test")
     prediction_folder = run_amg(
@@ -19,7 +19,6 @@ def run_amg_inference(dataset_name, model_type, checkpoint, experiment_folder, p
         val_image_paths=val_image_paths,
         val_gt_paths=val_gt_paths,
         test_image_paths=test_image_paths,
-        peft_kwargs=peft_kwargs,
     )
     return prediction_folder
 
@@ -35,9 +34,8 @@ def eval_amg(dataset_name, prediction_folder, experiment_folder):
 
 def main():
     args = get_default_arguments()
-    peft_kwargs = {"rank": args.peft_rank, "module": args.peft_module}
     prediction_folder = run_amg_inference(
-        args.dataset, args.model, args.checkpoint, args.experiment_folder, peft_kwargs
+        args.dataset, args.model, args.checkpoint, args.experiment_folder,
     )
     eval_amg(args.dataset, prediction_folder, args.experiment_folder)
 

--- a/finetuning/evaluation/evaluate_instance_segmentation.py
+++ b/finetuning/evaluation/evaluate_instance_segmentation.py
@@ -10,7 +10,7 @@ from util import (
 
 
 def run_instance_segmentation_with_decoder_inference(
-    dataset_name, model_type, checkpoint, experiment_folder, peft_kwargs,
+    dataset_name, model_type, checkpoint, experiment_folder,
 ):
     val_image_paths, val_gt_paths = get_paths(dataset_name, split="val")
     test_image_paths, _ = get_paths(dataset_name, split="test")
@@ -21,7 +21,6 @@ def run_instance_segmentation_with_decoder_inference(
         val_image_paths=val_image_paths,
         val_gt_paths=val_gt_paths,
         test_image_paths=test_image_paths,
-        peft_kwargs=peft_kwargs,
     )
     return prediction_folder
 
@@ -37,9 +36,8 @@ def eval_instance_segmentation_with_decoder(dataset_name, prediction_folder, exp
 
 def main():
     args = get_default_arguments()
-    peft_kwargs = {"rank": args.peft_rank, "module": args.peft_module}
     prediction_folder = run_instance_segmentation_with_decoder_inference(
-        args.dataset, args.model, args.checkpoint, args.experiment_folder, peft_kwargs,
+        args.dataset, args.model, args.checkpoint, args.experiment_folder,
     )
     eval_instance_segmentation_with_decoder(args.dataset, prediction_folder, args.experiment_folder)
 

--- a/finetuning/evaluation/iterative_prompting.py
+++ b/finetuning/evaluation/iterative_prompting.py
@@ -45,10 +45,7 @@ def main():
     start_with_box_prompt = args.box  # overwrite to start first iters' prompt with box instead of single point
 
     # get the predictor to perform inference
-    peft_kwargs = {"rank": args.peft_rank, "module": args.peft_module}
-    predictor = get_sam_model(
-        model_type=args.model, checkpoint_path=args.checkpoint, peft_kwargs=peft_kwargs,
-    )
+    predictor = get_sam_model(model_type=args.model, checkpoint_path=args.checkpoint)
 
     prediction_root = _run_iterative_prompting(
         args.dataset, args.experiment_folder, predictor, start_with_box_prompt, args.use_masks

--- a/finetuning/evaluation/precompute_embeddings.py
+++ b/finetuning/evaluation/precompute_embeddings.py
@@ -12,10 +12,7 @@ from util import (
 def main():
     args = get_default_arguments()
 
-    peft_kwargs = {"rank": args.peft_rank, "module": args.peft_module}
-    predictor = get_sam_model(
-        model_type=args.model, checkpoint_path=args.checkpoint, peft_kwargs=peft_kwargs,
-    )
+    predictor = get_sam_model(model_type=args.model, checkpoint_path=args.checkpoint)
     embedding_dir = os.path.join(args.experiment_folder, "embeddings")
     os.makedirs(embedding_dir, exist_ok=True)
 

--- a/finetuning/evaluation/util.py
+++ b/finetuning/evaluation/util.py
@@ -8,7 +8,8 @@ from torch_em.data import datasets
 from micro_sam.evaluation.livecell import _get_livecell_paths
 
 
-ROOT = "/scratch/projects/nim00007/sam/data/"
+# ROOT = "/scratch/projects/nim00007/sam/data/"
+ROOT = "/mnt/vast-nhr/projects/cidas/cca/data"
 
 EXPERIMENT_ROOT = "/scratch/projects/nim00007/sam/experiments/new_models"
 

--- a/finetuning/evaluation/util.py
+++ b/finetuning/evaluation/util.py
@@ -8,8 +8,7 @@ from torch_em.data import datasets
 from micro_sam.evaluation.livecell import _get_livecell_paths
 
 
-# ROOT = "/scratch/projects/nim00007/sam/data/"
-ROOT = "/mnt/vast-nhr/projects/cidas/cca/data"
+ROOT = "/scratch/projects/nim00007/sam/data/"
 
 EXPERIMENT_ROOT = "/scratch/projects/nim00007/sam/experiments/new_models"
 


### PR DESCRIPTION
Closes https://github.com/computational-cell-analytics/micro-sam/issues/1001.

This PR takes care of minor fixes to remove `peft_kwargs` from the internal evaluation scripts (all experiments from it have been moved to `peft-sam` anyways). The issue was that the function signature for `PEFT_Sam` changed at some point and the current scripts are not compatible.

GTG from my side! 

cc: @caroteu 