### PR TITLE
Make the v1 training choose precision from the hardware

### DIFF
--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -232,6 +232,29 @@ def get_device(device: Optional[Union[str, torch.device]] = None) -> Union[str, 
     return device
 
 
+# The compute capability that runs bfloat16 natively. Gated on this and not on
+# 'torch.cuda.is_bf16_supported', whose default counts emulation and reports bf16 on Volta.
+BF16_MIN_CAPABILITY = (8, 0)
+
+
+def training_autocast_dtype(device: Optional[Union[str, torch.device]] = None) -> Optional[torch.dtype]:
+    """The dtype that training runs in on a device.
+
+    Training runs in bfloat16 or fp32, never float16: float16 needs loss scaling and still overflows
+    in the decoder convolutions on GPUs that accumulate it in half precision.
+
+    Args:
+        device: The device the forward pass runs on. Defaults to the best available one.
+
+    Returns:
+        bfloat16 where the device runs it natively, or None where training stays in fp32.
+    """
+    device = torch.device(get_device() if device is None else device)
+    if device.type != "cuda" or not torch.cuda.is_available():
+        return None
+    return torch.bfloat16 if torch.cuda.get_device_capability(device) >= BF16_MIN_CAPABILITY else None
+
+
 def get_embedding_function(model_type: str) -> callable:
     """Get the precompute-embeddings function for the model family of `model_type`.
 

--- a/micro_sam/v1/training/training.py
+++ b/micro_sam/v1/training/training.py
@@ -27,11 +27,11 @@ import torch_em
 from torch_em.util import load_data
 from torch_em.data.datasets.util import split_kwargs
 
-from ...util import get_device
 from . import sam_trainer as trainers
 from ..instance_segmentation import get_unetr
 from ..models.peft_sam import ClassicalSurgery
 from . import joint_sam_trainer as joint_trainers
+from ...util import get_device, training_autocast_dtype
 from ..util import get_model_names, export_custom_sam_model, get_sam_model
 from .util import get_trainable_sam_model, ConvertToSamInputs, require_8bit, get_raw_transform
 
@@ -319,6 +319,9 @@ def train_sam(
             model_params, lr, optimizer_class, scheduler_class, scheduler_kwargs
         )
 
+        # The hardware decides the precision. Training runs in bfloat16 only.
+        mixed_precision = training_autocast_dtype(device) is not None
+
         # The trainer which performs training and validation.
         if with_segmentation_decoder:
             instance_seg_loss = torch_em.loss.DiceBasedDistanceLoss(mask_distances_in_bg=True)
@@ -333,7 +336,8 @@ def train_sam(
                 lr_scheduler=scheduler,
                 logger=joint_trainers.JointSamLogger,
                 log_image_interval=100,
-                mixed_precision=True,
+                mixed_precision=mixed_precision,
+                mixed_precision_dtype="bfloat16",
                 convert_inputs=convert_inputs,
                 n_objects_per_batch=n_objects_per_batch,
                 n_sub_iteration=n_sub_iteration,
@@ -355,7 +359,8 @@ def train_sam(
                 lr_scheduler=scheduler,
                 logger=trainers.SamLogger,
                 log_image_interval=100,
-                mixed_precision=True,
+                mixed_precision=mixed_precision,
+                mixed_precision_dtype="bfloat16",
                 convert_inputs=convert_inputs,
                 n_objects_per_batch=n_objects_per_batch,
                 n_sub_iteration=n_sub_iteration,
@@ -522,7 +527,9 @@ def train_instance_segmentation(
             train_loader=train_loader,
             val_loader=val_loader,
             device=device,
-            mixed_precision=True,
+            # The hardware decides the precision. Training runs in bfloat16 only.
+            mixed_precision=training_autocast_dtype(device) is not None,
+            mixed_precision_dtype="bfloat16",
             log_image_interval=50,
             compile_model=False,
             save_root=save_root,

--- a/micro_sam/v2/training/sam2_trainer.py
+++ b/micro_sam/v2/training/sam2_trainer.py
@@ -14,7 +14,7 @@ import torch.distributed as dist
 import torch_em
 from torch_em.trainer.logger_base import TorchEmLogger
 
-from micro_sam.v2.util import training_autocast_dtype
+from micro_sam.util import training_autocast_dtype
 from micro_sam.v2.loss.custom_sam2_loss import CORE_LOSS_KEY, CustomSAM2Metric
 
 # Fixed seed for the main-process randomness during validation (prompt/correction-click
@@ -153,7 +153,7 @@ class Sam2Trainer(CheckpointAdapter, torch_em.trainer.DefaultTrainer):
             train_loader, val_loader, optimizer, device, lr_scheduler,
             logger, save_root, etc.). mixed_precision and mixed_precision_dtype
             default to what the device runs natively, see
-            `micro_sam.v2.util.training_autocast_dtype`.
+            `micro_sam.util.training_autocast_dtype`.
     """
 
     def __init__(

--- a/micro_sam/v2/training/training.py
+++ b/micro_sam/v2/training/training.py
@@ -7,10 +7,9 @@ import torch
 import torch.distributed as dist
 from torch.utils.data import DataLoader
 
-from micro_sam.util import get_device
-from micro_sam.v2.util import training_autocast_dtype
 from micro_sam.v2.transforms.raw import VideoAugment
 from micro_sam.v2.loss.custom_sam2_loss import CustomSAM2Loss
+from micro_sam.util import get_device, training_autocast_dtype
 from .util import get_sam2_train_model, ConvertToSam2VideoBatch
 from .joint_sam2_trainer import JointSam2Trainer, JointSam2Logger
 from micro_sam.v2.loss.directed_distance_based import DirectedDistanceLoss

--- a/micro_sam/v2/util.py
+++ b/micro_sam/v2/util.py
@@ -19,17 +19,14 @@ from micro_sam.v2.models._video_predictor import _build_sam2_video_predictor
 from micro_sam.v2.normalization import IMAGE_PREPROCESSING, VIDEO_PREPROCESSING, to_image
 from micro_sam.util import (
     get_device, get_cache_directory, microsam_cachedir, _open_embeddings,
-    _configure_mps_memory, device_type, make_temp_embedding_path,
+    _configure_mps_memory, device_type, make_temp_embedding_path, BF16_MIN_CAPABILITY,
 )
 
 
 Device = Optional[Union[str, torch.device]]
 Devices = Optional[Union[str, torch.device, Sequence[Union[str, torch.device]]]]
 
-# Precision preference on cuda: bf16, then fp16, then fp32. Gated on the compute capability and not
-# on 'torch.cuda.is_bf16_supported', whose default counts emulation and reports bf16 on Volta, where
-# it is slower than fp32 and needs more memory.
-BF16_MIN_CAPABILITY = (8, 0)
+# Precision preference on cuda: bf16, then fp16, then fp32. See `micro_sam.util.BF16_MIN_CAPABILITY`.
 FP16_MIN_CAPABILITY = (7, 0)
 
 
@@ -72,21 +69,6 @@ def autocast(device: Device = None):
     if dtype is None:
         return contextlib.nullcontext()
     return torch.autocast(device_type=device.type, dtype=dtype)
-
-
-def training_autocast_dtype(device: Device = None) -> Optional[torch.dtype]:
-    """The dtype that training runs in on a device.
-
-    Training uses the same device gate as inference, but not its float16 tier. SAM2 finetunes in
-    bfloat16. Training in float16 needs loss scaling and can still diverge.
-
-    Args:
-        device: The device the forward pass runs on. Defaults to the best available one.
-
-    Returns:
-        bfloat16 where the device runs it natively, or None where training stays in fp32.
-    """
-    return torch.bfloat16 if autocast_dtype(device) is torch.bfloat16 else None
 
 
 def precision_name(device: Device = None) -> str:

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -2,6 +2,7 @@ import os
 import unittest
 from shutil import rmtree
 
+import pytest
 import numpy as np
 import requests
 import torch
@@ -806,6 +807,27 @@ class TestEmbeddingBackend(unittest.TestCase):
             self.assertEqual(f.attrs["model_name"], "vit_t")
             self.assertEqual(list(f.attrs["original_size"]), [512, 512])
             self.assertIsNone(f.attrs["tile_shape"])
+
+
+@pytest.mark.parametrize(
+    "capability, expected", [((9, 0), torch.bfloat16), ((8, 0), torch.bfloat16), ((7, 5), None), ((6, 1), None)]
+)
+def test_the_training_precision_skips_the_float16_tier(monkeypatch, capability, expected):
+    """Inference runs float16 on Volta and Turing. Training stays in fp32 there, because it uses bfloat16."""
+    from micro_sam.util import training_autocast_dtype
+
+    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
+    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device: capability)
+
+    assert training_autocast_dtype(torch.device("cuda")) is expected
+
+
+@pytest.mark.parametrize("device_type", ("cpu", "mps"))
+def test_the_training_precision_is_fp32_outside_cuda(device_type):
+    """bfloat16 is emulated on these devices, so autocast makes training slower."""
+    from micro_sam.util import training_autocast_dtype
+
+    assert training_autocast_dtype(torch.device(device_type)) is None
 
 
 if __name__ == "__main__":

--- a/test/test_v2_training.py
+++ b/test/test_v2_training.py
@@ -597,26 +597,5 @@ def test_the_trainer_trains_in_bfloat16_without_a_scaler_on_ampere(monkeypatch):
     assert calls == [("cuda", torch.bfloat16)]
 
 
-@pytest.mark.parametrize(
-    "capability, expected", [((9, 0), torch.bfloat16), ((8, 0), torch.bfloat16), ((7, 5), None), ((6, 1), None)]
-)
-def test_the_training_precision_skips_the_float16_tier(monkeypatch, capability, expected):
-    """Inference runs float16 on Volta and Turing. Training stays in fp32 there, because SAM2 uses bfloat16."""
-    from micro_sam.v2.util import training_autocast_dtype
-
-    monkeypatch.setattr(torch.cuda, "is_available", lambda: True)
-    monkeypatch.setattr(torch.cuda, "get_device_capability", lambda device: capability)
-
-    assert training_autocast_dtype(torch.device("cuda")) is expected
-
-
-@pytest.mark.parametrize("device_type", ("cpu", "mps"))
-def test_the_training_precision_is_fp32_outside_cuda(device_type):
-    """bfloat16 is emulated on these devices, so autocast makes training slower."""
-    from micro_sam.v2.util import training_autocast_dtype
-
-    assert training_autocast_dtype(torch.device(device_type)) is None
-
-
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The PRs mentioned in the issue #1214. Work with [this PR for torch-em](https://github.com/constantinpape/torch-em/pull/718)

fp16 mixed precision causes NaN in Conv2d(512, 512, 3x3) inside the UNETR decoder on GPUs that lack Tensor Cores (e.g. GTX 1660 Ti). Without Tensor Cores, cuDNN accumulates the 4608-element dot product in fp16, overflowing its ceiling of ~65504. bfloat16 avoids this by sharing fp32's exponent range. Confirmed by forward hook diagnostic and deterministic mode test ruling out Winograd as the specific cause.

- Add `_get_mixed_precision_dtype(device)` helper that returns torch.float16 for GPUs with Tensor Cores and torch.bfloat16 otherwise
- Detect Tensor Core presence via compute capability and device name: Ampere+ (sm_8.x+) always fp16; Volta/Turing (sm_7.x) fp16 except GTX 16xx series (TU116/TU117); Pascal and below bfloat16
- Avoid torch.cuda.is_bf16_supported() as it reflects software-level dtype support and returns True on sm_7.5 with CUDA 12.x regardless of Tensor Core presence
- Wire dtype through train_sam (JointSamTrainer and SamTrainer) and train_instance_segmentation (DefaultTrainer) via the new mixed_precision_dtype parameter added to torch_em DefaultTrainer