### PR TITLE
Add 3d toggle for selective z-propagation and early stopping in interactive segmentation

### DIFF
--- a/micro_sam/sam_annotator/_tooltips.py
+++ b/micro_sam/sam_annotator/_tooltips.py
@@ -16,6 +16,9 @@ tooltips = {
     "segmentnd": {
         "box_extension": "Enter factor by which box size is increased when projecting to adjacent slices. Larger factors help if object sizes change between slices.",  # noqa
         "iou_threshold": "Enter the minimal overlap between objects in adjacent slices to continue segmentation.",
+        "early_stop_patience": "SAM2 volume mode: stop propagating once the object has been absent for this many consecutive slices. Lower values stop sooner (faster); 0 disables early stopping and propagates through the whole volume.",  # noqa
+        "use_full_z_range": "SAM2 volume mode: propagate through all slices along z. Uncheck to restrict propagation to a chosen slice range with the slider below (faster, and a hard guardrail against leaking into neighbouring structures).",  # noqa
+        "z_range": "SAM2 volume mode: the inclusive range of slices (along z) that propagation is allowed to cover. Only used when 'Propagate through full volume' is unchecked.",  # noqa
         "motion_smoothing": "Enter the motion smoothing factor. It is used to follow objects which have a directed movement, higher values help for objects that are moving fast.",  # noqa
         "projection_dropdown": "Choose the projection mode. It determines which prompts are derived from the masks projected to adjacent frames to rerun SAM.",  # noqa
         "batched": "Enable to segment multiple objects with separate point prompts. Each positive point will be tracked as a separate object. Only available for SAM2 models.",  # noqa

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -29,8 +29,8 @@ from magicgui.widgets import ComboBox, Container, create_widget
 from napari.utils import progress
 from napari.utils.notifications import show_info
 from qtpy import QtWidgets
-from qtpy.QtCore import QObject, Signal
-from superqt import QCollapsible
+from qtpy.QtCore import QObject, Signal, Qt
+from superqt import QCollapsible, QLabeledRangeSlider
 
 from .. import util
 from ..v1 import instance_segmentation
@@ -1865,6 +1865,13 @@ class UnifiedSegmentWidget(_WidgetBase):
         )
         setting_values.layout().addLayout(layout)
 
+        # SAM2 volume-mode propagation controls. The engine only holds the values; the visible
+        # InteractiveSegmentationWidget owns the user-facing controls and writes these attributes.
+        # 'early_stop_patience': stop after this many consecutive empty slices (0 -> disabled).
+        # 'z_range': inclusive (z_min, z_max) hard bound on propagation, or 'None' for the full volume.
+        self.early_stop_patience = 2
+        self.z_range = None
+
         # Motion smoothing (tracking only)
         if self.tracking:
             self.motion_smoothing = 0.5
@@ -2177,9 +2184,26 @@ class UnifiedSegmentWidget(_WidgetBase):
 
                 # Propagate the prompts throughout the volume and combine the propagated segmentations.
                 # Report per-slice progress so the user can see the propagation advancing.
+                # A patience of 0 disables early stopping (propagate through the whole volume).
+                early_stop_patience = self.early_stop_patience if self.early_stop_patience > 0 else None
+                # 'self.z_range' is a hard slice bound set by the interactive widget; 'None' = full volume.
+                # Match the progress bar total to the slices that will actually be propagated.
+                # When a z-range is set the total is its width. With the full volume and no early
+                # stopping it is the full depth. But with the full volume AND early stopping the
+                # endpoint is not knowable upfront (propagation halts wherever the object ends), so
+                # we use an indeterminate ('busy') bar: napari renders total=0 as an animated range.
+                if self.z_range is not None:
+                    z_lo, z_hi = self.z_range
+                    n_propagation_steps = z_hi - z_lo + 1
+                elif early_stop_patience is None:
+                    n_propagation_steps = shape[0]
+                else:
+                    n_propagation_steps = 0  # Indeterminate / busy bar.
+                pbar_signals.pbar_total.emit(n_propagation_steps)
                 pbar_signals.pbar_description.emit("Propagate in volume")
                 seg = state.interactive_segmenter.predict(
-                    update_progress=lambda update: pbar_signals.pbar_update.emit(update)
+                    update_progress=lambda update: pbar_signals.pbar_update.emit(update),
+                    early_stop_patience=early_stop_patience, z_range=self.z_range,
                 )
 
             else:
@@ -2417,6 +2441,7 @@ class InteractiveSegmentationWidget(_WidgetBase):
         self.batched = False
         self.apply_to_volume = False
         self._segment_widget = None
+        self._propagation_settings = None
         self._create_widget()
 
     def _create_widget(self):
@@ -2475,16 +2500,109 @@ class InteractiveSegmentationWidget(_WidgetBase):
             checkbox_row.addWidget(self.apply_to_volume_checkbox)
             self.layout().addLayout(checkbox_row)
 
+            # SAM2 volume-mode propagation controls (early stopping + z-range). Hidden until the
+            # user enables 'Apply to Volume' with a SAM2 model; the controls drive the engine.
+            self._propagation_settings = self._create_propagation_settings()
+            self._propagation_settings.setVisible(False)
+            self.layout().addWidget(self._propagation_settings)
+
         # Place the segment and clear buttons side by side.
         button_row = QtWidgets.QHBoxLayout()
         button_row.addWidget(self.segment_button)
         button_row.addWidget(self.clear_button)
         self.layout().addLayout(button_row)
 
+    def _create_propagation_settings(self):
+        """Build the SAM2 volume-mode propagation controls (early stopping + z-range slider).
+
+        The controls live on the visible interactive widget and write their values into the hidden
+        'UnifiedSegmentWidget' engine, which reads 'early_stop_patience' and 'z_range' at run time.
+        """
+        container = QtWidgets.QWidget()
+        container.setLayout(QtWidgets.QVBoxLayout())
+
+        # Stop after this many consecutive empty slices (0 disables early stopping).
+        self.early_stop_patience = 2
+        self.early_stop_patience_param, layout = self._add_int_param(
+            "early_stop_patience", self.early_stop_patience, min_val=0, max_val=100,
+            title="Stop after empty slices", tooltip=get_tooltip("segmentnd", "early_stop_patience"),
+        )
+        self.early_stop_patience_param.valueChanged.connect(self._sync_propagation_settings)
+        container.layout().addLayout(layout)
+
+        # Full-volume propagation (default) vs. a restricted z-range.
+        self.use_full_z_range = True
+        self.full_z_range_checkbox = self._add_boolean_param(
+            "use_full_z_range", self.use_full_z_range,
+            title="Propagate through all slices",
+            tooltip=get_tooltip("segmentnd", "use_full_z_range"),
+        )
+        container.layout().addWidget(self.full_z_range_checkbox)
+
+        # The labeled range slider collapses to zero height when sharing a row with a text label,
+        # so it gets its own full-width row with the caption above it and a minimum height.
+        z_range_label = QtWidgets.QLabel("Propagation z-range")
+        z_range_label.setToolTip(get_tooltip("segmentnd", "z_range"))
+        container.layout().addWidget(z_range_label)
+        self.z_range_slider = QLabeledRangeSlider(Qt.Orientation.Horizontal)
+        self.z_range_slider.setRange(0, 1)
+        self.z_range_slider.setValue((0, 1))
+        self.z_range_slider.setToolTip(get_tooltip("segmentnd", "z_range"))
+        self.z_range_slider.setEnabled(not self.use_full_z_range)
+        self.z_range_slider.setMinimumHeight(40)
+        self.z_range_slider.setSizePolicy(QtWidgets.QSizePolicy.Expanding, QtWidgets.QSizePolicy.Fixed)
+        container.layout().addWidget(self.z_range_slider)
+
+        self.full_z_range_checkbox.stateChanged.connect(self._on_full_z_range_changed)
+        self.z_range_slider.valueChanged.connect(self._sync_propagation_settings)
+
+        return _make_collapsible(container, title="Volume Propagation Settings")
+
+    def _on_full_z_range_changed(self, state):
+        """Enable/disable the z-range slider and push the change to the engine."""
+        self.use_full_z_range = bool(state)
+        self.z_range_slider.setEnabled(not self.use_full_z_range)
+        self._sync_propagation_settings()
+
+    def _update_z_range_slider(self):
+        """Match the z-range slider extent to the depth of the loaded volume."""
+        state = AnnotatorState()
+        if state.image_shape is None:
+            return
+        z_max = int(state.image_shape[0]) - 1
+        if z_max < 0:
+            return
+        lo, hi = self.z_range_slider.value()
+        self.z_range_slider.setRange(0, z_max)
+        if not self.use_full_z_range and hi <= z_max and lo < hi:
+            self.z_range_slider.setValue((lo, hi))
+        else:
+            self.z_range_slider.setValue((0, z_max))
+
+    def _sync_propagation_settings(self, *args):
+        """Write the propagation controls into the hidden segmentation engine."""
+        if self._segment_widget is None:
+            return
+        self._segment_widget.early_stop_patience = int(self.early_stop_patience_param.value())
+        if bool(self.use_full_z_range):
+            self._segment_widget.z_range = None
+        else:
+            self._segment_widget.z_range = tuple(int(v) for v in self.z_range_slider.value())
+
     def _on_apply_to_volume_changed(self, state):
         """Sync the shared volume mode to the segmentation engine."""
         self.apply_to_volume = bool(state)
         self._segment_widget.apply_to_volume = self.apply_to_volume
+
+        # Show the propagation controls only in volume mode with a SAM2 model, and size the slider.
+        if self._propagation_settings is not None:
+            annotator_state = AnnotatorState()
+            is_sam2 = bool(annotator_state.is_sam2) if annotator_state.is_sam2 is not None else False
+            show = self.apply_to_volume and is_sam2
+            self._propagation_settings.setVisible(show)
+            if show:
+                self._update_z_range_slider()
+                self._sync_propagation_settings()
 
     def _on_batched_changed(self, state):
         """Sync the batched mode to the segmentation engine."""
@@ -2496,6 +2614,7 @@ class InteractiveSegmentationWidget(_WidgetBase):
         if self._ndim == 2:
             _segment_object_2d(self._viewer, batched=bool(self.batched))
         else:
+            self._sync_propagation_settings()
             self._segment_widget(self._viewer)
 
     def clear(self, viewer=None):

--- a/micro_sam/v2/prompt_based_segmentation.py
+++ b/micro_sam/v2/prompt_based_segmentation.py
@@ -477,29 +477,78 @@ class PromptableSegmentation3D:
     ):
         raise NotImplementedError
 
-    def propagate_prompts(self, update_progress=None):
-        # First, we propagate the masklets throughout the frames using the input prompts in selected frames.
-        # 'update_progress' is an optional callback that is called with the number of newly processed
-        # frames, so callers (e.g. the napari annotator) can report propagation progress to the user.
-        forward_video_segments = {}
-        for out_frame_idx, out_obj_ids, out_mask_logits in self.predictor.propagate_in_video(self.inference_state):
-            forward_video_segments[out_frame_idx] = {
+    def _propagate_in_direction(self, reverse, update_progress=None, early_stop_patience=None, z_range=None):
+        """Run SAM2 propagation in one temporal direction, optionally stopping early.
+
+        Each step of the SAM2 video predictor runs the full memory attention and mask decoder
+        for one frame, which is the dominant cost of volumetric segmentation (especially on CPU).
+        Early stopping reads the masks we already compute and breaks out of the propagation once
+        the object has clearly left the volume, so we do not keep running the network on frames
+        that no longer contain the object.
+
+        Args:
+            reverse: Propagate backwards in time (towards lower slice indices) if True.
+            update_progress: Optional callback invoked with the number of newly processed frames.
+            early_stop_patience: If given, stop this direction after this many consecutive frames
+                in which every tracked object's mask is empty (i.e. the object has left the volume).
+                'None' disables early stopping and propagates to the end of the volume.
+            z_range: If given, an inclusive '(z_min, z_max)' bound on the slice indices propagation
+                may cover. Propagation stops at the range edge in this direction. 'None' propagates
+                to the end of the volume.
+
+        Returns:
+            Mapping from frame index to per-object boolean masks, in the order frames were yielded.
+        """
+        video_segments = {}
+        consecutive_empty = 0
+        for out_frame_idx, out_obj_ids, out_mask_logits in self.predictor.propagate_in_video(
+            self.inference_state, reverse=reverse,
+        ):
+            # Hard z-range bound: stop once propagation would leave the user-selected slice range.
+            if z_range is not None and not (z_range[0] <= out_frame_idx <= z_range[1]):
+                break
+
+            per_object = {
                 out_obj_id: (out_mask_logits[i] > 0.0).cpu().numpy() for i, out_obj_id in enumerate(out_obj_ids)
             }
+            video_segments[out_frame_idx] = per_object
             if update_progress is not None:
                 update_progress(1)
+
+            # Early stopping: once every tracked object has been absent for 'early_stop_patience'
+            # consecutive frames, the object has left the volume and there is nothing more to track.
+            # A single empty frame is not enough (SAM2 can momentarily drop and recover a mask), so
+            # we require a run of empty frames before breaking.
+            if early_stop_patience is not None:
+                frame_is_empty = not any(mask.any() for mask in per_object.values())
+                consecutive_empty = consecutive_empty + 1 if frame_is_empty else 0
+                if consecutive_empty >= early_stop_patience:
+                    break
+
+            # Hard z-range bound: we have just stored the edge slice, so stop before the predictor
+            # steps outside the range (and pays for a frame we would discard).
+            if z_range is not None and out_frame_idx == (z_range[0] if reverse else z_range[1]):
+                break
+
+        return video_segments
+
+    def propagate_prompts(self, update_progress=None, early_stop_patience=None, z_range=None):
+        # First, we propagate the masklets forward in time using the input prompts in selected frames.
+        # 'update_progress' is an optional callback that is called with the number of newly processed
+        # frames, so callers (e.g. the napari annotator) can report propagation progress to the user.
+        # 'early_stop_patience' bounds the propagation by stopping a direction once the object has been
+        # absent for that many consecutive frames (see '_propagate_in_direction'). 'z_range' is an
+        # inclusive '(z_min, z_max)' hard bound on the slices propagation may cover.
+        forward_video_segments = self._propagate_in_direction(
+            reverse=False, update_progress=update_progress, early_stop_patience=early_stop_patience, z_range=z_range,
+        )
 
         # Next, we do the propagation reverse in time.
         reverse_video_segments = {}
         if len(forward_video_segments) < self.volume.shape[0]:  # Perform reverse propagation only if necessary
-            for out_frame_idx, out_obj_ids, out_mask_logits in self.predictor.propagate_in_video(
-                self.inference_state, reverse=True,
-            ):
-                reverse_video_segments[out_frame_idx] = {
-                    out_obj_id: (out_mask_logits[i] > 0.0).cpu().numpy() for i, out_obj_id in enumerate(out_obj_ids)
-                }
-                if update_progress is not None:
-                    update_progress(1)
+            reverse_video_segments = self._propagate_in_direction(
+                reverse=True, update_progress=update_progress, early_stop_patience=early_stop_patience, z_range=z_range,
+            )
             # NOTE: The order is reversed to stitch the reverse propagation with forward.
             reverse_video_segments = dict(reversed(list(reverse_video_segments.items())))
 
@@ -565,19 +614,22 @@ class PromptableSegmentation3D:
 
         return seg
 
-    def predict(self, update_progress=None):
+    def predict(self, update_progress=None, early_stop_patience=None, z_range=None):
         # First, we propagate prompts.
-        video_segments = self.propagate_prompts(update_progress=update_progress)
+        video_segments = self.propagate_prompts(
+            update_progress=update_progress, early_stop_patience=early_stop_patience, z_range=z_range,
+        )
 
         # Next, let's merge the segmented objects per frame back together as instances per slice.
-        segmentation = []
-        for slice_idx in video_segments.keys():
-            per_slice_seg = np.zeros(self.volume.shape[-2:])
-            for _instance_idx, _instance_mask in video_segments[slice_idx].items():
-                mask = _crop_to_original_shape(_instance_mask.squeeze(), self.volume.shape[-2:])
-                per_slice_seg[mask] = _instance_idx
-            segmentation.append(per_slice_seg)
-
-        segmentation = np.stack(segmentation).astype("uint64")
+        # We allocate the full-volume output and index it by the slice id so that frames skipped by
+        # early stopping (which are absent from 'video_segments') stay as background instead of
+        # shifting the remaining slices out of alignment with the volume.
+        shape = self.volume.shape[-2:]
+        segmentation = np.zeros((self.volume.shape[0],) + tuple(shape), dtype="uint64")
+        for slice_idx, instances in video_segments.items():
+            per_slice_seg = segmentation[slice_idx]
+            for instance_idx, instance_mask in instances.items():
+                mask = _crop_to_original_shape(instance_mask.squeeze(), shape)
+                per_slice_seg[mask] = instance_idx
 
         return segmentation


### PR DESCRIPTION
So the tricks here are mostly applied to aim for speeding up CPU-based segmentation

1. Early stopping for missing masks after n slices
2. Selective propagation for any "n (continuous) slices"

Both are currently optional, and works like a charm tbh.

I think it's a good addditional to the segmentation tool, and will merge it for now. If it feels too much, we can remove it in future.

PS. It's hidden down inside "Segmentation Settings" dropdown, and shows up only when "Apply to Volume" is selected for volumetric interactive segmentation! ;)