### PR TITLE
Minor update to return value for iterative prompting evaluation

### DIFF
--- a/micro_sam/evaluation/evaluation.py
+++ b/micro_sam/evaluation/evaluation.py
@@ -153,6 +153,8 @@ def run_evaluation_for_iterative_prompting(
     res_df = pd.concat(list_of_results, ignore_index=True)
     res_df.to_csv(csv_path)
 
+    return res_df
+
 
 def main():
     """@private"""


### PR DESCRIPTION
This is a super teeny tiny update for returning the evaluation results for iterative prompting. Idk when I removed this, because the return type and docstrings always pointed that this was returned. Well, I'll merge this once the tests pass!