### PR TITLE
Resume tests for py3.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,9 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # 3.12 currently not supported due to issues with nifty.
-        # python-version: ["3.11", "3.12"]
-        python-version: ["3.11"]
+        python-version: ["3.11", "3.12"]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Since `nifty` is fixed now, should we run tests for `py3.12` as well?