### PR TITLE
Decoder lora feature

### DIFF
--- a/micro_sam/training/util.py
+++ b/micro_sam/training/util.py
@@ -135,9 +135,10 @@ def get_trainable_sam_model(
 
             # we would want to "freeze" all the components in the model if passed a list of parts
             for l_item in freeze:
-                # in case PEFT is switched on, we cannot freeze the image encoder
+                # in case PEFT is switched on, we cannot freeze the image encoder unless decoder_lora is enabled
                 if (peft_kwargs and peft_kwargs.get('rank') is not None) and (l_item == "image_encoder"):
-                    raise ValueError("You cannot use PEFT & freeze the image encoder at the same time.")
+                    if not peft_kwargs.get('decoder_lora', False):
+                        raise ValueError("You cannot use PEFT & freeze the image encoder at the same time.")
 
                 if name.startswith(f"{l_item}"):
                     param.requires_grad = False


### PR DESCRIPTION
Hi @anwai98, I have something to discuss.

## Summary
Add LoRA support for SAM decoder transformer layers with `decoder_lora=True` parameter.

## Changes
- Add `SimpleLoRALayer` for individual linear layer LoRA adaptation
- Add `decoder_lora` parameter to `PEFT_Sam.__init__()`
- Apply LoRA to decoder: self-attention, cross-attention, MLP layers

## SimpleLoRALayer
Why I added `SimpleLoRALayer` instead of adapting `LoRASurgery`:

- **Encoder**: Uses combined `qkv = nn.Linear(dim, dim*3)` → splits output into q,k,v
- **Decoder**: Uses separate `q_proj`, `k_proj`, `v_proj` layers

**Current LoRASurgery/AttentionLoRA (encoder)**:
```python
# One projection layer for all Q, K, V
qkv = self.qkv_proj(x)
qkv = torch.cat([
    qkv[:, :, :, :self.dim] + new_q,
    qkv[:, :, :, self.dim:-self.dim] + new_k,
    qkv[:, :, :, -self.dim:] + new_v
], dim=-1)
````

**Decoder needs (separate projections)**:

```python
q = self.q_proj(x) + lora_q(x)
k = self.k_proj(x) + lora_k(x)
v = self.v_proj(x) + lora_v(x)
```

That's why I add a `SimpleLoRALayer`. What do you think?