### PR TITLE
Update export_instance_segmentation_model for UNETR-only checkpoints

### DIFF
--- a/micro_sam/training/training.py
+++ b/micro_sam/training/training.py
@@ -392,27 +392,25 @@ def export_instance_segmentation_model(
         model_type: The model type.
         initial_checkpoint_path: The initial checkpoint path the instance segmentation training was based on (optional).
     """
-    trained_state = torch.load(trained_model_path, weights_only=False, map_location="cpu")["model_state"]
+    state = torch.load(trained_model_path, weights_only=False, map_location="cpu")
+    trained_state = state.get("model_state", state)
 
     # Get the state of the encoder and instance segmentation decoder from the trained checkpoint.
     encoder_state = OrderedDict([(k, v) for k, v in trained_state.items() if k.startswith("encoder")])
     decoder_state = OrderedDict([(k, v) for k, v in trained_state.items() if not k.startswith("encoder")])
 
     # Load the original state of the model that was used as the basis of instance segmentation training.
-    _, model_state = get_sam_model(
-        model_type=model_type, checkpoint_path=initial_checkpoint_path, return_state=True, device="cpu",
+    predictor = get_sam_model(
+        model_type=model_type, checkpoint_path=initial_checkpoint_path, device="cpu",
     )
-    # Remove the sam prefix if it's in the model state.
-    prefix = "sam."
-    model_state = OrderedDict(
-        [(k[len(prefix):] if k.startswith(prefix) else k, v) for k, v in model_state.items()]
-    )
+    model_state = OrderedDict(predictor.model.state_dict())
 
-    # Replace the image encoder state.
-    model_state = OrderedDict(
-        [(k, encoder_state[k[6:]] if k.startswith("image_encoder") else v)
-         for k, v in model_state.items()]
-    )
+    # Replace the image encoder weights with the trained ones.
+    # UNETR stores the image encoder as "encoder.*"; SAM uses "image_encoder.*".
+    for k in list(model_state.keys()):
+        if k.startswith("image_encoder."):
+            encoder_key = "encoder." + k[len("image_encoder."):]
+            model_state[k] = encoder_state[encoder_key]
 
     save_state = {"model_state": model_state, "decoder_state": decoder_state}
     torch.save(save_state, output_path)


### PR DESCRIPTION
There were some assumptions and edge-cases not covered in `export_instance_segmentation_model`. It now accepts raw UNETR state dicts in a flexible manner now!

This PR aims to make the `export_instance_segmentation_model` function more robust to miscellanous edge cases and ties out of some state dict assumptions!

I'll merge this once the tests pass!