### PR TITLE
More features for classification tools

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -33,3 +33,5 @@ dependencies:
     - pip:
         - git+https://github.com/ChaoningZhang/MobileSAM.git
         - git+https://github.com/facebookresearch/sam2.git
+        # Optional AnyUp feature upsampler for the pixel and object classifiers.
+        - git+https://github.com/wimmerth/anyup

--- a/environment.yaml
+++ b/environment.yaml
@@ -33,5 +33,4 @@ dependencies:
     - pip:
         - git+https://github.com/ChaoningZhang/MobileSAM.git
         - git+https://github.com/facebookresearch/sam2.git
-        # Optional AnyUp feature upsampler for the pixel and object classifiers.
         - git+https://github.com/wimmerth/anyup

--- a/micro_sam/object_classification.py
+++ b/micro_sam/object_classification.py
@@ -19,17 +19,57 @@ from .import util
 from .v1.util import precompute_image_embeddings
 
 
-def _compute_object_features_impl(embeddings, segmentation, resize_embedding_shape):
-    # Get the embeddings and put the channel axis last.
-    embeddings = embeddings.transpose(1, 2, 0)
+def _anyup_object_resize(embeds_chw, image_region, target_hw, upsampler, is_sam2=False):
+    # Upsample a (C, h, w) embedding to (target_h, target_w, C) with AnyUp, using the image region
+    # as guidance. SAM1 padded the image to a square, so we square-pad the image here to match how
+    # the segmentation is padded; SAM2 stretched the image to a square, so we pass it as-is (AnyUp
+    # pools it to the embedding grid, matching the stretched features).
+    import torch
+    import torch.nn.functional as F
+    from .pixel_classification import _to_anyup_image
 
-    # Pad the segmentation to be of square shape.
+    # AnyUp's internal convolutions need at least 2 px per spatial dim. Fall back to plain
+    # interpolation for degenerate regions.
+    if min(embeds_chw.shape[-2:]) < 2 or min(target_hw) < 2 or min(image_region.shape[:2]) < 2:
+        return resize(
+            embeds_chw.transpose(1, 2, 0), tuple(target_hw) + (embeds_chw.shape[0],), preserve_range=True
+        ).astype("float32")
+
+    device = next(upsampler.parameters()).device
+    image_tensor = _to_anyup_image(image_region, device)  # (1, 3, H, W)
+    if not is_sam2:
+        h, w = image_tensor.shape[-2:]
+        image_tensor = F.pad(image_tensor, (0, max(h - w, 0), 0, max(w - h, 0)))
+    feature_tensor = torch.from_numpy(np.ascontiguousarray(embeds_chw)).to(device).float().unsqueeze(0)
+    from .pixel_classification import ANYUP_Q_CHUNK_SIZE
+    with torch.no_grad():
+        upsampled = upsampler(
+            image_tensor, feature_tensor, output_size=tuple(target_hw), q_chunk_size=ANYUP_Q_CHUNK_SIZE
+        )
+    return upsampled[0].permute(1, 2, 0).cpu().numpy().astype("float32")
+
+
+def _compute_object_features_impl(
+    embeddings, segmentation, resize_embedding_shape, image_region=None, upsampler=None, is_sam2=False,
+    pbar_update=None,
+):
+    # Keep the raw (C, h, w) embedding for AnyUp, which needs the channel axis first.
+    embeddings_chw = embeddings
+
+    # Bring the segmentation to a square shape matching the (square) embedding. SAM1 pads the image
+    # to a square (so we zero-pad the segmentation to match); SAM2 stretches the image to a square
+    # (so we resize the segmentation to a square to match the stretched embedding).
     shape = segmentation.shape
-    if shape[0] == shape[1]:
+    if is_sam2:
+        side = max(shape)
+        segmentation_rescaled = resize(
+            segmentation, (side, side), order=0, anti_aliasing=False, preserve_range=True
+        ).astype(segmentation.dtype)
+    elif shape[0] == shape[1]:
         segmentation_rescaled = segmentation
     elif shape[0] > shape[1]:
         segmentation_rescaled = np.pad(segmentation, ((0, 0), (0, shape[0] - shape[1])))
-    elif shape[1] > shape[0]:
+    else:
         segmentation_rescaled = np.pad(segmentation, ((0, shape[1] - shape[0]), (0, 0)))
     assert segmentation_rescaled.shape[0] == segmentation_rescaled.shape[1]
     shape = segmentation_rescaled.shape
@@ -40,8 +80,15 @@ def _compute_object_features_impl(embeddings, segmentation, resize_embedding_sha
     # The motivation for this is to avoid loosing smaller segmented objects when resizing the segmentation
     # to the original embedding shape. On the other hand, we avoid resizing the embeddings to the full segmentation
     # shape for efficiency reasons.
-    resize_shape = tuple(min(rsh, sh) for rsh, sh in zip(resize_embedding_shape, shape)) + (embeddings.shape[-1],)
-    embeddings = resize(embeddings, resize_shape, preserve_range=True).astype(embeddings.dtype)
+    resize_hw = tuple(min(rsh, sh) for rsh, sh in zip(resize_embedding_shape, shape))
+    if upsampler is not None:
+        # AnyUp upsamples the embedding using the image region instead of plain interpolation.
+        embeddings = _anyup_object_resize(embeddings_chw, image_region, resize_hw, upsampler, is_sam2)
+    else:
+        embeddings = embeddings_chw.transpose(1, 2, 0)  # put the channel axis last
+        embeddings = resize(
+            embeddings, resize_hw + (embeddings.shape[-1],), preserve_range=True
+        ).astype(embeddings.dtype)
 
     segmentation_rescaled = resize(
         segmentation_rescaled, embeddings.shape[:2], order=0, anti_aliasing=False, preserve_range=True
@@ -56,10 +103,12 @@ def _compute_object_features_impl(embeddings, segmentation, resize_embedding_sha
         ["area"] + [f"mean_intensity-{i}" for i in range(embeddings.shape[-1])]
     ].values
 
+    if pbar_update is not None:
+        pbar_update(1)
     return seg_ids, features
 
 
-def _create_seg_and_embed_generator(segmentation, image_embeddings, is_tiled, is_3d):
+def _create_seg_and_embed_generator(segmentation, image_embeddings, is_tiled, is_3d, image=None):
     assert is_tiled or is_3d
 
     if is_tiled:
@@ -71,10 +120,13 @@ def _create_seg_and_embed_generator(segmentation, image_embeddings, is_tiled, is
         tiling = None
         length = segmentation.shape[0]
 
+    # The generators yield (segmentation, embeddings, image_region) per slice / tile. The image
+    # region is None unless an image is given (only needed for AnyUp upsampling).
     if is_3d and is_tiled:  # 3d data with tiling
         def generator():
             for z in range(segmentation.shape[0]):
                 seg_z = segmentation[z]
+                image_z = None if image is None else image[z]
                 for block_id in range(tiling.number_of_blocks):
                     block = tiling.get_block_with_halo(block_id, halo)
 
@@ -83,15 +135,17 @@ def _create_seg_and_embed_generator(segmentation, image_embeddings, is_tiled, is
 
                     bb = tuple(slice(beg, end) for beg, end in zip(block.outer_block.begin, block.outer_block.end))
                     seg = seg_z[bb]
+                    image_region = None if image_z is None else image_z[bb]
 
-                    yield seg, embeds
+                    yield seg, embeds, image_region
 
     elif is_3d:  # 3d data no tiling
         def generator():
             for z in range(length):
                 seg = segmentation[z]
                 embeds = image_embeddings["features"][z].squeeze()
-                yield seg, embeds
+                image_region = None if image is None else image[z]
+                yield seg, embeds, image_region
 
     else:  # 2d data with tiling
         def generator():
@@ -102,8 +156,9 @@ def _create_seg_and_embed_generator(segmentation, image_embeddings, is_tiled, is
                 embeds = tile_embeds[str(block_id)][:].squeeze()
                 bb = tuple(slice(beg, end) for beg, end in zip(block.outer_block.begin, block.outer_block.end))
                 seg = segmentation[bb]
+                image_region = None if image is None else image[bb]
 
-                yield seg, embeds
+                yield seg, embeds, image_region
 
     return generator, length
 
@@ -113,6 +168,8 @@ def compute_object_features(
     segmentation: np.ndarray,
     resize_embedding_shape: Tuple[int, int] = (256, 256),
     verbose: bool = True,
+    image: Optional[np.ndarray] = None,
+    upsampler=None,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Compute object features based on SAM embeddings.
 
@@ -121,18 +178,37 @@ def compute_object_features(
         segmentation: The segmentation for which to compute the features.
         resize_embedding_shape: Shape for intermediate resizing of the embeddings.
         verbose: Whether to print a progressbar for the computation.
+        image: The original image, required when `upsampler` is given (AnyUp uses it as guidance).
+        upsampler: An optional AnyUp model (see `pixel_classification.get_anyup_upsampler`). When
+            given, the embedding is upsampled with AnyUp using the image instead of plain interpolation.
 
     Returns:
         The segmentation ids.
         The object features.
     """
+    if upsampler is not None and image is None:
+        raise ValueError("An 'image' is required when an AnyUp 'upsampler' is given.")
+
     is_tiled = image_embeddings["input_size"] is None
     is_3d = segmentation.ndim == 3
+    # SAM2 embeddings carry the high-resolution decoder features; SAM1 embeddings never do. SAM2
+    # stretches the image to a square (no padding), which changes how the embedding aligns spatially.
+    is_sam2 = "high_res_feats" in image_embeddings
 
     # If we have simple embeddings, i.e. 2d without tiling, then we can directly compute the features.
     if not is_tiled and not is_3d:
         embeddings = image_embeddings["features"].squeeze()
-        return _compute_object_features_impl(embeddings, segmentation, resize_embedding_shape)
+        # AnyUp is the slow part, so show a progress bar (which also drives napari's activity dots)
+        # for the single upsampling call.
+        anyup_pbar = tqdm(
+            total=1, desc="Upsampling with AnyUp", disable=(not verbose) or (upsampler is None)
+        )
+        result = _compute_object_features_impl(
+            embeddings, segmentation, resize_embedding_shape, image_region=image, upsampler=upsampler,
+            is_sam2=is_sam2, pbar_update=anyup_pbar.update if upsampler is not None else None,
+        )
+        anyup_pbar.close()
+        return result
 
     # Otherwise, we compute the features by iterating over slices and/or tiles,
     # compute the features for each slice / tile and accumulate them.
@@ -149,14 +225,18 @@ def compute_object_features(
     # Then, we create a generator for iterating over the slices and / or tile.
     # This generator returns the respective segmentation and embeddings.
     seg_embed_generator, n_gen = _create_seg_and_embed_generator(
-        segmentation, image_embeddings, is_tiled=is_tiled, is_3d=is_3d
+        segmentation, image_embeddings, is_tiled=is_tiled, is_3d=is_3d, image=image
     )
 
-    for seg, embeds in tqdm(
-        seg_embed_generator(), total=n_gen, disable=not verbose, desc="Compute object features"
+    # With AnyUp, label the bar accordingly since the upsampling is the slow part.
+    desc = "Upsampling with AnyUp" if upsampler is not None else "Compute object features"
+    for seg, embeds, image_region in tqdm(
+        seg_embed_generator(), total=n_gen, disable=not verbose, desc=desc
     ):
         # Compute this seg ids and features.
-        this_seg_ids, this_features = _compute_object_features_impl(embeds, seg, resize_embedding_shape)
+        this_seg_ids, this_features = _compute_object_features_impl(
+            embeds, seg, resize_embedding_shape, image_region=image_region, upsampler=upsampler, is_sam2=is_sam2
+        )
         this_seg_ids = this_seg_ids.tolist()
 
         # Find which of the seg ids are new (= processed for the first time).
@@ -232,6 +312,7 @@ def run_prediction_with_object_classifier(
     segmentation_key: Optional[str] = None,
     project_prediction: bool = True,
     ndim: Optional[int] = None,
+    upsampler=None,
 ) -> List[np.ndarray]:
     """Run prediction with a pretrained object classifier on a series of images.
 
@@ -244,6 +325,9 @@ def run_prediction_with_object_classifier(
         segmentation_key:
         project_prediction:
         ndim:
+        upsampler: An optional AnyUp model (see `pixel_classification.get_anyup_upsampler`) to
+            upsample the embeddings with the image as guidance instead of plain interpolation.
+            Use the same setting that the classifier was trained with.
 
     Returns:
         The predictions.
@@ -255,7 +339,10 @@ def run_prediction_with_object_classifier(
         zip(images, segmentations), total=len(images), desc="Run prediction with object classifier"
     ):
         embeddings = precompute_image_embeddings(predictor, image, verbose=False, ndim=ndim)
-        seg_ids, features = compute_object_features(embeddings, segmentation, verbose=False)
+        seg_ids, features = compute_object_features(
+            embeddings, segmentation, verbose=False, image=image if upsampler is not None else None,
+            upsampler=upsampler,
+        )
         prediction = rf.predict(features)
         if project_prediction:
             prediction = project_prediction_to_segmentation(segmentation, prediction, seg_ids)

--- a/micro_sam/pixel_classification.py
+++ b/micro_sam/pixel_classification.py
@@ -4,6 +4,7 @@ from multiprocessing import cpu_count
 from typing import List, Optional, Sequence, Tuple, Union
 
 import numpy as np
+import torch
 
 from bioimage_cpp.utils import Blocking
 
@@ -26,6 +27,84 @@ from .v1.util import precompute_image_embeddings
 # yields more genuine embedding detail (n_tiles x the per-tile resolution).
 DEFAULT_GRID_SIZE = 256
 DEFAULT_MAX_GRID_SIZE = 512
+
+# AnyUp paper checkpoint (raw state_dict), loaded into a default AnyUp() (see anyup/hubconf.py).
+ANYUP_URL = "https://github.com/wimmerth/anyup/releases/download/checkpoint/anyup_paper.pth"
+# ImageNet statistics AnyUp was trained with, applied to the image after mapping it to [0, 1].
+IMAGENET_MEAN = (0.485, 0.456, 0.406)
+IMAGENET_STD = (0.229, 0.224, 0.225)
+# Cap the number of query rows processed per AnyUp cross-attention chunk, to bound peak memory on
+# large (e.g. full, untiled) images. Does not change results, only memory/runtime.
+ANYUP_Q_CHUNK_SIZE = 4096
+
+
+def get_anyup_upsampler(checkpoint_path: Optional[Union[str, os.PathLike]] = None, device=None):
+    """Load the AnyUp feature upsampler.
+
+    AnyUp is an optional dependency. The weights are resolved from `checkpoint_path`, then the
+    `MICROSAM_ANYUP_CHECKPOINT` environment variable, and finally the released paper checkpoint
+    (downloaded and cached by torch hub).
+
+    Args:
+        checkpoint_path: Optional path to a local AnyUp state_dict.
+        device: The device to load the model on. By default, the best available device.
+
+    Returns:
+        The AnyUp model in eval mode.
+    """
+    try:
+        from anyup.model import AnyUp
+    except ImportError as e:
+        raise ImportError(
+            "Upsampling with AnyUp requires the 'anyup' package. Install it from "
+            "https://github.com/wimmerth/anyup to use this option."
+        ) from e
+
+    device = util.get_device(device)
+    checkpoint_path = checkpoint_path or os.environ.get("MICROSAM_ANYUP_CHECKPOINT")
+    if checkpoint_path is not None:
+        state_dict = torch.load(checkpoint_path, map_location=device)
+    else:
+        state_dict = torch.hub.load_state_dict_from_url(ANYUP_URL, map_location=device)
+
+    model = AnyUp().to(device)
+    model.load_state_dict(state_dict)
+    return model.eval()
+
+
+def _to_anyup_image(image: np.ndarray, device) -> torch.Tensor:
+    """Convert an image to the AnyUp input tensor (1, 3, H, W).
+
+    The image is first mapped to the uint8 3-channel RGB that SAM itself consumed via
+    `util._to_image` (same channel mapping and per-channel min-max normalization), then scaled
+    to [0, 1] and ImageNet-normalized to match AnyUp's training distribution.
+    """
+    rgb = util._to_image(image)  # (H, W, 3) uint8, identical to what SAM saw
+    tensor = torch.from_numpy(np.ascontiguousarray(rgb)).to(device).float().permute(2, 0, 1).unsqueeze(0) / 255.0
+    mean = torch.tensor(IMAGENET_MEAN, device=device).view(1, -1, 1, 1)
+    std = torch.tensor(IMAGENET_STD, device=device).view(1, -1, 1, 1)
+    return (tensor - mean) / std
+
+
+def _anyup_to_grid(embeddings: np.ndarray, image_region: np.ndarray, target_hw: Tuple[int, int], upsampler):
+    """Upsample a (C, H, W) embedding to a (target_h, target_w, C) feature image with AnyUp.
+
+    Mirrors the contract of `_resize_to_grid`, but uses the matching `image_region` as guidance
+    instead of plain interpolation. The embedding is passed raw (AnyUp normalizes it internally).
+    """
+    # AnyUp's internal convolutions need at least 2 px per spatial dim. Fall back to plain
+    # interpolation for degenerate sliver regions (e.g. a 1-px-tall edge tile).
+    if min(embeddings.shape[-2:]) < 2 or min(target_hw) < 2 or min(image_region.shape[:2]) < 2:
+        return _resize_to_grid(embeddings, target_hw)
+
+    device = next(upsampler.parameters()).device
+    image_tensor = _to_anyup_image(image_region, device)
+    feature_tensor = torch.from_numpy(np.ascontiguousarray(embeddings)).to(device).float().unsqueeze(0)
+    with torch.no_grad():
+        upsampled = upsampler(
+            image_tensor, feature_tensor, output_size=tuple(target_hw), q_chunk_size=ANYUP_Q_CHUNK_SIZE
+        )
+    return upsampled[0].permute(1, 2, 0).cpu().numpy().astype("float32")
 
 
 def _grid_shape(image_hw: Tuple[int, int], target_long: int) -> Tuple[Tuple[int, int], float]:
@@ -58,15 +137,30 @@ def _resize_to_grid(embeddings: np.ndarray, target_hw: Tuple[int, int]) -> np.nd
     return resize(feature_image, resize_shape, preserve_range=True).astype("float32")
 
 
-def _block_to_grid(embeddings: np.ndarray, block_hw: Tuple[int, int], target_hw: Tuple[int, int]) -> np.ndarray:
-    """Crop a block embedding to its aspect ratio and resize it to the target grid shape."""
-    return _resize_to_grid(_aspect_crop(embeddings, block_hw), target_hw)
+def _block_to_grid(embeddings, block_hw, target_hw, image_region=None, upsampler=None, is_sam2=False, pbar_update=None):
+    """Crop a block embedding to its aspect ratio and map it to the target grid shape.
+
+    SAM1 pads the image to a square before encoding, so the square embedding has content in a
+    sub-rectangle that we crop out. SAM2 stretches the image to a square, so the full embedding
+    already corresponds to the whole image and must not be cropped. With `upsampler`, AnyUp
+    upsamples the embedding using `image_region` as guidance; otherwise it is plainly interpolated.
+    """
+    block = embeddings if is_sam2 else _aspect_crop(embeddings, block_hw)
+    if upsampler is not None:
+        result = _anyup_to_grid(block, image_region, target_hw, upsampler)
+        if pbar_update is not None:
+            pbar_update(1)
+        return result
+    return _resize_to_grid(block, target_hw)
 
 
-def _compute_tiled_feature_image(features, image_hw, max_grid_size, z=None):
+def _compute_tiled_feature_image(
+    features, image_hw, max_grid_size, z=None, image=None, upsampler=None, is_sam2=False, pbar_update=None
+):
     """Assemble a downsampled (GH, GW, C) feature image for a single 2d (tiled) plane.
 
     For 3d data 'z' selects the slice of each tile's embedding; for 2d data 'z' is None.
+    With `upsampler`, each tile's inner block is upsampled with AnyUp using the matching image crop.
     """
     tile_shape, halo, shape = features.attrs["tile_shape"], features.attrs["halo"], features.attrs["shape"]
     tiling = Blocking([0, 0], list(shape), list(tile_shape))
@@ -83,19 +177,28 @@ def _compute_tiled_feature_image(features, image_hw, max_grid_size, z=None):
         outer, inner_local = block.outer_block, block.inner_block_local
         outer_hw = (outer.end[0] - outer.begin[0], outer.end[1] - outer.begin[1])
 
-        # Crop the (square-padded) tile embedding to the outer block aspect, then slice the inner block.
-        embeds = _aspect_crop(embeds, outer_hw)
+        # SAM1 pads the tile to a square (crop to the outer block aspect); SAM2 stretches it (no crop).
+        if not is_sam2:
+            embeds = _aspect_crop(embeds, outer_hw)
         tile_scale = (embeds.shape[-2] / outer_hw[0], embeds.shape[-1] / outer_hw[1])
         iy0, iy1 = int(round(inner_local.begin[0] * tile_scale[0])), int(round(inner_local.end[0] * tile_scale[0]))
         ix0, ix1 = int(round(inner_local.begin[1] * tile_scale[1])), int(round(inner_local.end[1] * tile_scale[1]))
         inner_embeds = embeds[:, iy0:iy1, ix0:ix1]
 
-        # Map the inner block to its position in the global grid and place the resized features there.
+        # Map the inner block to its position in the global grid and place the features there.
         gy0, gy1 = outer.begin[0] + inner_local.begin[0], outer.begin[0] + inner_local.end[0]
         gx0, gx1 = outer.begin[1] + inner_local.begin[1], outer.begin[1] + inner_local.end[1]
         by0, by1 = int(round(gy0 * scale)), int(round(gy1 * scale))
         bx0, bx1 = int(round(gx0 * scale)), int(round(gx1 * scale))
-        feature_image[by0:by1, bx0:bx1] = _resize_to_grid(inner_embeds, (by1 - by0, bx1 - bx0))
+        if upsampler is not None:
+            image_crop = image[gy0:gy1, gx0:gx1] if z is None else image[z, gy0:gy1, gx0:gx1]
+            feature_image[by0:by1, bx0:bx1] = _anyup_to_grid(
+                inner_embeds, image_crop, (by1 - by0, bx1 - bx0), upsampler
+            )
+            if pbar_update is not None:
+                pbar_update(1)
+        else:
+            feature_image[by0:by1, bx0:bx1] = _resize_to_grid(inner_embeds, (by1 - by0, bx1 - bx0))
 
     return feature_image, grid
 
@@ -105,6 +208,8 @@ def compute_pixel_features(
     image_shape: Tuple[int, ...],
     grid_size: int = DEFAULT_GRID_SIZE,
     max_grid_size: int = DEFAULT_MAX_GRID_SIZE,
+    image: Optional[np.ndarray] = None,
+    upsampler=None,
     verbose: bool = True,
 ) -> Tuple[np.ndarray, Tuple[int, ...]]:
     """Compute per-pixel features from SAM embeddings for pixel classification.
@@ -118,39 +223,77 @@ def compute_pixel_features(
         image_shape: The spatial shape of the image, (H, W) for 2d or (Z, H, W) for 3d.
         grid_size: In-plane grid size (longest side) for non-tiled images.
         max_grid_size: In-plane grid size (longest side) for tiled images.
+        image: The original image, required when `upsampler` is given (AnyUp uses it as guidance).
+        upsampler: An optional AnyUp model (see `get_anyup_upsampler`). When given, the embedding
+            is upsampled with AnyUp using the image instead of plain interpolation.
         verbose: Whether to print a progressbar for the computation.
 
     Returns:
         The per-pixel features, of shape (N, C) flattened over the grid in row-major order.
         The grid shape, (gh, gw) for 2d or (Z, gh, gw) for 3d.
     """
+    if upsampler is not None and image is None:
+        raise ValueError("An 'image' is required when an AnyUp 'upsampler' is given.")
+
     is_tiled = image_embeddings["input_size"] is None
     is_3d = len(image_shape) == 3
+    # SAM2 embeddings carry the high-resolution decoder features; SAM1 embeddings never do. SAM2
+    # stretches the image to a square (no padding), so its embedding must not be aspect-cropped.
+    is_sam2 = "high_res_feats" in image_embeddings
     features = image_embeddings["features"]
 
+    # AnyUp is the slow part, so when it is used we show a dedicated progress bar (which also drives
+    # napari's activity indicator) ticking once per AnyUp call, and silence the per-slice bar.
+    depth = image_shape[0] if is_3d else 1
+    anyup_pbar, pbar_update = None, None
+    if upsampler is not None:
+        if is_tiled:
+            n_blocks = Blocking(
+                [0, 0], list(features.attrs["shape"]), list(features.attrs["tile_shape"])
+            ).number_of_blocks
+        else:
+            n_blocks = 1
+        anyup_pbar = tqdm(total=n_blocks * depth, desc="Upsampling with AnyUp", disable=not verbose)
+        pbar_update = anyup_pbar.update
+    slice_disable = (not verbose) or (upsampler is not None)
+
     if is_3d:
-        depth = image_shape[0]
         image_hw = (image_shape[1], image_shape[2])
         planes = []
-        for z in tqdm(range(depth), total=depth, disable=not verbose, desc="Compute pixel features"):
+        for z in tqdm(range(depth), total=depth, disable=slice_disable, desc="Compute pixel features"):
             if is_tiled:
-                plane, grid = _compute_tiled_feature_image(features, image_hw, max_grid_size, z=z)
+                plane, grid = _compute_tiled_feature_image(
+                    features, image_hw, max_grid_size, z=z, image=image, upsampler=upsampler,
+                    is_sam2=is_sam2, pbar_update=pbar_update,
+                )
             else:
                 embeds = np.asarray(features[z]).squeeze()
                 grid, _ = _grid_shape(image_hw, grid_size)
-                plane = _block_to_grid(embeds, image_hw, grid)
+                plane = _block_to_grid(
+                    embeds, image_hw, grid, image_region=None if image is None else image[z],
+                    upsampler=upsampler, is_sam2=is_sam2, pbar_update=pbar_update,
+                )
             planes.append(plane)
         feature_image = np.stack(planes)
         grid_shape = (depth,) + grid
     else:
         image_hw = (image_shape[0], image_shape[1])
         if is_tiled:
-            feature_image, grid = _compute_tiled_feature_image(features, image_hw, max_grid_size)
+            feature_image, grid = _compute_tiled_feature_image(
+                features, image_hw, max_grid_size, image=image, upsampler=upsampler,
+                is_sam2=is_sam2, pbar_update=pbar_update,
+            )
         else:
             embeds = np.asarray(features).squeeze()
             grid, _ = _grid_shape(image_hw, grid_size)
-            feature_image = _block_to_grid(embeds, image_hw, grid)
+            feature_image = _block_to_grid(
+                embeds, image_hw, grid, image_region=image, upsampler=upsampler,
+                is_sam2=is_sam2, pbar_update=pbar_update,
+            )
         grid_shape = grid
+
+    if anyup_pbar is not None:
+        anyup_pbar.close()
 
     return feature_image.reshape(-1, feature_image.shape[-1]), grid_shape
 
@@ -283,6 +426,7 @@ def run_training_with_pixel_classifier(
     max_depth: int = 10,
     n_jobs: Optional[int] = None,
     n_components: Optional[int] = None,
+    upsampler=None,
     **rf_kwargs,
 ):
     """Train a pixel classifier on a series of images and (sparse) annotations.
@@ -305,6 +449,8 @@ def run_training_with_pixel_classifier(
         n_jobs: The number of parallel jobs for training. By default uses all available cores.
         n_components: If given, reduce the features to this many PCA components before training.
             If `None`, `0` or `>=` the feature dimension, all embedding channels are used.
+        upsampler: An optional AnyUp model (see `get_anyup_upsampler`) to upsample the embeddings
+            with the image as guidance instead of plain interpolation.
         rf_kwargs: Additional keyword arguments for the `RandomForestClassifier`.
 
     Returns:
@@ -327,7 +473,10 @@ def run_training_with_pixel_classifier(
         this_ndim = ndim if ndim is not None else (image.ndim - 1 if image.shape[-1] == 3 else image.ndim)
         image_shape = image.shape[:this_ndim]
         embeddings = precompute_image_embeddings(predictor, image, verbose=False, ndim=this_ndim)
-        features, grid_shape = compute_pixel_features(embeddings, image_shape, verbose=False)
+        features, grid_shape = compute_pixel_features(
+            embeddings, image_shape, image=image if upsampler is not None else None,
+            upsampler=upsampler, verbose=False,
+        )
         labels = accumulate_pixel_labels(annotation, grid_shape)
 
         valid = labels != 0
@@ -360,6 +509,7 @@ def run_prediction_with_pixel_classifier(
     rf_path: Union[str, os.PathLike],
     image_key: Optional[str] = None,
     ndim: Optional[int] = None,
+    upsampler=None,
 ) -> List[np.ndarray]:
     """Run prediction with a pretrained pixel classifier on a series of images.
 
@@ -369,6 +519,9 @@ def run_prediction_with_pixel_classifier(
         rf_path: The filepath to the trained random forest.
         image_key: The key for the image data, for filepath inputs (e.g. an internal dataset path).
         ndim: The dimensionality of the data. If not given will be derived from the data.
+        upsampler: An optional AnyUp model (see `get_anyup_upsampler`) to upsample the embeddings
+            with the image as guidance instead of plain interpolation. Use the same setting that
+            the classifier was trained with.
 
     Returns:
         The pixel level predictions.
@@ -381,7 +534,10 @@ def run_prediction_with_pixel_classifier(
         this_ndim = ndim if ndim is not None else (image.ndim - 1 if image.shape[-1] == 3 else image.ndim)
         image_shape = image.shape[:this_ndim]
         embeddings = precompute_image_embeddings(predictor, image, verbose=False, ndim=this_ndim)
-        features, grid_shape = compute_pixel_features(embeddings, image_shape, verbose=False)
+        features, grid_shape = compute_pixel_features(
+            embeddings, image_shape, image=image if upsampler is not None else None,
+            upsampler=upsampler, verbose=False,
+        )
         prediction = rf.predict(features)
         predictions.append(project_prediction_to_image(prediction, grid_shape, image_shape))
     return predictions

--- a/micro_sam/pixel_classification.py
+++ b/micro_sam/pixel_classification.py
@@ -7,7 +7,9 @@ import numpy as np
 
 from bioimage_cpp.utils import Blocking
 
+from sklearn.decomposition import PCA
 from sklearn.ensemble import RandomForestClassifier
+from sklearn.pipeline import Pipeline
 
 from skimage.transform import resize
 
@@ -213,8 +215,9 @@ def train_pixel_classifier(
     n_estimators: int = 200,
     max_depth: int = 10,
     n_jobs: Optional[int] = None,
+    n_components: Optional[int] = None,
     **rf_kwargs,
-) -> RandomForestClassifier:
+):
     """Train a random forest on per-pixel features and labels.
 
     Pixels with label 0 are treated as unlabeled and excluded from training. This is the
@@ -229,10 +232,15 @@ def train_pixel_classifier(
         n_estimators: The number of trees in the random forest.
         max_depth: The maximum depth of each tree.
         n_jobs: The number of parallel jobs for training. By default uses all available cores.
+        n_components: If given and smaller than the feature dimension, reduce the features to this
+            many PCA components before training. If `None`, `0` or `>=` the feature dimension, all
+            features are used. The fitted PCA is part of the returned model, so prediction transforms
+            the features automatically.
         rf_kwargs: Additional keyword arguments for the `RandomForestClassifier`.
 
     Returns:
-        The trained random forest.
+        The trained classifier. A `RandomForestClassifier`, or a `Pipeline` of PCA and the random
+        forest when `n_components` triggers dimensionality reduction.
     """
     assert len(features) == len(labels)
     valid = labels != 0
@@ -247,8 +255,18 @@ def train_pixel_classifier(
         n_estimators=n_estimators, max_depth=max_depth,
         n_jobs=cpu_count() if n_jobs is None else n_jobs, **rf_kwargs,
     )
-    rf.fit(X, y)
-    return rf
+
+    # Optionally reduce the features to the top-n PCA components. n_components is clamped to the
+    # number of features and samples; if it covers all features we skip PCA and use the plain RF.
+    n_features = X.shape[1]
+    k = min(int(n_components), n_features, len(X)) if n_components else 0
+    if 0 < k < n_features:
+        model = Pipeline([("pca", PCA(n_components=k)), ("rf", rf)])
+    else:
+        model = rf
+
+    model.fit(X, y)
+    return model
 
 
 # TODO think about the function signature, specially how exactly we pass model and optional embedding path.
@@ -264,8 +282,9 @@ def run_training_with_pixel_classifier(
     n_estimators: int = 200,
     max_depth: int = 10,
     n_jobs: Optional[int] = None,
+    n_components: Optional[int] = None,
     **rf_kwargs,
-) -> RandomForestClassifier:
+):
     """Train a pixel classifier on a series of images and (sparse) annotations.
 
     Object features are computed from the SAM embeddings for each image, the annotations
@@ -284,10 +303,12 @@ def run_training_with_pixel_classifier(
         n_estimators: The number of trees in the random forest.
         max_depth: The maximum depth of each tree.
         n_jobs: The number of parallel jobs for training. By default uses all available cores.
+        n_components: If given, reduce the features to this many PCA components before training.
+            If `None`, `0` or `>=` the feature dimension, all embedding channels are used.
         rf_kwargs: Additional keyword arguments for the `RandomForestClassifier`.
 
     Returns:
-        The trained random forest.
+        The trained classifier.
     """
     if len(images) != len(annotations):
         raise ValueError(
@@ -321,7 +342,8 @@ def run_training_with_pixel_classifier(
     labels = np.concatenate(all_labels, axis=0)
 
     rf = train_pixel_classifier(
-        features, labels, n_estimators=n_estimators, max_depth=max_depth, n_jobs=n_jobs, **rf_kwargs,
+        features, labels, n_estimators=n_estimators, max_depth=max_depth, n_jobs=n_jobs,
+        n_components=n_components, **rf_kwargs,
     )
 
     dump(rf, rf_path)

--- a/micro_sam/sam_annotator/_state.py
+++ b/micro_sam/sam_annotator/_state.py
@@ -128,6 +128,9 @@ class AnnotatorState(metaclass=Singleton):
     # TODO use RF class
     pixel_rf: Optional[Any] = None
 
+    # Cached AnyUp upsampler, shared by the classification tools when upsampling is enabled.
+    anyup_upsampler: Optional[Any] = None
+
     # Interactive segmentation class for 'micro-sam2'.
     interactive_segmenter: Optional[Any] = None  # TODO: Create a base class and add it here.
     is_sam2: Optional[bool] = None  # Whether this is a SAM1 or SAM2 model.
@@ -349,4 +352,5 @@ class AnnotatorState(metaclass=Singleton):
         self.data_signature = None
         self.interactive_segmenter = None
         self.is_sam2 = None
+        self.anyup_upsampler = None
         # Note: we don't clear the widgets here, because they are fixed for a viewer session.

--- a/micro_sam/sam_annotator/object_classifier.py
+++ b/micro_sam/sam_annotator/object_classifier.py
@@ -11,7 +11,9 @@ import numpy as np
 import torch
 
 from magicgui import magicgui
-from magicgui.widgets import CheckBox, Widget, Container, FileEdit, FunctionGui, PushButton, SpinBox, create_widget
+from magicgui.widgets import (
+    CheckBox, Widget, Container, FileEdit, FunctionGui, Label, PushButton, SpinBox, create_widget
+)
 from napari.utils.notifications import show_info
 from qtpy import QtWidgets
 
@@ -82,6 +84,16 @@ def _train_rf(features, labels, previous_features=None, previous_labels=None, n_
     return model
 
 
+def _get_cached_upsampler():
+    # Load the AnyUp model once and cache it on the state (small model, reused across runs).
+    from ..pixel_classification import get_anyup_upsampler
+    state = AnnotatorState()
+    if state.anyup_upsampler is None:
+        device = getattr(state.predictor, "device", None)
+        state.anyup_upsampler = get_anyup_upsampler(device=device)
+    return state.anyup_upsampler
+
+
 def _compute_object_features_if_needed(viewer):
     # Returns (features, seg_ids) for the current image+segmentation, computing/caching if needed.
     state = AnnotatorState()
@@ -89,7 +101,18 @@ def _compute_object_features_if_needed(viewer):
         if widgets._validate_embeddings(viewer):
             return None, None
         segmentation = state.segmentation_selection.get_value().data
-        seg_ids, features = compute_object_features(state.image_embeddings, segmentation)
+        use_anyup = getattr(state.annotator, "_get_use_anyup", None)
+        image, upsampler = None, None
+        if use_anyup is not None and use_anyup():
+            try:
+                upsampler = _get_cached_upsampler()
+            except ImportError as e:
+                widgets._generate_message("error", str(e))
+                return None, None
+            image = viewer.layers["image"].data
+        seg_ids, features = compute_object_features(
+            state.image_embeddings, segmentation, image=image, upsampler=upsampler,
+        )
         state.seg_ids, state.object_features = seg_ids, features
     return state.object_features, state.seg_ids
 
@@ -207,22 +230,51 @@ def _create_classifier_io_widget(viewer):
     # count of top PCA components to reduce the features to before training. Object features are
     # the area plus the 256 per-channel embedding means, i.e. 257, which is the maximum.
     use_top_features = CheckBox(value=False, text="Choose top feature channels")
-    top_features = SpinBox(value=10, min=1, max=OBJECT_FEATURES, step=1, visible=False)
-    top_features.native.setToolTip(
-        f"Number of top PCA components to reduce the object features to, between 1 and {OBJECT_FEATURES} "
-        "(object area plus the 256 per-channel embedding means)."
-    )
     use_top_features.native.setToolTip(
         "Reduce the object features to their most informative components via PCA before training. "
         "When unchecked, all features are used and no PCA is applied."
     )
-    use_top_features.changed.connect(lambda checked: setattr(top_features, "visible", checked))
-    top_features_row = Container(
-        layout="horizontal", widgets=[use_top_features, top_features], labels=False,
+
+    # Optional AnyUp upsampling. When checked, the SAM/SAM2 embedding is upsampled with AnyUp using
+    # the original image as guidance instead of plain interpolation. Toggling it changes the
+    # features, so the cached features are cleared on change to force a recompute.
+    use_anyup = CheckBox(value=False, text="Upsample with AnyUp")
+    use_anyup.native.setToolTip(
+        "Use AnyUp to upsample the embedding with the original image as guidance, for sharper "
+        "features near object boundaries. When unchecked, plain interpolation is used."
     )
+
+    # The two option checkboxes sit side by side (PCA on the left, AnyUp on the right). A trailing
+    # stretch packs them flush left; zeroing the nested-container margins lines them up with the
+    # path fields below (which otherwise get double-indented by the nested container).
+    checkbox_row = Container(layout="horizontal", widgets=[use_top_features, use_anyup], labels=False)
+    checkbox_row.native.layout().setContentsMargins(0, 0, 0, 0)
+    checkbox_row.native.layout().addStretch(1)
+
+    # The PCA component count appears on its own row below, revealed when the checkbox is ticked.
+    top_features = SpinBox(value=10, min=1, max=OBJECT_FEATURES, step=1)
+    top_features.native.setToolTip(
+        f"Number of top PCA components to reduce the object features to, between 1 and {OBJECT_FEATURES} "
+        "(object area plus the 256 per-channel embedding means)."
+    )
+    top_features_row = Container(
+        layout="horizontal", widgets=[Label(value="top feature channels:"), top_features], labels=False,
+    )
+    top_features_row.native.layout().setContentsMargins(0, 0, 0, 0)
+    top_features_row.native.layout().addStretch(1)
+    top_features_row.visible = False
+    use_top_features.changed.connect(lambda checked: setattr(top_features_row, "visible", checked))
 
     def get_n_components():
         return int(top_features.value) if use_top_features.value else 0
+
+    def _invalidate_features(*args):
+        state = AnnotatorState()
+        state.object_features, state.seg_ids = None, None
+    use_anyup.changed.connect(_invalidate_features)
+
+    def get_use_anyup():
+        return bool(use_anyup.value)
 
     # Classifier load/export, with separate paths (load a stored model, retrain, then export
     # the current one elsewhere). The path fields follow the same path-selector style as the
@@ -248,9 +300,9 @@ def _create_classifier_io_widget(viewer):
     export_button.clicked.connect(lambda: _save_rf(viewer, export_dir.value))
 
     container = Container(
-        widgets=[top_features_row, load_path, load_button, export_dir, export_button], labels=False,
+        widgets=[checkbox_row, top_features_row, load_path, load_button, export_dir, export_button], labels=False,
     )
-    return container, get_n_components
+    return container, get_n_components, get_use_anyup
 
 #
 # Object classifier implementation.
@@ -381,7 +433,8 @@ class ObjectClassifier(QtWidgets.QScrollArea):
         # load/export) on top, with the 'Train and predict' button below it.
         self._train_and_predict_widget = _create_train_widget(self._viewer)
         self._seg_selection_widget = self._create_segmentation_layer_section()
-        self._classifier_io_widget, self._get_n_components = _create_classifier_io_widget(self._viewer)
+        io = _create_classifier_io_widget(self._viewer)
+        self._classifier_io_widget, self._get_n_components, self._get_use_anyup = io
 
         settings = QtWidgets.QWidget()
         settings.setLayout(QtWidgets.QVBoxLayout())
@@ -546,7 +599,7 @@ def object_classifier(
     annotator._update_image()
 
     # Add the annotator widget to the viewer and sync widgets.
-    viewer.window.add_dock_widget(annotator)
+    viewer.window.add_dock_widget(annotator, name="(Object Classifier) Segment Anything for Microscopy")
     _sync_embedding_widget(
         widget=state.widgets["embeddings"],
         model_type=model_type if checkpoint_path is None else state.predictor.model_type,

--- a/micro_sam/sam_annotator/object_classifier.py
+++ b/micro_sam/sam_annotator/object_classifier.py
@@ -11,18 +11,25 @@ import numpy as np
 import torch
 
 from magicgui import magicgui
-from magicgui.widgets import Widget, Container, FileEdit, FunctionGui, PushButton, create_widget
+from magicgui.widgets import CheckBox, Widget, Container, FileEdit, FunctionGui, PushButton, SpinBox, create_widget
 from napari.utils.notifications import show_info
 from qtpy import QtWidgets
 
 from skimage.measure import regionprops_table
+from sklearn.decomposition import PCA
 from sklearn.ensemble import RandomForestClassifier
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
 
 from .. import util
 from ..object_classification import compute_object_features, project_prediction_to_segmentation
 from ._state import AnnotatorState
 from . import _widgets as widgets
 from .util import _sync_embedding_widget
+
+# Object features are the object area plus the per-channel mean of the 256-channel SAM/SAM2 image
+# embedding, i.e. 257 features. PCA can reduce to at most this many components.
+OBJECT_FEATURES = 257
 
 #
 # Utility functionality.
@@ -48,7 +55,7 @@ def _accumulate_labels(segmentation, annotations):
     return all_features["majority_label"].astype("int")
 
 
-def _train_rf(features, labels, previous_features=None, previous_labels=None, **rf_kwargs):
+def _train_rf(features, labels, previous_features=None, previous_labels=None, n_components=None, **rf_kwargs):
     assert len(features) == len(labels)
     valid = labels != 0
     X, y = features[valid], labels[valid]
@@ -59,8 +66,20 @@ def _train_rf(features, labels, previous_features=None, previous_labels=None, **
         y = np.concatenate([previous_labels, y], axis=0)
 
     rf = RandomForestClassifier(**rf_kwargs)
-    rf.fit(X, y)
-    return rf
+
+    # Optionally reduce the features to the top-n PCA components. n_components is clamped to the
+    # number of features and samples; if it covers all features we skip PCA and use the plain RF.
+    # Object features mix area (large magnitude) with embedding means (small), so we standardize
+    # them before PCA to keep area from dominating the components.
+    n_features = X.shape[1]
+    k = min(int(n_components), n_features, len(X)) if n_components else 0
+    if 0 < k < n_features:
+        model = Pipeline([("scaler", StandardScaler()), ("pca", PCA(n_components=k)), ("rf", rf)])
+    else:
+        model = rf
+
+    model.fit(X, y)
+    return model
 
 
 def _compute_object_features_if_needed(viewer):
@@ -104,10 +123,14 @@ def _run_train_and_predict(viewer):
     if (labels == 0).all() and (previous_labels is None):
         return widgets._generate_message("error", "You have not provided any annotations.")
 
+    # Optionally reduce to the top-n PCA feature channels, read from the settings widget.
+    get_n_components = getattr(state.annotator, "_get_n_components", None)
+    n_components = get_n_components() if get_n_components is not None else 0
+
     # Run RF training and store it in the state.
     state.object_rf = _train_rf(
         features, labels, previous_features=previous_features, previous_labels=previous_labels,
-        n_estimators=200, max_depth=10, n_jobs=cpu_count(),
+        n_estimators=200, max_depth=10, n_jobs=cpu_count(), n_components=n_components,
     )
 
     # Run and set the prediction.
@@ -179,6 +202,28 @@ def _create_train_widget(viewer):
 
 
 def _create_classifier_io_widget(viewer):
+    # Optional PCA dimensionality reduction. The checkbox is off by default, in which case all
+    # object features are used and PCA is never applied. Checking it reveals a number box for the
+    # count of top PCA components to reduce the features to before training. Object features are
+    # the area plus the 256 per-channel embedding means, i.e. 257, which is the maximum.
+    use_top_features = CheckBox(value=False, text="Choose top feature channels")
+    top_features = SpinBox(value=10, min=1, max=OBJECT_FEATURES, step=1, visible=False)
+    top_features.native.setToolTip(
+        f"Number of top PCA components to reduce the object features to, between 1 and {OBJECT_FEATURES} "
+        "(object area plus the 256 per-channel embedding means)."
+    )
+    use_top_features.native.setToolTip(
+        "Reduce the object features to their most informative components via PCA before training. "
+        "When unchecked, all features are used and no PCA is applied."
+    )
+    use_top_features.changed.connect(lambda checked: setattr(top_features, "visible", checked))
+    top_features_row = Container(
+        layout="horizontal", widgets=[use_top_features, top_features], labels=False,
+    )
+
+    def get_n_components():
+        return int(top_features.value) if use_top_features.value else 0
+
     # Classifier load/export, with separate paths (load a stored model, retrain, then export
     # the current one elsewhere). The path fields follow the same path-selector style as the
     # custom weights in the embedding widget.
@@ -202,7 +247,10 @@ def _create_classifier_io_widget(viewer):
     export_button.native.setToolTip("Save the current classifier into the selected folder.")
     export_button.clicked.connect(lambda: _save_rf(viewer, export_dir.value))
 
-    return Container(widgets=[load_path, load_button, export_dir, export_button], labels=False)
+    container = Container(
+        widgets=[top_features_row, load_path, load_button, export_dir, export_button], labels=False,
+    )
+    return container, get_n_components
 
 #
 # Object classifier implementation.
@@ -333,7 +381,7 @@ class ObjectClassifier(QtWidgets.QScrollArea):
         # load/export) on top, with the 'Train and predict' button below it.
         self._train_and_predict_widget = _create_train_widget(self._viewer)
         self._seg_selection_widget = self._create_segmentation_layer_section()
-        self._classifier_io_widget = _create_classifier_io_widget(self._viewer)
+        self._classifier_io_widget, self._get_n_components = _create_classifier_io_widget(self._viewer)
 
         settings = QtWidgets.QWidget()
         settings.setLayout(QtWidgets.QVBoxLayout())

--- a/micro_sam/sam_annotator/pixel_classifier.py
+++ b/micro_sam/sam_annotator/pixel_classifier.py
@@ -8,13 +8,14 @@ import napari
 import numpy as np
 import torch
 
-from magicgui.widgets import CheckBox, Widget, Container, FileEdit, FunctionGui, PushButton, SpinBox
+from magicgui.widgets import CheckBox, Widget, Container, FileEdit, FunctionGui, Label, PushButton, SpinBox
 from napari.utils.notifications import show_info
 from qtpy import QtWidgets
 
 from .. import util
 from ..pixel_classification import (
-    accumulate_pixel_labels, compute_pixel_features, project_prediction_to_image, train_pixel_classifier,
+    accumulate_pixel_labels, compute_pixel_features, get_anyup_upsampler, project_prediction_to_image,
+    train_pixel_classifier,
 )
 from ._state import AnnotatorState
 from . import _widgets as widgets
@@ -25,13 +26,33 @@ from .util import _sync_embedding_widget
 EMBEDDING_CHANNELS = 256
 
 
+def _get_cached_upsampler():
+    # Load the AnyUp model once and cache it on the state (small model, reused across runs).
+    state = AnnotatorState()
+    if state.anyup_upsampler is None:
+        device = getattr(state.predictor, "device", None)
+        state.anyup_upsampler = get_anyup_upsampler(device=device)
+    return state.anyup_upsampler
+
+
 def _compute_pixel_features_if_needed(viewer):
     # Returns (features, grid_shape) for the current image, computing and caching them if needed.
     state = AnnotatorState()
     if state.pixel_features is None:
         if widgets._validate_embeddings(viewer):
             return None, None
-        features, grid_shape = compute_pixel_features(state.image_embeddings, state.image_shape)
+        use_anyup = getattr(state.annotator, "_get_use_anyup", None)
+        image, upsampler = None, None
+        if use_anyup is not None and use_anyup():
+            try:
+                upsampler = _get_cached_upsampler()
+            except ImportError as e:
+                widgets._generate_message("error", str(e))
+                return None, None
+            image = viewer.layers["image"].data
+        features, grid_shape = compute_pixel_features(
+            state.image_embeddings, state.image_shape, image=image, upsampler=upsampler,
+        )
         state.pixel_features, state.pixel_grid_shape = features, grid_shape
     return state.pixel_features, state.pixel_grid_shape
 
@@ -148,22 +169,51 @@ def _create_classifier_io_widget(viewer):
     # the count of top PCA components to reduce the features to before training. The SAM and SAM2
     # image embeddings have 256 channels for every model size, so that is the maximum.
     use_top_features = CheckBox(value=False, text="Choose top feature channels")
-    top_features = SpinBox(value=10, min=1, max=EMBEDDING_CHANNELS, step=1, visible=False)
-    top_features.native.setToolTip(
-        f"Number of top PCA components to reduce the embedding to, between 1 and {EMBEDDING_CHANNELS} "
-        "(the SAM/SAM2 image embedding has 256 channels for all model sizes)."
-    )
     use_top_features.native.setToolTip(
         "Reduce the SAM/SAM2 embedding to its most informative channels via PCA before training. "
         "When unchecked, all 256 embedding channels are used and no PCA is applied."
     )
-    use_top_features.changed.connect(lambda checked: setattr(top_features, "visible", checked))
-    top_features_row = Container(
-        layout="horizontal", widgets=[use_top_features, top_features], labels=False,
+
+    # Optional AnyUp upsampling. When checked, the SAM/SAM2 embedding is upsampled with AnyUp using
+    # the original image as guidance instead of plain interpolation. Toggling it changes the
+    # features, so the cached features are cleared on change to force a recompute.
+    use_anyup = CheckBox(value=False, text="Upsample with AnyUp")
+    use_anyup.native.setToolTip(
+        "Use AnyUp to upsample the embedding with the original image as guidance, for sharper "
+        "features near object boundaries. When unchecked, plain interpolation is used."
     )
+
+    # The two option checkboxes sit side by side (PCA on the left, AnyUp on the right). A trailing
+    # stretch packs them flush left; zeroing the nested-container margins lines them up with the
+    # path fields below (which otherwise get double-indented by the nested container).
+    checkbox_row = Container(layout="horizontal", widgets=[use_top_features, use_anyup], labels=False)
+    checkbox_row.native.layout().setContentsMargins(0, 0, 0, 0)
+    checkbox_row.native.layout().addStretch(1)
+
+    # The PCA component count appears on its own row below, revealed when the checkbox is ticked.
+    top_features = SpinBox(value=10, min=1, max=EMBEDDING_CHANNELS, step=1)
+    top_features.native.setToolTip(
+        f"Number of top PCA components to reduce the embedding to, between 1 and {EMBEDDING_CHANNELS} "
+        "(the SAM/SAM2 image embedding has 256 channels for all model sizes)."
+    )
+    top_features_row = Container(
+        layout="horizontal", widgets=[Label(value="top feature channels:"), top_features], labels=False,
+    )
+    top_features_row.native.layout().setContentsMargins(0, 0, 0, 0)
+    top_features_row.native.layout().addStretch(1)
+    top_features_row.visible = False
+    use_top_features.changed.connect(lambda checked: setattr(top_features_row, "visible", checked))
 
     def get_n_components():
         return int(top_features.value) if use_top_features.value else 0
+
+    def _invalidate_features(*args):
+        state = AnnotatorState()
+        state.pixel_features, state.pixel_grid_shape = None, None
+    use_anyup.changed.connect(_invalidate_features)
+
+    def get_use_anyup():
+        return bool(use_anyup.value)
 
     # Classifier load/export. Load takes a stored model file; export chooses a destination folder
     # (defaulting to the current working directory) where the model is saved with an auto-generated
@@ -189,9 +239,9 @@ def _create_classifier_io_widget(viewer):
     export_button.clicked.connect(lambda: _save_rf(viewer, export_dir.value))
 
     container = Container(
-        widgets=[top_features_row, load_path, load_button, export_dir, export_button], labels=False,
+        widgets=[checkbox_row, top_features_row, load_path, load_button, export_dir, export_button], labels=False,
     )
-    return container, get_n_components
+    return container, get_n_components, get_use_anyup
 
 
 class PixelClassifier(QtWidgets.QScrollArea):
@@ -305,7 +355,8 @@ class PixelClassifier(QtWidgets.QScrollArea):
         # One section: the "Classification Settings" dropdown (classifier load/export) on top,
         # with the 'Train and predict' button below it.
         self._train_and_predict_widget = _create_train_widget(self._viewer)
-        self._classifier_io_widget, self._get_n_components = _create_classifier_io_widget(self._viewer)
+        io = _create_classifier_io_widget(self._viewer)
+        self._classifier_io_widget, self._get_n_components, self._get_use_anyup = io
 
         settings = QtWidgets.QWidget()
         settings.setLayout(QtWidgets.QVBoxLayout())
@@ -466,7 +517,7 @@ def pixel_classifier(
     annotator._update_image()
 
     # Add the annotator widget to the viewer and sync widgets.
-    viewer.window.add_dock_widget(annotator)
+    viewer.window.add_dock_widget(annotator, name="(Pixel Classifier) Segment Anything for Microscopy")
     _sync_embedding_widget(
         widget=state.widgets["embeddings"],
         model_type=model_type if checkpoint_path is None else state.predictor.model_type,

--- a/micro_sam/sam_annotator/pixel_classifier.py
+++ b/micro_sam/sam_annotator/pixel_classifier.py
@@ -8,7 +8,7 @@ import napari
 import numpy as np
 import torch
 
-from magicgui.widgets import Widget, Container, FileEdit, FunctionGui, PushButton
+from magicgui.widgets import CheckBox, Widget, Container, FileEdit, FunctionGui, PushButton, SpinBox
 from napari.utils.notifications import show_info
 from qtpy import QtWidgets
 
@@ -19,6 +19,10 @@ from ..pixel_classification import (
 from ._state import AnnotatorState
 from . import _widgets as widgets
 from .util import _sync_embedding_widget
+
+# The SAM and SAM2 image encoders project every model size down to a fixed 256-channel image
+# embedding (prompt_embed_dim), so the per-pixel feature dimension is always 256.
+EMBEDDING_CHANNELS = 256
 
 
 def _compute_pixel_features_if_needed(viewer):
@@ -59,9 +63,14 @@ def _run_train_and_predict(viewer):
     if (labels == 0).all() and (previous_labels is None):
         return widgets._generate_message("error", "You have not provided any annotations.")
 
+    # Optionally reduce to the top-n PCA feature channels, read from the settings widget.
+    get_n_components = getattr(state.annotator, "_get_n_components", None)
+    n_components = get_n_components() if get_n_components is not None else 0
+
     # Run RF training and store it in the state.
     state.pixel_rf = train_pixel_classifier(
         features, labels, previous_features=previous_features, previous_labels=previous_labels,
+        n_components=n_components,
     )
 
     # Run and set the prediction.
@@ -134,6 +143,28 @@ def _create_train_widget(viewer):
 
 
 def _create_classifier_io_widget(viewer):
+    # Optional PCA dimensionality reduction. The checkbox is off by default, in which case all
+    # embedding channels are used and PCA is never applied. Checking it reveals a number box for
+    # the count of top PCA components to reduce the features to before training. The SAM and SAM2
+    # image embeddings have 256 channels for every model size, so that is the maximum.
+    use_top_features = CheckBox(value=False, text="Choose top feature channels")
+    top_features = SpinBox(value=10, min=1, max=EMBEDDING_CHANNELS, step=1, visible=False)
+    top_features.native.setToolTip(
+        f"Number of top PCA components to reduce the embedding to, between 1 and {EMBEDDING_CHANNELS} "
+        "(the SAM/SAM2 image embedding has 256 channels for all model sizes)."
+    )
+    use_top_features.native.setToolTip(
+        "Reduce the SAM/SAM2 embedding to its most informative channels via PCA before training. "
+        "When unchecked, all 256 embedding channels are used and no PCA is applied."
+    )
+    use_top_features.changed.connect(lambda checked: setattr(top_features, "visible", checked))
+    top_features_row = Container(
+        layout="horizontal", widgets=[use_top_features, top_features], labels=False,
+    )
+
+    def get_n_components():
+        return int(top_features.value) if use_top_features.value else 0
+
     # Classifier load/export. Load takes a stored model file; export chooses a destination folder
     # (defaulting to the current working directory) where the model is saved with an auto-generated
     # name. The fields follow the path-selector style of the custom weights in the embedding widget.
@@ -157,7 +188,10 @@ def _create_classifier_io_widget(viewer):
     export_button.native.setToolTip("Save the current classifier into the selected folder.")
     export_button.clicked.connect(lambda: _save_rf(viewer, export_dir.value))
 
-    return Container(widgets=[load_path, load_button, export_dir, export_button], labels=False)
+    container = Container(
+        widgets=[top_features_row, load_path, load_button, export_dir, export_button], labels=False,
+    )
+    return container, get_n_components
 
 
 class PixelClassifier(QtWidgets.QScrollArea):
@@ -271,7 +305,7 @@ class PixelClassifier(QtWidgets.QScrollArea):
         # One section: the "Classification Settings" dropdown (classifier load/export) on top,
         # with the 'Train and predict' button below it.
         self._train_and_predict_widget = _create_train_widget(self._viewer)
-        self._classifier_io_widget = _create_classifier_io_widget(self._viewer)
+        self._classifier_io_widget, self._get_n_components = _create_classifier_io_widget(self._viewer)
 
         settings = QtWidgets.QWidget()
         settings.setLayout(QtWidgets.QVBoxLayout())

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ include_package_data = True
 package_dir =
     = .
 install_requires =
+    anyup @ git+https://github.com/wimmerth/anyup
     bioimage-cpp>=0.3
     bioimageio.core
     h5py


### PR DESCRIPTION
Well I came up with another improvement on top of https://github.com/computational-cell-analytics/micro-sam/pull/1249 (might be cool to discuss and see if we wanna keep one or both of the features)

The idea was to integrate:
1. PCA over all interpolated features (in some cases, I noticed via the tool that there's a slight advantage)
2. Add AnyUp upsampling

(1+2 are currently checkboxes, if not applied, all features with interpolation based upsampling works! either one or both can be applied as the user likes)

PS. AnyUp does not really look good for pixel classification at all, but PCA does look much more crisp in terms of segmentation quality.

What do we think? @caroteu @constantinpape 
 