### PR TITLE
Lock pyopengl==3.1.6 to avoid OpenGL 3D rendering failure on linux ma…

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -28,5 +28,6 @@ dependencies:
     - timm
     - xarray
     - zarr
+    - pyopengl=3.1.6
     - pip:
         - git+https://github.com/ChaoningZhang/MobileSAM.git


### PR DESCRIPTION
After installing micro-sam using:

```bash
conda create -c conda-forge -n micro-sam micro_sam
```

On a linux machine on a HPC, napari reported error regarding OpenGL. I saw the following discussion on napari repo and by downgrading pyopengl to 3.16 napari was able to do 3D rendering.

https://github.com/napari/napari/issues/7671

```bash
conda install -c conda-forge pyopengl=3.1.6
```