### PR TITLE
Minor fix for last image interruption in image series annotator

### DIFF
--- a/micro_sam/sam_annotator/image_series_annotator.py
+++ b/micro_sam/sam_annotator/image_series_annotator.py
@@ -252,6 +252,13 @@ def image_series_annotator(
     def next_image(*args):
         nonlocal next_image_id
 
+        # Check whether we are already past the last image (eg. button pressed again).
+        if next_image_id >= len(images):
+            abort = widgets._generate_message("info", end_msg)
+            if not abort:
+                QTimer.singleShot(0, viewer.close)
+            return
+
         segmentation = viewer.layers["committed_objects"].data
         abort = False
         if segmentation.sum() == 0:


### PR DESCRIPTION
Haha I love the branch name for this!

This PR aims to fix https://github.com/computational-cell-analytics/micro-sam/issues/754. It seems like we need this micro-managed addition to ensure that we are past the last image, and the viewer can close now!

Can you please test this for me once you have sometime? @constantinpape @lufre1 