### PR TITLE
Fix: Handle missing seg_ids after resizing

### DIFF
--- a/micro_sam/object_classification.py
+++ b/micro_sam/object_classification.py
@@ -210,7 +210,14 @@ def project_prediction_to_segmentation(
     """
     assert len(object_prediction) == len(seg_ids)
     prediction = {seg_id: class_pred for seg_id, class_pred in zip(seg_ids, object_prediction)}
-    prediction[0] = 0
+    # prediction[0] = 0
+    # Due to resizing in the acquisition of seg_ids it could happen that seg_ids is not ordered, e.g. [1, 2, 4, 5]
+    # because instance 3 was removed by the resizing process.
+    # In this case, we need to add the missing id with a prediction of 0.
+    for i in np.unique(segmentation):
+        if i not in seg_ids:
+            prediction[i] = 0
+
     return takeDict(prediction, segmentation)
 
 


### PR DESCRIPTION
After resizing in `_compute_object_features_impl`, some small instances are dropped. Thus the seg_ids list could become non-contiguous (e.g., [1, 2, 4, 5] because instance 3 was removed). This results in an error when mapping the predictions to the segmentation, since some instances have no corresponding prediction.

I added a quick fix, that simply sets the predictions of these missing instances to 0.

An alternative solution could be to introduce a min_size argument, which would proactively filter out small instances before resizing. This would make the filtering explicit and more transparent to the user.

@constantinpape @anwai98 