### PR TITLE
Remove global event emitter error suppression filter

### DIFF
--- a/micro_sam/sam_annotator/_series.py
+++ b/micro_sam/sam_annotator/_series.py
@@ -16,7 +16,6 @@ from qtpy.QtCore import Qt, QTimer
 
 from . import _widgets as widgets
 from ._state import AnnotatorState
-from .util import suppress_eventemitter_loop_errors
 
 
 def _hide_embedding_widget(annotator):
@@ -172,9 +171,6 @@ def run_image_series(
         The napari viewer, only if `return_viewer=True`.
     """
     end_msg = "You have annotated the last image. Do you wish to close napari?"
-    # Rapid input (fast Next, prompt + Segment) can re-enter napari's event emitters, raising vispy's
-    # benign 'EventEmitter loop detected!' that clogs the trace; filter it out.
-    suppress_eventemitter_loop_errors()
     os.makedirs(output_folder, exist_ok=True)
     task.output_folder = output_folder
     task.have_inputs_as_arrays = have_inputs_as_arrays

--- a/micro_sam/sam_annotator/util.py
+++ b/micro_sam/sam_annotator/util.py
@@ -916,25 +916,3 @@ def _load_is_state(embedding_path):
             is_state[i] = state
 
     return is_state
-
-
-def suppress_eventemitter_loop_errors():
-    """Swallow vispy's benign 'EventEmitter loop detected!' RuntimeError so it stops clogging the
-    napari trace. napari routes uncaught Qt-slot exceptions through its notification manager
-    (installed as `sys.excepthook`); this wraps it to drop that one message and pass everything else
-    through. Idempotent."""
-    import sys
-    from napari.utils.notifications import notification_manager as nm
-
-    if getattr(nm, "_micro_sam_loop_filter_installed", False):
-        return
-    original = nm.receive_error
-
-    def filtered(exctype, value, traceback=None, thread=None):
-        if isinstance(value, RuntimeError) and "EventEmitter loop detected" in str(value):
-            return
-        return original(exctype, value, traceback, thread)
-
-    nm.receive_error = filtered
-    sys.excepthook = filtered
-    nm._micro_sam_loop_filter_installed = True

--- a/test/test_sam_annotator/test_image_series_launcher.py
+++ b/test/test_sam_annotator/test_image_series_launcher.py
@@ -184,23 +184,3 @@ def test_launcher_removes_itself_after_launch(make_napari_viewer_proxy, monkeypa
             QApplication.processEvents()
 
         assert dock not in viewer.window._qt_window.findChildren(QDockWidget)
-
-
-def test_eventemitter_loop_error_is_suppressed():
-    import sys
-    from napari.utils.notifications import notification_manager as nm
-    from micro_sam.sam_annotator.util import suppress_eventemitter_loop_errors
-
-    suppress_eventemitter_loop_errors()
-    dispatched = []
-    original_dispatch = nm.dispatch
-    nm.dispatch = lambda notification: dispatched.append(notification)
-    try:
-        # The benign reentrancy error is swallowed (no notification surfaced)...
-        sys.excepthook(RuntimeError, RuntimeError("EventEmitter loop detected!"), None)
-        assert dispatched == []
-        # ...but any other error still passes through to napari's notification manager.
-        sys.excepthook(RuntimeError, RuntimeError("a real error"), None)
-        assert len(dispatched) == 1
-    finally:
-        nm.dispatch = original_dispatch


### PR DESCRIPTION
The latest napari version does not like this, paired with refreshing structure (creates a huge chaos because it filters out some valid errors -- and that's dangerous).

It's best that we keep the event emitter signal errors around -- the annotators just have to be a bit patient and slow hehe!