### PR TITLE
Add example script for instance segmentation only finetuning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,8 +197,11 @@ iterative_prompting_results/
 *MACOSX
 hela_ctc
 clf-test-data
+*.h5
+.claude/
 
 # Related to i2k workshop folders.
 data/
 embeddings/
 *.zarr
+

--- a/examples/finetuning/README.md
+++ b/examples/finetuning/README.md
@@ -2,4 +2,5 @@
 
 This folder contains example scripts that show how to finetune a SAM model on your own data and how the finetuned model can then be used:
 - `finetune_hela.py`: Shows how to finetune the model on new data. Set `train_instance_segmentation` (line 130) to `True` in order to also train a decoder for automatic instance segmentation.
+- `finetune_hela_instance_segmentation.py`: Shows how to train **only** the instance segmentation decoder (UNETR) without updating the interactive segmentation components (prompt encoder and mask decoder). Use this when you only need automatic instance segmentation (AIS) and not interactive segmentation. The trained model can be exported with `export_instance_segmentation_model` and used with the micro_sam AIS functionality.
 - `annotator_with_finetuned_model.py`: Use the finetuned model in the 2d annotator.

--- a/examples/finetuning/finetune_hela_instance_segmentation.py
+++ b/examples/finetuning/finetune_hela_instance_segmentation.py
@@ -1,20 +1,19 @@
 import os
-import numpy as np
 
 import micro_sam.training as sam_training
-from micro_sam.util import export_custom_sam_model, get_device
+from micro_sam.util import get_device
 from micro_sam.sample_data import fetch_tracking_example_data, fetch_tracking_segmentation_data
 
 
 DATA_FOLDER = "data"
 
 
-def get_dataloader(split, patch_shape, batch_size, train_instance_segmentation):
-    """Return train or val data loader for finetuning SAM.
+def get_dataloader(split, patch_shape, batch_size):
+    """Return train or val data loader for training the instance segmentation decoder.
 
     The data loader must be a torch data loader that returns `x, y` tensors,
     where `x` is the image data and `y` are the labels.
-    The labels have to be in a label mask instance segmentation format.
+    The labels have to be in a label mask instance segmentation format,
     i.e. a tensor of the same spatial shape as `x`, with each object mask having its own ID.
     Important: the ID 0 is reserved for background, and the IDs must be consecutive.
 
@@ -22,6 +21,8 @@ def get_dataloader(split, patch_shape, batch_size, train_instance_segmentation):
     the example hela data. You can either adapt this for your own data (see comments below)
     or write a suitable torch dataloader yourself.
     """
+    import numpy as np
+
     assert split in ("train", "val")
     os.makedirs(DATA_FOLDER, exist_ok=True)
 
@@ -29,18 +30,9 @@ def get_dataloader(split, patch_shape, batch_size, train_instance_segmentation):
     image_dir = fetch_tracking_example_data(DATA_FOLDER)
     segmentation_dir = fetch_tracking_segmentation_data(DATA_FOLDER)
 
-    # 'sam_training.default_sam_loader' is a convenience function to build a torch dataloader
-    # from image data and labels for training SAM models.
-    # It supports image data in various formats. Here, we load image data and labels from the two
-    # folders with tif images that were downloaded by the example data functionality, by specifying
-    # `raw_key` and `label_key` as `*.tif`. This means all images in the respective folders that end with
-    # .tif will be loaded.
-    # The function supports many other file formats. For example, if you have tif stacks with multiple slices
-    # instead of multiple tif images in a folder, then you can pass raw_key=label_key=None.
-
-    # Load images from multiple files in folder via pattern (here: all tif files)
+    # Load images from multiple files in folder via pattern (here: all tif files).
     raw_key, label_key = "*.tif", "*.tif"
-    # Alternative: if you have tif stacks you can just set raw_key and label_key to None
+    # Alternative: if you have tif stacks you can just set raw_key and label_key to None.
     # raw_key, label_key = None, None
 
     # The 'roi' argument can be used to subselect parts of the data.
@@ -50,11 +42,17 @@ def get_dataloader(split, patch_shape, batch_size, train_instance_segmentation):
     else:
         roi = np.s_[70:, :, :]
 
+    # 'default_sam_loader' creates a dataloader suitable for SAM training.
+    # Setting 'train_instance_segmentation_only=True' configures the label transform to produce
+    # only the 3 distance-related channels (normalized distances, boundary distances, foreground
+    # probabilities), without the instance segmentation channel. This is the correct format
+    # for 'train_instance_segmentation'.
     loader = sam_training.default_sam_loader(
         raw_paths=image_dir, raw_key=raw_key,
         label_paths=segmentation_dir, label_key=label_key,
         patch_shape=patch_shape, batch_size=batch_size,
-        with_segmentation_decoder=train_instance_segmentation,
+        with_segmentation_decoder=True,
+        train_instance_segmentation_only=True,
         is_train=(split == "train"),
         rois=roi,
         num_workers=8, shuffle=True, raw_transform=sam_training.identity,
@@ -62,61 +60,65 @@ def get_dataloader(split, patch_shape, batch_size, train_instance_segmentation):
     return loader
 
 
-def run_training(checkpoint_name, model_type, train_instance_segmentation):
-    """Run the actual model training."""
+def run_training(checkpoint_name, model_type):
+    """Run training of the UNETR instance segmentation decoder."""
 
     # All hyperparameters for training.
     batch_size = 1  # the training batch size
     patch_shape = (1, 512, 512)  # the size of patches for training
-    n_objects_per_batch = 25  # the number of objects per batch that will be sampled
     device = get_device()  # the device used for training
 
     # Get the dataloaders.
-    train_loader = get_dataloader("train", patch_shape, batch_size, train_instance_segmentation)
-    val_loader = get_dataloader("val", patch_shape, batch_size, train_instance_segmentation)
+    train_loader = get_dataloader("train", patch_shape, batch_size)
+    val_loader = get_dataloader("val", patch_shape, batch_size)
 
-    # Run training.
-    sam_training.train_sam(
+    # Run training of only the UNETR instance segmentation decoder.
+    # This trains the SAM image encoder together with the UNETR decoder,
+    # but does not train the prompt encoder or mask decoder.
+    sam_training.train_instance_segmentation(
         name=checkpoint_name,
         model_type=model_type,
         train_loader=train_loader,
         val_loader=val_loader,
         n_epochs=100,
-        n_objects_per_batch=n_objects_per_batch,
-        with_segmentation_decoder=train_instance_segmentation,
         device=device,
     )
 
 
 def export_model(checkpoint_name, model_type):
-    """Export the trained model."""
-    # export the model after training so that it can be used by the rest of the 'micro_sam' library
-    export_path = "./finetuned_hela_model.pth"
+    """Export the trained model.
+
+    The exported model can be used with the micro_sam automatic instance segmentation (AIS) functionality.
+    Note: the exported model is only suitable for automatic segmentation,
+    not for interactive segmentation with prompts.
+    """
+    export_path = "./finetuned_hela_instance_segmentation_model.pth"
     checkpoint_path = os.path.join("checkpoints", checkpoint_name, "best.pt")
-    export_custom_sam_model(
-        checkpoint_path=checkpoint_path,
+    sam_training.export_instance_segmentation_model(
+        trained_model_path=checkpoint_path,
+        output_path=export_path,
         model_type=model_type,
-        save_path=export_path,
     )
 
 
 def main():
-    """Finetune a Segment Anything model.
+    """Finetune only the instance segmentation decoder (UNETR) of a Segment Anything model.
 
     This example uses image data and segmentations from the cell tracking challenge,
     but can easily be adapted for other data (including data you have annotated with micro_sam beforehand).
+
+    Unlike 'finetune_hela.py', this script trains only the UNETR decoder for automatic instance
+    segmentation, without updating the interactive segmentation components (prompt encoder and mask decoder).
+    Use this when you only need automatic instance segmentation (AIS) and not interactive segmentation.
     """
     # The model_type determines which base model is used to initialize the weights that are finetuned.
     # We use vit_b here because it can be trained faster. Note that vit_h usually yields higher quality results.
     model_type = "vit_b"
 
     # The name of the checkpoint. The checkpoints will be stored in './checkpoints/<checkpoint_name>'
-    checkpoint_name = "sam_hela"
+    checkpoint_name = "sam_hela_instance_segmentation"
 
-    # Train an additional convolutional decoder for end-to-end automatic instance segmentation
-    train_instance_segmentation = True
-
-    run_training(checkpoint_name, model_type, train_instance_segmentation)
+    run_training(checkpoint_name, model_type)
     export_model(checkpoint_name, model_type)
 
 


### PR DESCRIPTION
This PR adds a new example script `finetune_hela_instance_segmentation.py` for users who only want to train the UNETR instance segmentation decoder, without touching the interactive segmentation training engine (in reference to @schilling40's experiments)

GTM from my side once the tests pass.

PS. Not super relevant, but I decided to migrate `finetune_hela.py` off from `torch_em.default_segmentation_loader` to `default_sam_loader`, since that's the right abstraction to use here.

PPS. @schilling40 the new example script for you should work without any issues. And `train_sam` is not the correct function to train a UNETR backbone only. `train_sam` is engineered for SAM-training or SAM+UNETR training, and `train_instance_segmentation for UNETR training. Lemme know if the issues you are facing are fixed. 