### PR TITLE
Fix image loading and saving logic in image_series_annotator

### DIFF
--- a/micro_sam/sam_annotator/image_series_annotator.py
+++ b/micro_sam/sam_annotator/image_series_annotator.py
@@ -209,10 +209,10 @@ def image_series_annotator(
         return os.path.join(output_folder, fname)
 
     def _load_image(image_id):
-        image = images[next_image_id]
+        image = images[image_id]
         if not have_inputs_as_arrays:
             image = imageio.imread(image)
-        image_embedding_path = embedding_paths[next_image_id]
+        image_embedding_path = embedding_paths[image_id]
         return image, image_embedding_path
 
     # Check which image to load next if we skip segmented images.
@@ -244,7 +244,7 @@ def image_series_annotator(
     )
 
     def _save_segmentation(image_path, current_idx, segmentation):
-        save_path = _get_save_path(image_path, next_image_id)
+        save_path = _get_save_path(image_path, current_idx)
         imageio.imwrite(save_path, segmentation, compression="zlib")
 
     # Add functionality for going to the next image.
@@ -279,8 +279,8 @@ def image_series_annotator(
 
         # If we are skipping images that are already segmented, then check if we have to load the next image.
         save_path = _get_save_path(images[next_image_id], next_image_id)
+        segmentation_result = None
         if skip_segmented:
-            segmentation_result = None
             while os.path.exists(save_path):
                 next_image_id += 1
 


### PR DESCRIPTION
Related to this issue: https://github.com/computational-cell-analytics/micro-sam/issues/1174

> When running the image_series_annotator, the first image in the series incorrectly reports that embeddings have not been calculated, even when they have been precomputed for all images. Rerunning the embedding computation resolves it temporarily, but if an embedding_path is set, it throws an error until the embedding path is removed.

> The root cause seem to be in the _load_image helper function, which accepts an image_id parameter but ignores it — instead reading next_image_id from the outer scope.

> A related issue exists in _save_segmentation, which similarly ignores its current_idx parameter in favour of the outer next_image_id.

