### PR TITLE
Fix motion model in interactive tracking

### DIFF
--- a/micro_sam/sam_annotator/util.py
+++ b/micro_sam/sam_annotator/util.py
@@ -563,13 +563,13 @@ def _compute_movement(seg, t0, t1):
     def compute_center(t):
         # computation with center of mass
         center = np.where(seg[t] == 1)
-        center = np.array(np.mean(center[0]), np.mean(center[1]))
+        center = np.array([np.mean(center[0]), np.mean(center[1])])
         return center
 
     center0 = compute_center(t0)
     center1 = compute_center(t1)
 
-    move = center1 - center0
+    move = center0 - center1
     return move.astype("float64")
 
 


### PR DESCRIPTION
Okay meanwhile looking at a user's issue, I realized there are two tiny bugs in interactive tracking:

1. The first one for missing list brackets in `np.array(a, b)` is obvious!  
2. The sign computed for the move was reverted, i.e. both causing the mask shift to drift in the wrong direction from the 3rd tracked frame onwards (I thought about it, and maybe with cells which drift slowly / less is where we didn't notice this)

These are super minor changes, but should do the trick! @constantinpape 