### PR TITLE
Added is_seg_dataset parameter in training.training.default_sam_dataset()

### DIFF
--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -687,7 +687,7 @@ def default_sam_dataset(
         raw_paths, raw_key, label_paths, label_key, with_channels, **kwargs
     )
     # Since `is_seg_dataset` is selected and sorted above, let's remove it out of running kwargs, if available.
-    kwargs.pop("is_seg_dataset")
+    kwargs.pop("is_seg_dataset", None)
 
     # Set the data transformations.
     if raw_transform is None:


### PR DESCRIPTION
Fix to solve `TypeError: torch_em.segmentation.default_segmentation_loader() got multiple values for keyword argument 'is_seg_dataset' `- issue #1142

Added an additional parameter in `training.training.default_sam_dataset(**args)` named `is_seg_dataset`, which takes precedence over the argmunet with the same name in `**kwargs`, eliminating the TypeError.