### PR TITLE
Remove napari pin to allow v6 supports

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -5,7 +5,7 @@ dependencies:
     - nifty >=1.2.3
     - imagecodecs
     - magicgui
-    - napari >=0.5.0,<0.6.0
+    - napari
     - natsort
     - pip
     - pooch


### PR DESCRIPTION
WIP!

The installation from `conda-forge` seems to create some problems for me locally, but let's see how the tests behave for now!