### PR TITLE
Add defensive design for recreating point layer

### DIFF
--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -849,7 +849,16 @@ def create_prompt_menu(points_layer, labels, menu_name="prompt", label_name="lab
     label_widget = Container(widgets=[label_menu])
 
     def update_label_menu(event):
-        new_label = str(points_layer.current_properties[label_name][0])
+        current_properties = points_layer.current_properties
+        if label_name not in current_properties:
+            return
+        try:
+            values = current_properties[label_name]
+            if len(values) == 0:
+                return
+            new_label = str(values[0])
+        except Exception:
+            return
         if new_label != label_menu.value:
             label_menu.value = new_label
 


### PR DESCRIPTION
This PR builds on an old PR (https://github.com/computational-cell-analytics/micro-sam/pull/943), to address a specific limitation @constantinpape encountered (see https://github.com/computational-cell-analytics/micro-sam/pull/943#issuecomment-2819216004). We aim to fix https://github.com/computational-cell-analytics/micro-sam/issues/1009 here.

Can you try to check this behaviour and tell me if this fixes our previous observation? (i.e. multiple times deleting the point prompt layer)