### PR TITLE
Fix predictor adapter load state dict to accept keyword arguments

### DIFF
--- a/micro_sam/bioimageio/model_export.py
+++ b/micro_sam/bioimageio/model_export.py
@@ -235,10 +235,10 @@ def _check_model(model_description, input_paths, result_paths):
                 "mask_prompts": mask_prompts,
                 "embeddings": embeddings,
             },
-        ).as_single_block()
-        prediction = pp.predict_sample_block(sample)
+        )
+        prediction = pp.predict_sample_without_blocking(sample)
 
-        predicted_mask = prediction.blocks["masks"].data.data
+        predicted_mask = prediction.members["masks"].data
         assert predicted_mask.shape == mask.shape
         assert np.allclose(mask, predicted_mask)
 
@@ -261,9 +261,9 @@ def _check_model(model_description, input_paths, result_paths):
         for kwargs in prompt_kwargs:
             sample = create_sample_for_model(
                 model=model_description, inputs={"image": image, "embeddings": embeddings, **kwargs},
-            ).as_single_block()
-            prediction = pp.predict_sample_block(sample)
-            predicted_mask = prediction.blocks["masks"].data.data
+            )
+            prediction = pp.predict_sample_without_blocking(sample)
+            predicted_mask = prediction.members["masks"].data
             assert predicted_mask.shape == mask.shape
 
 

--- a/micro_sam/bioimageio/predictor_adaptor.py
+++ b/micro_sam/bioimageio/predictor_adaptor.py
@@ -31,8 +31,8 @@ class PredictorAdaptor(nn.Module):
         self.sam_model = sam_model_registry[model_type]()
         self.sam = SamPredictor(self.sam_model)
 
-    def load_state_dict(self, state):
-        self.sam.model.load_state_dict(state)
+    def load_state_dict(self, state, **kwargs):
+        self.sam.model.load_state_dict(state, **kwargs)
 
     @torch.no_grad()
     def forward(

--- a/micro_sam/bioimageio/predictor_adaptor.py
+++ b/micro_sam/bioimageio/predictor_adaptor.py
@@ -32,7 +32,7 @@ class PredictorAdaptor(nn.Module):
         self.sam = SamPredictor(self.sam_model)
 
     def load_state_dict(self, state, **kwargs):
-        self.sam.model.load_state_dict(state, **kwargs)
+        return self.sam.model.load_state_dict(state, **kwargs)
 
     @torch.no_grad()
     def forward(


### PR DESCRIPTION
`pytorch`'s model loading engine calls has changed and `strict=True` is the hard default for a while (not sure what changed that the tests are breaking right now).

Let's see how the tests work at https://github.com/computational-cell-analytics/micro-sam/pull/1206, this would confirm the suspicion!