### PR TITLE
Make passing checkpoint flexible in livecell inference script

### DIFF
--- a/micro_sam/evaluation/livecell.py
+++ b/micro_sam/evaluation/livecell.py
@@ -78,7 +78,7 @@ def _get_livecell_paths(input_folder, split="test", n_val_per_cell_type=None):
 
 
 def livecell_inference(
-    checkpoint: Union[str, os.PathLike],
+    checkpoint: Optional[Union[str, os.PathLike]],
     input_folder: Union[str, os.PathLike],
     model_type: str,
     experiment_folder: Union[str, os.PathLike],
@@ -145,7 +145,7 @@ def livecell_inference(
 
 
 def run_livecell_precompute_embeddings(
-    checkpoint: Union[str, os.PathLike],
+    checkpoint: Optional[Union[str, os.PathLike]],
     input_folder: Union[str, os.PathLike],
     model_type: str,
     experiment_folder: Union[str, os.PathLike],
@@ -173,7 +173,7 @@ def run_livecell_precompute_embeddings(
 
 
 def run_livecell_iterative_prompting(
-    checkpoint: Union[str, os.PathLike],
+    checkpoint: Optional[Union[str, os.PathLike]],
     input_folder: Union[str, os.PathLike],
     model_type: str,
     experiment_folder: Union[str, os.PathLike],
@@ -216,7 +216,7 @@ def run_livecell_iterative_prompting(
 
 
 def run_livecell_amg(
-    checkpoint: Union[str, os.PathLike],
+    checkpoint: Optional[Union[str, os.PathLike]],
     input_folder: Union[str, os.PathLike],
     model_type: str,
     experiment_folder: Union[str, os.PathLike],
@@ -273,7 +273,7 @@ def run_livecell_amg(
 
 
 def run_livecell_instance_segmentation_with_decoder(
-    checkpoint: Union[str, os.PathLike],
+    checkpoint: Optional[Union[str, os.PathLike]],
     input_folder: Union[str, os.PathLike],
     model_type: str,
     experiment_folder: Union[str, os.PathLike],
@@ -343,7 +343,7 @@ def run_livecell_inference() -> None:
 
     # the checkpoint, input and experiment folder
     parser.add_argument(
-        "-c", "--ckpt", type=str, required=True,
+        "-c", "--ckpt", type=str, default=None,
         help="Provide model checkpoints (vanilla / finetuned)."
     )
     parser.add_argument(


### PR DESCRIPTION
This PR updates the livecell inference functionalities, by making the requirement of checkpoint path more flexible, in order to support automatic downloading from `micro-sam` models. GTG from my side!

I will go ahead and merge this once the tests pass! @constantinpape let me know if you spot something!

PS. This was easier than I thought. We use this function quite locally only for some `livecell` experiments!

And resolves https://github.com/computational-cell-analytics/micro-sam/issues/1031