### PR TITLE
Minor fix to 3d encoder wrapper for expected model type configuration

### DIFF
--- a/micro_sam/models/sam_3d_wrapper.py
+++ b/micro_sam/models/sam_3d_wrapper.py
@@ -38,7 +38,7 @@ def get_sam_3d_model(
 
     # Make sure not to freeze the encoder when using LoRA.
     _freeze_encoder = freeze_encoder if lora_rank is None else False
-    sam_3d = Sam3DWrapper(sam, freeze_encoder=_freeze_encoder, model_type=model_type)
+    sam_3d = Sam3DWrapper(sam, freeze_encoder=_freeze_encoder, model_type=model_type[:5])
     sam_3d.to(device)
 
     return sam_3d


### PR DESCRIPTION
This PR makes a tiny fix for updating the `model_type` argument provided to the `Sam3DWrapper` to match the expected ViT input arguments (eg. embedding dimensions, etc).

It's a super tiny change, this is why I kept it on `master`, and is relevant for latest `medico-sam` release. I'll go ahead and merge this once the tests pass!