### PR TITLE
Minor fix to additional arguments for training instance segmentation

### DIFF
--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -848,14 +848,17 @@ def train_sam_for_configuration(
 
     train_kwargs.update(**kwargs)
     if train_instance_segmentation_only:
+        instance_seg_kwargs, extra_kwargs = split_kwargs(train_instance_segmentation, **train_kwargs)
+        model_kwargs, extra_kwargs = split_kwargs(get_sam_model, **extra_kwargs)
+        instance_seg_kwargs.update(**model_kwargs)
+
         train_instance_segmentation(
             name=name,
             train_loader=train_loader,
             val_loader=val_loader,
             checkpoint_path=checkpoint_path,
-            with_segmentation_decoder=with_segmentation_decoder,
             model_type=model_type,
-            **train_kwargs
+            **instance_seg_kwargs,
         )
     else:
         train_sam(


### PR DESCRIPTION
Hi @lufre1,

I realized that the argument you spotted doesn't really exist in the function, which is why the issue was happening. Removing that lead to more issues (because it got some SAM-related parameters for interactive segmentation training heuristics). Hence, I make the checks exclusively now for expected additional arguments. 

Could you check if this branch works now?

If yes, I'll merge this then!