### PR TITLE
Fix SAM2 automatic segmentation on MPS and drop hard vigra dependency

### DIFF
--- a/micro_sam/v2/datasets/raw_dataset.py
+++ b/micro_sam/v2/datasets/raw_dataset.py
@@ -5,7 +5,7 @@ from typing import Union
 
 import numpy as np
 import imageio.v3 as imageio
-from skimage.measure import label as connected_components
+from bioimage_cpp.segmentation import label as connected_components
 
 import torch
 

--- a/micro_sam/v2/evaluation/inference.py
+++ b/micro_sam/v2/evaluation/inference.py
@@ -7,7 +7,7 @@ from typing import Union, Optional, List
 
 import numpy as np
 import imageio.v3 as imageio
-from skimage.measure import label as connected_components
+from bioimage_cpp.segmentation import label as connected_components
 
 import torch
 

--- a/micro_sam/v2/postprocessing.py
+++ b/micro_sam/v2/postprocessing.py
@@ -14,10 +14,10 @@ from typing import Optional, Tuple
 
 import numpy as np
 from skimage.filters import gaussian
-from skimage.measure import label
-from skimage.segmentation import watershed
 from scipy.ndimage import map_coordinates
 from tqdm import tqdm, trange
+
+from bioimage_cpp.segmentation import label, watershed
 
 FLOW_BACKENDS = ("python", "cpp")
 
@@ -228,6 +228,8 @@ def run_multicut(
             backend=backend, n_threads=1,
         )
         seeds = label(density > density_threshold)
+        # watershed requires a float heightmap; boundary maps are usually float already.
+        bd = bd if np.issubdtype(bd.dtype, np.floating) else bd.astype("float32")
         wsz = watershed(bd, markers=seeds)
         overseg[z] = wsz
         return int(wsz.max())

--- a/micro_sam/v2/transforms/labels.py
+++ b/micro_sam/v2/transforms/labels.py
@@ -3,19 +3,18 @@ from typing import Optional, Tuple
 import numpy as np
 from skimage.measure import regionprops
 from skimage.segmentation import find_boundaries
-from skimage.measure import label as connected_components
 
-import vigra
+from bioimage_cpp.distance import vector_difference_transform
+from bioimage_cpp.segmentation import label as connected_components, relabel_sequential
 
 
 def _instance_labels(labels):
     """Relabel each connected region as a unique integer instance.
 
-    Wraps skimage.measure.label so that disconnected regions with the same
-    label ID get separate consecutive IDs.  Used as label_transform2 in the
+    Wraps a connected-components labeling so that disconnected regions with the
+    same label ID get separate consecutive IDs.  Used as label_transform2 in the
     interactive generalist dataloaders.
     """
-    from skimage.measure import label as connected_components
     return connected_components(labels).astype("int64")
 
 
@@ -102,8 +101,10 @@ class DirectedPerObjectBoundaryDistanceTransform:
 
         cropped_boundary_mask = boundaries[bb]
 
-        kwargs = {} if self.sampling is None else {"pixel_pitch": self.sampling}
-        this_distances = vigra.filters.vectorDistanceTransform(cropped_boundary_mask, **kwargs)
+        # Inverted mask ('== 0') gives the vector to the nearest boundary, matching vigra's
+        # 'vectorDistanceTransform' (as migrated in torch_em); 'sampling' replaces 'pixel_pitch'.
+        kwargs = {} if self.sampling is None else {"sampling": self.sampling}
+        this_distances = vector_difference_transform(cropped_boundary_mask == 0, **kwargs)
         this_distances[inv_mask] = 0
 
         spatial_axes = tuple(range(labels.ndim))
@@ -126,21 +127,22 @@ class DirectedPerObjectBoundaryDistanceTransform:
         if labels.ndim == 2:
             labels = labels[None]
 
-        # skimage/vigra C extensions read raw bytes assuming native byte order; swap if needed.
+        # bioimage-cpp / skimage C extensions read raw bytes assuming native byte order; swap if needed.
         if not labels.dtype.isnative:
             labels = labels.byteswap().view(labels.dtype.newbyteorder())
 
         if self.apply_label:
             labels = connected_components(labels).astype("uint32")
         else:  # Otherwise just relabel the segmentation.
-            labels = vigra.analysis.relabelConsecutive(labels)[0].astype("uint32")
+            # Cast to uint32: relabel_sequential rejects uint8/16 and labels fit uint32.
+            labels = relabel_sequential(labels.astype("uint32"))[0].astype("uint32")
 
         # Filter out small objects if min_size is specified.
         if self.min_size > 0:
             ids, sizes = np.unique(labels, return_counts=True)
             discard_ids = ids[sizes < self.min_size]
             labels[np.isin(labels, discard_ids)] = 0
-            labels = vigra.analysis.relabelConsecutive(labels)[0].astype("uint32")
+            labels = relabel_sequential(labels)[0].astype("uint32")
 
         # Compute the boundaries.
         boundaries = find_boundaries(labels, mode="inner").astype("uint32")

--- a/micro_sam/v2/transforms/raw.py
+++ b/micro_sam/v2/transforms/raw.py
@@ -14,7 +14,7 @@ from .labels import _plantseg_label_trafo  # noqa
 
 # NOTE: This is a legacy function: we will keep this for now for unpickling checkpoints saved before the refactor.
 def _axondeepseg_label_transform(y):  # noqa
-    from skimage.measure import label as connected_components
+    from bioimage_cpp.segmentation import label as connected_components
     return connected_components(y == 2).astype("uint32")
 
 

--- a/micro_sam/v2/util.py
+++ b/micro_sam/v2/util.py
@@ -737,6 +737,24 @@ def precompute_image_embeddings(
     return embeddings
 
 
+def _to_device_tensor(data, device):
+    """Convert embedding data (numpy array or torch tensor on any device) to a float tensor.
+
+    Freshly computed embeddings may still be tensors on MPS/CUDA, which 'np.asarray' cannot
+    convert; move those to the target device directly instead of via numpy.
+
+    Args:
+        data: The embedding data, either a numpy array or a torch tensor on any device.
+        device: The target device for the returned tensor.
+
+    Returns:
+        The data as a float tensor on the given device.
+    """
+    if torch.is_tensor(data):
+        return data.detach().to(device).float()
+    return torch.as_tensor(np.asarray(data), device=device).float()
+
+
 def set_precomputed(
     predictor,
     image_embeddings,
@@ -807,9 +825,9 @@ def set_precomputed(
         running_features = {}
         for slice_id in range(features.shape[0]):
             image = inference_state["images"][slice_id].to(device).float().unsqueeze(0)
-            vision_features = torch.as_tensor(np.asarray(features[slice_id]), device=device).float()
-            vision_pos_enc = [torch.as_tensor(np.asarray(t[slice_id]), device=device).float() for t in pos_list]
-            backbone_fpn = [torch.as_tensor(np.asarray(t[slice_id]), device=device).float() for t in fpn_list]
+            vision_features = _to_device_tensor(features[slice_id], device)
+            vision_pos_enc = [_to_device_tensor(t[slice_id], device) for t in pos_list]
+            backbone_fpn = [_to_device_tensor(t[slice_id], device) for t in fpn_list]
             backbone_out = {
                 "vision_features": vision_features, "vision_pos_enc": vision_pos_enc, "backbone_fpn": backbone_fpn,
             }
@@ -822,13 +840,9 @@ def set_precomputed(
         if i is not None:
             raise ValueError("The data is 2D so an index is not needed.")
 
-        # Reloaded embeddings are numpy arrays, so convert them to tensors on the predictor device,
-        # matching what 'predictor.set_image' would have produced for the decoder.
-        image_embed = torch.as_tensor(np.asarray(features), device=device).float()
-        high_res_feats = [
-            torch.as_tensor(np.asarray(feat), device=device).float()
-            for feat in image_embeddings["high_res_feats"]
-        ]
+        # Convert to tensors on the predictor device, as 'predictor.set_image' would for the decoder.
+        image_embed = _to_device_tensor(features, device)
+        high_res_feats = [_to_device_tensor(feat, device) for feat in image_embeddings["high_res_feats"]]
         predictor._features = {"image_embed": image_embed, "high_res_feats": high_res_feats}
         predictor._is_image_set = True
         predictor._orig_hw = image_embeddings["original_size"]


### PR DESCRIPTION
There were two hickups:
1. Existing vigra functions in automatic segmentation, the global import broke things -- and looking at this, I decided to port all v2 remaining things to `bioimage-cpp` as well. I did some checks, looks good to me.
2. The mechanism how arrays are converted around for MPS device (this broke automatic segmentation before for MPS)

Should work now!

@Marei33 can you retest this please on this branch?

cc: @constantinpape 

