### PR TITLE
More zarr-related updates to avoid warnings

### DIFF
--- a/micro_sam/sam_annotator/_state.py
+++ b/micro_sam/sam_annotator/_state.py
@@ -138,7 +138,7 @@ class AnnotatorState(metaclass=Singleton):
         # If we have an embedding path the data signature has already been computed,
         # and we can read it from there.
         if save_path is not None and isinstance(save_path, str):
-            f = zarr.open(save_path, "r")
+            f = zarr.open(save_path, mode="r")
             self.data_signature = f.attrs["data_signature"]
 
         # Otherwise we compute it here.

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -1340,7 +1340,7 @@ class EmbeddingWidget(_WidgetBase):
         # and we ask the user if they want to load these embeddings.
         if self.embeddings_save_path and os.listdir(self.embeddings_save_path):
             try:
-                f = zarr.open(self.embeddings_save_path, "a")
+                f = zarr.open(self.embeddings_save_path, mode="a")
 
                 # Validate that the embeddings are complete.
                 # Note: 'input_size' is the last value set in the attrs of f,


### PR DESCRIPTION
I was testing the object classification pipeline, and made two tiny updates in zarr open mode, to avoid the `zarr>3.1` related warning (i.e. `mode` is gonna be an expected keyword argument and positional won't work).

GTG from my side!