### PR TITLE
Remove verbosity argument from learning rate schedulers

### DIFF
--- a/finetuning/generalists/training/electron_microscopy/boundaries/train_boundaries_em_generalist.py
+++ b/finetuning/generalists/training/electron_microscopy/boundaries/train_boundaries_em_generalist.py
@@ -54,7 +54,7 @@ def finetune_boundaries_em_generalist(args):
 
     # all the stuff we need for training
     optimizer = torch.optim.Adam(joint_model_params, lr=1e-5)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=20, verbose=True)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=20)
     train_loader, val_loader = get_generalist_boundaries_loaders(input_path=args.input_path, patch_shape=patch_shape)
 
     # this class creates all the training data for a batch (inputs, prompts and labels)

--- a/finetuning/generalists/training/electron_microscopy/mito_nuc/train_mito_nuc_em_generalist.py
+++ b/finetuning/generalists/training/electron_microscopy/mito_nuc/train_mito_nuc_em_generalist.py
@@ -54,7 +54,7 @@ def finetune_mito_nuc_em_generalist(args):
 
     # all the stuff we need for training
     optimizer = torch.optim.Adam(joint_model_params, lr=1e-5)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=15, verbose=True)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=15)
     train_loader, val_loader = get_generalist_mito_nuc_loaders(input_path=args.input_path, patch_shape=patch_shape)
 
     # this class creates all the training data for a batch (inputs, prompts and labels)

--- a/finetuning/generalists/training/histopathology/train_histopathology_generalist.py
+++ b/finetuning/generalists/training/histopathology/train_histopathology_generalist.py
@@ -27,7 +27,7 @@ def finetune_hp_generalist(args):
 
     # all the stuff we need for training
     optimizer = torch.optim.Adam(model.parameters(), lr=1e-5)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=10, verbose=True)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=10)
     train_loader, val_loader = get_generalist_hp_loaders(patch_shape=patch_shape, data_path=args.input_path)
 
     # this class creates all the training data for a batch (inputs, prompts and labels)

--- a/finetuning/generalists/training/light_microscopy/train_lm_generalist.py
+++ b/finetuning/generalists/training/light_microscopy/train_lm_generalist.py
@@ -23,7 +23,7 @@ def finetune_lm_generalist(args):
 
     # all the stuff we need for training
     train_loader, val_loader = get_generalist_lm_loaders(input_path=args.input_path, patch_shape=patch_shape)
-    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 5, "verbose": True}
+    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 5}
 
     # Run training.
     sam_training.train_sam(

--- a/finetuning/livecell_finetuning.py
+++ b/finetuning/livecell_finetuning.py
@@ -54,7 +54,7 @@ def finetune_livecell(args):
 
     # all the stuff we need for training
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
-    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10, "verbose": True}
+    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10}
 
     # freeze encoder: 35.02 GB
     # late lora 50% classic: 43.142 GB

--- a/finetuning/specialists/resource-efficient/covid_if_finetuning.py
+++ b/finetuning/specialists/resource-efficient/covid_if_finetuning.py
@@ -86,7 +86,7 @@ def finetune_covid_if(args):
     train_loader, val_loader = get_dataloaders(
         patch_shape=patch_shape, data_path=args.input_path, n_images=args.n_images
     )
-    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 3, "verbose": True}
+    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 3}
 
     # Run training
     sam_training.train_sam(

--- a/finetuning/specialists/training/electron_microscopy/boundaries/cremi_finetuning.py
+++ b/finetuning/specialists/training/electron_microscopy/boundaries/cremi_finetuning.py
@@ -104,7 +104,7 @@ def finetune_cremi(args):
 
     # all the stuff we need for training
     optimizer = torch.optim.Adam(joint_model_params, lr=1e-5)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=10, verbose=True)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=10)
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
 
     # this class creates all the training data for a batch (inputs, prompts and labels)

--- a/finetuning/specialists/training/electron_microscopy/organelles/asem_finetuning.py
+++ b/finetuning/specialists/training/electron_microscopy/organelles/asem_finetuning.py
@@ -111,7 +111,7 @@ def finetune_asem(args):
 
     # all the stuff we need for training
     optimizer = torch.optim.Adam(joint_model_params, lr=1e-5)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=10, verbose=True)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=10)
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
 
     # this class creates all the training data for a batch (inputs, prompts and labels)

--- a/finetuning/specialists/training/histopathology/pannuke_finetuning.py
+++ b/finetuning/specialists/training/histopathology/pannuke_finetuning.py
@@ -24,7 +24,7 @@ def finetune_pannuke(args):
 
     # all the stuff we need for training
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
-    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10, "verbose": True}
+    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10}
 
     # Run training.
     sam_training.train_sam(

--- a/finetuning/specialists/training/light_microscopy/deepbacs_finetuning.py
+++ b/finetuning/specialists/training/light_microscopy/deepbacs_finetuning.py
@@ -94,9 +94,7 @@ def finetune_deepbacs(args):
 
     # all the stuff we need for training
     optimizer = torch.optim.Adam(joint_model_params, lr=1e-5)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        optimizer, mode="min", factor=0.9, patience=50, verbose=True
-    )
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=50)
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
 
     # this class creates all the training data for a batch (inputs, prompts and labels)

--- a/finetuning/specialists/training/light_microscopy/dynamicnuclearnet_finetuning.py
+++ b/finetuning/specialists/training/light_microscopy/dynamicnuclearnet_finetuning.py
@@ -67,7 +67,7 @@ def finetune_dynamicnuclearnet(args):
 
     # all the stuff we need for training
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
-    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10, "verbose": True}
+    scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 10}
 
     # Run training.
     sam_training.train_sam(

--- a/finetuning/specialists/training/light_microscopy/neurips_cellseg_finetuning.py
+++ b/finetuning/specialists/training/light_microscopy/neurips_cellseg_finetuning.py
@@ -94,7 +94,7 @@ def finetune_neurips_cellseg_root(args):
 
     # all the stuff we need for training
     optimizer = torch.optim.Adam(joint_model_params, lr=1e-5)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=50, verbose=True)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=50)
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
 
     # this class creates all the training data for a batch (inputs, prompts and labels)

--- a/finetuning/specialists/training/light_microscopy/plantseg_root_finetuning.py
+++ b/finetuning/specialists/training/light_microscopy/plantseg_root_finetuning.py
@@ -85,7 +85,7 @@ def finetune_plantseg_root(args):
 
     # all the stuff we need for training
     optimizer = torch.optim.Adam(joint_model_params, lr=1e-5)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=10, verbose=True)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=10)
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
 
     # this class creates all the training data for a batch (inputs, prompts and labels)

--- a/finetuning/specialists/training/light_microscopy/tissuenet_finetuning.py
+++ b/finetuning/specialists/training/light_microscopy/tissuenet_finetuning.py
@@ -86,7 +86,7 @@ def finetune_tissuenet(args):
 
     # all the stuff we need for training
     optimizer = torch.optim.Adam(joint_model_params, lr=1e-5)
-    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=10, verbose=True)
+    scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(optimizer, mode="min", factor=0.9, patience=10)
     train_loader, val_loader = get_dataloaders(patch_shape=patch_shape, data_path=args.input_path)
 
     # this class creates all the training data for a batch (inputs, prompts and labels)

--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -280,7 +280,7 @@ def train_sam(
         optimizer = optimizer_class(model_params, lr=lr)
 
         if scheduler_kwargs is None:
-            scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 3, "verbose": True}
+            scheduler_kwargs = {"mode": "min", "factor": 0.9, "patience": 3}
 
         scheduler = scheduler_class(optimizer=optimizer, **scheduler_kwargs)
 

--- a/scripts/for_benchmarking_ais/train_semanticsam.py
+++ b/scripts/for_benchmarking_ais/train_semanticsam.py
@@ -17,7 +17,7 @@ def run_semantic_training(path, save_root, iterations, model, device, for_sam, n
     # all the stuff we need for training
     optimizer = torch.optim.AdamW(model.parameters(), lr=1e-5)
     scheduler = torch.optim.lr_scheduler.ReduceLROnPlateau(
-        optimizer, mode="min", factor=0.9, verbose=True, patience=10 if dataset.startswith("covid_if") else 5,
+        optimizer, mode="min", factor=0.9, patience=10 if dataset.startswith("covid_if") else 5,
     )
 
     patch_shape = (512, 512)


### PR DESCRIPTION
This PR removes the `verbose` argument from the learning rate schedulers as it is depreciated in `pytorch>=2.7`, and the latest pytorch is up on `conda-forge` since last week!

GTG from my side!