### PR TITLE
Add is_multi_tensor argument to default_sam_dataset to split kwargs in loader

### DIFF
--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -582,7 +582,7 @@ def default_sam_dataset(
     min_size: int = 25,
     max_sampling_attempts: Optional[int] = None,
     rois: Optional[Union[slice, Tuple[slice, ...]]] = None,
-    _tensor: bool = True,
+    is_multi_tensor: bool = True,
     **kwargs,
 ) -> Dataset:
     """Create a PyTorch Dataset for training a SAM model.


### PR DESCRIPTION
Hello again :D
i found a better way to alter param "is_multitensor" in default sam dataset by adding param to the function header. 
This way we utilize split_kwargs function: 
split_kwargs(default_sam_dataset, **kwargs)

and we do not have to use kwargs seperately. 

@anwai98 