### PR TITLE
Migrate to z5py backend for storing and loading image embeddings

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -29,8 +29,8 @@ dependencies:
     - timm
     - trackastra >=0.5.3
     - xarray
-    - z5py
-    - zarr
+    - z5py >=3
+    - zarr >=3
     - pip:
         - git+https://github.com/ChaoningZhang/MobileSAM.git
         - git+https://github.com/facebookresearch/sam2.git

--- a/environment.yaml
+++ b/environment.yaml
@@ -29,6 +29,7 @@ dependencies:
     - timm
     - trackastra >=0.5.3
     - xarray
+    - z5py
     - zarr
     - pip:
         - git+https://github.com/ChaoningZhang/MobileSAM.git

--- a/micro_sam/sam_annotator/_state.py
+++ b/micro_sam/sam_annotator/_state.py
@@ -7,7 +7,6 @@ from functools import partial
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Tuple
 
-import zarr
 import numpy as np
 
 from napari.layers import Image
@@ -271,7 +270,7 @@ class AnnotatorState(metaclass=Singleton):
         # If we have an embedding path the data signature has already been computed,
         # and we can read it from there.
         if save_path is not None and isinstance(save_path, str):
-            f = zarr.open(save_path, mode="r")
+            f = util._open_embeddings(save_path, mode="r")
             self.data_signature = f.attrs["data_signature"]
 
         # Otherwise we compute it here.

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -12,7 +12,6 @@ import elf.parallel
 import h5py
 import napari
 import numpy as np
-import zarr
 
 try:
     import z5py
@@ -1886,7 +1885,7 @@ class EmbeddingWidget(_WidgetBase):
             and os.listdir(self.embeddings_save_path)
         ):
             try:
-                f = zarr.open(self.embeddings_save_path, mode="a")
+                f = util._open_embeddings(self.embeddings_save_path, mode="a")
 
                 # Validate that the embeddings are complete.
                 # Note: 'input_size' is the last value set in the attrs of f,
@@ -1937,7 +1936,7 @@ class EmbeddingWidget(_WidgetBase):
                     # Recompute with the user's current selection: clear the saved file so the backend
                     # recomputes from scratch (works for any model and even when the model is unchanged).
                     # Tiling and model stay as the user set them in the widget.
-                    zarr.open(self.embeddings_save_path, mode="w")
+                    util._open_embeddings(self.embeddings_save_path, mode="w")
                     return False
 
                 # 'load': adopt the saved model and tiling, then load the existing embeddings. Clear any

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -12,11 +12,7 @@ import elf.parallel
 import h5py
 import napari
 import numpy as np
-
-try:
-    import z5py
-except ImportError:
-    z5py = None
+import z5py
 
 from bioimage_cpp.utils import segmentation_overlap
 from magicgui import magic_factory
@@ -788,13 +784,6 @@ def _get_promptable_segmentation_options(state, object_ids):
 
 
 def _commit_to_file(path, viewer, layer, seg, mask, bb, extra_attrs=None):
-
-    if z5py is None:
-        raise RuntimeError(
-            "Committing annotations to file requires z5py, which is only available via conda. "
-            "Install it with 'conda install -c conda-forge z5py'."
-        )
-
     # NOTE: zarr-python is quite inefficient and writes empty blocks.
     # So we have to use z5py here.
 

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -2,6 +2,7 @@
 """
 
 import os
+import json
 import pooch
 import xxhash
 import pickle
@@ -17,6 +18,7 @@ import imageio.v3 as imageio
 import segment_anything.utils.amg as amg_utils
 
 import zarr
+import z5py
 
 from elf.io import open_file
 import elf.parallel as parallel_impl
@@ -243,11 +245,50 @@ def _to_image(image, normalization="minmax"):
     return np.array(input_)
 
 
-# Wrapper of zarr.create dataset to support zarr v2 and zarr v3.
+# The zarr format used when writing new on-disk embedding caches. Reading auto-detects the format,
+# so existing caches (v2 or v3) still load; this only controls newly created containers.
+EMBEDDING_ZARR_FORMAT = 3
+# Compression codec for on-disk embeddings. blosc (byte-shuffle + lz4) is the fastest to read/write
+# and the smallest for float32 features; it is also z5py's default, so this just pins it explicitly.
+EMBEDDING_COMPRESSION = "blosc"
+
+
+def _open_embeddings(save_path, mode="a"):
+    """Open the container for image embeddings.
+
+    On-disk embeddings use z5py, whose C++ core reads and writes zarr much faster than zarr-python.
+    Reading auto-detects the zarr format, so existing caches (v2 and v3) still load; new caches use
+    the format given by ``EMBEDDING_ZARR_FORMAT``. In-memory embeddings (``save_path=None``) use an
+    in-memory zarr group, which z5py does not support.
+    """
+    if save_path is None:
+        return zarr.group()
+    save_path = str(save_path)
+    # Unlike zarr-python, z5py cannot open an existing directory that has no zarr metadata
+    # (e.g. an empty folder left by a previous run). When appending, write the group metadata
+    # for the pinned format first so the container opens as an empty group, as zarr-python did.
+    if mode == "a" and os.path.isdir(save_path):
+        has_metadata = any(
+            os.path.exists(os.path.join(save_path, name)) for name in (".zgroup", ".zarray", "zarr.json")
+        )
+        if not has_metadata:
+            if EMBEDDING_ZARR_FORMAT == 2:
+                meta_name, meta = ".zgroup", {"zarr_format": 2}
+            else:
+                meta_name, meta = "zarr.json", {"zarr_format": 3, "node_type": "group", "attributes": {}}
+            with open(os.path.join(save_path, meta_name), "w") as f:
+                json.dump(meta, f)
+    return z5py.ZarrFile(save_path, mode=mode, zarr_format=EMBEDDING_ZARR_FORMAT)
+
+
 def _create_dataset_with_data(group, name, data, chunks=None):
-    zarr_major_version = int(zarr.__version__.split(".")[0])
     if chunks is None:
         chunks = data.shape
+    # z5py exposes the h5py-style create_dataset for both zarr v2 and v3.
+    if isinstance(group, z5py.Group):
+        return group.create_dataset(name, data=data, shape=data.shape, chunks=chunks, compression=EMBEDDING_COMPRESSION)
+    # In-memory zarr group (only used when no save_path is given).
+    zarr_major_version = int(zarr.__version__.split(".")[0])
     if zarr_major_version == 2:
         ds = group.create_dataset(name, data=data, shape=data.shape, chunks=chunks)
     elif zarr_major_version == 3:
@@ -259,6 +300,11 @@ def _create_dataset_with_data(group, name, data, chunks=None):
 
 
 def _create_dataset_without_data(group, name, shape, dtype, chunks):
+    if isinstance(group, z5py.Group):
+        return group.create_dataset(
+            name, shape=shape, dtype=dtype, chunks=chunks, compression=EMBEDDING_COMPRESSION
+        )
+    # In-memory zarr group (only used when no save_path is given).
     zarr_major_version = int(zarr.__version__.split(".")[0])
     if zarr_major_version == 2:
         ds = group.create_dataset(name, shape=shape, dtype=dtype, chunks=chunks)

--- a/micro_sam/v1/models/vfm.py
+++ b/micro_sam/v1/models/vfm.py
@@ -449,22 +449,21 @@ def precompute_vfm_embeddings(
     Returns:
         The image embeddings.
     """
-    import zarr
     ndim = input_.ndim if ndim is None else ndim
     if ndim not in (2, 3):
         raise ValueError(f"Invalid dimensionality {ndim}, expect 2 or 3 dimensional data.")
 
     # Open / create the zarr container and return cached embeddings if they match; otherwise truncate.
     if save_path is None:
-        f = zarr.group()
+        f = util._open_embeddings(None)
     elif os.path.exists(save_path):
-        f = zarr.open(save_path, mode="a")
+        f = util._open_embeddings(save_path, mode="a")
         cached = _load_cached_embeddings(f, predictor, input_)
         if cached is not None:
             return cached
-        f = zarr.open(save_path, mode="w")
+        f = util._open_embeddings(save_path, mode="w")
     else:
-        f = zarr.open(save_path, mode="a")
+        f = util._open_embeddings(save_path, mode="a")
 
     pbar_init, pbar_update, pbar_close = _handle_pbar(verbose, pbar_init, pbar_update)
     is_3d = ndim == 3

--- a/micro_sam/v1/util.py
+++ b/micro_sam/v1/util.py
@@ -10,7 +10,6 @@ from typing import Any, Dict, Iterable, List, Optional, Tuple, Union, Callable  
 
 import numpy as np
 import pooch
-import zarr
 import torch
 
 from bioimage_cpp.utils import Blocking
@@ -20,7 +19,7 @@ from ..util import (  # noqa
     _DEFAULT_MODEL, _MODEL_TYPES,
     get_device, _available_devices, _to_image, _load_checkpoint, _compute_hash,
     _CustomUnpickler, get_cache_directory, microsam_cachedir,
-    _create_dataset_with_data, _create_dataset_without_data,
+    _create_dataset_with_data, _create_dataset_without_data, _open_embeddings,
     _compute_data_signature, _get_embedding_signature, _write_embedding_signature,
     handle_pbar,
 )
@@ -885,20 +884,20 @@ def precompute_image_embeddings(
     # Handle the embedding save_path.
     # We don't have a save path, open in memory zarr file to hold tiled embeddings.
     if save_path is None:
-        f = zarr.group()
+        f = _open_embeddings(None)
 
     # We have a save path and it already exists. Embeddings will be loaded from it,
     # check that the saved embeddings in there match the parameters of the function call.
     elif os.path.exists(save_path):
-        f = zarr.open(save_path, mode="a")
+        f = _open_embeddings(save_path, mode="a")
         if _check_saved_embeddings(input_, predictor, f, save_path, tile_shape, halo):
             # Stale embeddings (model or tiling changed): truncate and recompute, overwriting them.
-            f = zarr.open(save_path, mode="w")
+            f = _open_embeddings(save_path, mode="w")
 
     # We have a save path and it does not exist yet. Create the zarr file to which the
     # embeddings will then be saved.
     else:
-        f = zarr.open(save_path, mode="a")
+        f = _open_embeddings(save_path, mode="a")
 
     _, pbar_init, pbar_update, pbar_close = handle_pbar(verbose, pbar_init, pbar_update)
 

--- a/micro_sam/v2/util.py
+++ b/micro_sam/v2/util.py
@@ -5,12 +5,13 @@ import warnings
 from pathlib import Path
 from typing import Union, Literal, Optional, Tuple
 
-import zarr
 import numpy as np
 
 import torch
 
-from micro_sam.util import get_device, get_cache_directory, microsam_cachedir
+from micro_sam.util import (
+    get_device, get_cache_directory, microsam_cachedir, _open_embeddings, _create_dataset_without_data,
+)
 from micro_sam.v2.models._video_predictor import _build_sam2_video_predictor
 
 import sam2
@@ -476,7 +477,6 @@ def _compute_tiled_3d(input_, predictor, tile_shape, halo, f, save_path, pbar_in
 
 
 def _create_list_dataset_without_data(group, prefix_name, tensors, dtype, z_slices):
-    zarr_major_version = int(zarr.__version__.split(".")[0])
     subgroup = group.require_group(prefix_name)
 
     ds_list = []
@@ -493,12 +493,7 @@ def _create_list_dataset_without_data(group, prefix_name, tensors, dtype, z_slic
             if getattr(ds, "chunks", None) is not None and ds.chunks != chunks:
                 raise RuntimeError(f"Invalid chunks for {prefix_name}/{name}: expected {chunks}, got {ds.chunks}")
         else:
-            if zarr_major_version == 2:
-                ds = subgroup.create_dataset(name, shape=shape, dtype=dtype, chunks=chunks, overwrite=False)
-            elif zarr_major_version == 3:
-                ds = subgroup.create_array(name, shape=shape, chunks=chunks, dtype=dtype, overwrite=False)
-            else:
-                raise RuntimeError(f"Unsupported zarr version: {zarr_major_version}")
+            ds = _create_dataset_without_data(subgroup, name, shape=shape, dtype=dtype, chunks=chunks)
 
         ds_list.append(ds)
 
@@ -700,20 +695,20 @@ def precompute_image_embeddings(
     # Handle the embedding save_path.
     # We don't have a save path, open in memory zarr file to hold tiled embeddings.
     if save_path is None:
-        f = zarr.group()
+        f = _open_embeddings(None)
 
     # We have a save path and it already exists. Embeddings will be loaded from it,
-    # check tha tthe saved embeedidng in there match the parameters of the function call.abs
+    # check that the saved embeddings in there match the parameters of the function call.
     elif os.path.exists(save_path):
-        f = zarr.open(save_path, mode="a")
+        f = _open_embeddings(save_path, mode="a")
         if _check_saved_embeddings(input_, predictor, f, save_path, tile_shape, halo):
             # Stale embeddings (model or tiling changed): truncate and recompute, overwriting them.
-            f = zarr.open(save_path, mode="w")
+            f = _open_embeddings(save_path, mode="w")
 
     # We have a save path and it does not exist yet. Create the zarr file to which the
     # embeddings will then be saved.
     else:
-        f = zarr.open(save_path, mode="a")
+        f = _open_embeddings(save_path, mode="a")
 
     from micro_sam.util import handle_pbar
     _, pbar_init, pbar_update, pbar_close = handle_pbar(verbose, pbar_init, pbar_update)

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,7 @@ install_requires =
     trackastra>=0.5.3
     xarray
     xxhash
+    z5py
     zarr
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -66,8 +66,8 @@ install_requires =
     trackastra>=0.5.3
     xarray
     xxhash
-    z5py
-    zarr
+    z5py>=3
+    zarr>=3
 
 [options.packages.find]
 where = .

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -14,8 +14,10 @@ except ImportError:
 
 from skimage.data import binary_blobs
 from skimage.measure import label
-from micro_sam.util import VIT_T_SUPPORT, SamPredictor, get_cache_directory
+from micro_sam.util import VIT_T_SUPPORT, SamPredictor, get_cache_directory, _open_embeddings
 from micro_sam.v1.util import get_sam_model, set_precomputed
+
+ZARR_MAJOR = int(zarr.__version__.split(".")[0])
 
 
 class TestUtil(unittest.TestCase):
@@ -144,7 +146,7 @@ class TestUtil(unittest.TestCase):
 
         # Check the contents of the saved embeddings.
         self.assertTrue(os.path.exists(save_path))
-        f = zarr.open(save_path, mode="r")
+        f = _open_embeddings(save_path, mode="r")
         self.assertIn("features", f)
         self.assertEqual(f["features"].shape, (1, 256, 64, 64))
 
@@ -173,7 +175,7 @@ class TestUtil(unittest.TestCase):
 
         # Check the contents of the saved embeddings.
         self.assertTrue(os.path.exists(save_path))
-        f = zarr.open(save_path, mode="r")
+        f = _open_embeddings(save_path, mode="r")
         self.assertIn("features", f)
         self.assertEqual(f["features"].shape, (3, 1, 256, 64, 64))
 
@@ -204,7 +206,7 @@ class TestUtil(unittest.TestCase):
 
         # Check the contents of the saved embeddings.
         self.assertTrue(os.path.exists(save_path))
-        f = zarr.open(save_path, mode="r")
+        f = _open_embeddings(save_path, mode="r")
         self.assertIn("features", f)
         self.assertEqual(len(f["features"]), 4)
 
@@ -239,7 +241,7 @@ class TestUtil(unittest.TestCase):
 
         # Check the contents of the saved embeddings.
         self.assertTrue(os.path.exists(save_path))
-        f = zarr.open(save_path, mode="r")
+        f = _open_embeddings(save_path, mode="r")
         self.assertIn("features", f)
         self.assertEqual(len(f["features"]), 4)
 
@@ -339,7 +341,7 @@ class TestSAM2Util(unittest.TestCase):
 
         # Check the contents of the saved embeddings.
         self.assertTrue(os.path.exists(save_path))
-        f = zarr.open(save_path, mode="r")
+        f = _open_embeddings(save_path, mode="r")
         self.assertIn("features", f)
         self.assertIn("high_res_feats", f)
         self.assertEqual(f["features"].shape, (1, 256, 64, 64))
@@ -378,7 +380,7 @@ class TestSAM2Util(unittest.TestCase):
 
         # Check the contents of the saved embeddings.
         self.assertTrue(os.path.exists(save_path))
-        f = zarr.open(save_path, mode="r")
+        f = _open_embeddings(save_path, mode="r")
         self.assertIn("features", f)
         self.assertIn("pos_enc", f)
         self.assertIn("fpn", f)
@@ -403,12 +405,14 @@ class TestEmbeddingBackend(unittest.TestCase):
 
     @staticmethod
     def _write_legacy_cache(save_path, data, attrs, zarr_format):
-        # Mimic a cache written by the old zarr-python backend.
-        group = zarr.open(save_path, mode="w", zarr_format=zarr_format)
-        if hasattr(group, "create_array"):  # zarr-python v3
+        # Mimic a cache written by the old zarr-python backend. zarr-python v2 has no zarr_format
+        # argument and always writes v2, so only pass it on v3.
+        if ZARR_MAJOR >= 3:
+            group = zarr.open(save_path, mode="w", zarr_format=zarr_format)
             arr = group.create_array("features", shape=data.shape, dtype=data.dtype, chunks=data.shape)
             arr[:] = data
-        else:  # zarr-python v2
+        else:
+            group = zarr.open(save_path, mode="w")
             group.create_dataset("features", data=data, shape=data.shape, chunks=data.shape)
         for key, val in attrs.items():
             group.attrs[key] = val
@@ -438,11 +442,13 @@ class TestEmbeddingBackend(unittest.TestCase):
         self.assertEqual(list(g.attrs["input_size"]), [1024, 1024])
         self.assertIsNone(g.attrs["tile_shape"])
 
-        # z5py-written caches remain readable by zarr-python, and are written as zarr v3 with blosc.
-        z = zarr.open(save_path, mode="r")
-        self.assertTrue(np.allclose(z["features"][:], data))
-        self.assertEqual(z.metadata.zarr_format, 3)
-        self.assertTrue(any("blosc" in repr(codec).lower() for codec in z["features"].metadata.codecs))
+        # z5py-written caches are zarr v3 with blosc; verify via zarr-python where it can read v3
+        # (zarr-python v2 cannot read the v3 format, so this cross-check only applies on v3).
+        if ZARR_MAJOR >= 3:
+            z = zarr.open(save_path, mode="r")
+            self.assertTrue(np.allclose(z["features"][:], data))
+            self.assertEqual(z.metadata.zarr_format, 3)
+            self.assertTrue(any("blosc" in repr(codec).lower() for codec in z["features"].metadata.codecs))
 
     def test_open_metadataless_dir(self):
         # z5py cannot open a directory without zarr metadata; _open_embeddings must handle it
@@ -454,13 +460,15 @@ class TestEmbeddingBackend(unittest.TestCase):
         self.assertNotIn("features", f)
 
     def test_read_legacy_zarr_python_cache(self):
-        # Caches written by the old zarr-python backend (v2 and v3) must still load via z5py.
+        # Caches written by the old zarr-python backend must still load via z5py. Only test the
+        # formats the installed zarr-python can write (v2 alone on zarr-python v2, v2 and v3 on v3).
         from micro_sam.util import _open_embeddings
         data = np.random.rand(1, 256, 64, 64).astype("float32")
         attrs = {
             "input_size": [1024, 1024], "original_size": [512, 512], "tile_shape": None, "model_name": "vit_t",
         }
-        for zarr_format in (2, 3):
+        formats = (2, 3) if ZARR_MAJOR >= 3 else (2,)
+        for zarr_format in formats:
             save_path = os.path.join(self.tmp_folder, f"legacy_v{zarr_format}.zarr")
             self._write_legacy_cache(save_path, data, attrs, zarr_format)
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -7,6 +7,11 @@ import requests
 import torch
 import zarr
 
+try:
+    import z5py
+except ImportError:
+    z5py = None
+
 from skimage.data import binary_blobs
 from skimage.measure import label
 from micro_sam.util import VIT_T_SUPPORT, SamPredictor, get_cache_directory
@@ -383,6 +388,87 @@ class TestSAM2Util(unittest.TestCase):
         # Check that everything still works when we load the image embeddings from file.
         embeddings = precompute_image_embeddings(predictor, input_, save_path=save_path, ndim=3)
         check_slices(embeddings)
+
+
+@unittest.skipUnless(z5py, "The z5py embedding backend requires z5py.")
+class TestEmbeddingBackend(unittest.TestCase):
+    """Direct tests of the z5py embedding backend, without needing a SAM model."""
+    tmp_folder = "tmp-backend"
+
+    def setUp(self):
+        os.makedirs(self.tmp_folder, exist_ok=True)
+
+    def tearDown(self):
+        rmtree(self.tmp_folder)
+
+    @staticmethod
+    def _write_legacy_cache(save_path, data, attrs, zarr_format):
+        # Mimic a cache written by the old zarr-python backend.
+        group = zarr.open(save_path, mode="w", zarr_format=zarr_format)
+        if hasattr(group, "create_array"):  # zarr-python v3
+            arr = group.create_array("features", shape=data.shape, dtype=data.dtype, chunks=data.shape)
+            arr[:] = data
+        else:  # zarr-python v2
+            group.create_dataset("features", data=data, shape=data.shape, chunks=data.shape)
+        for key, val in attrs.items():
+            group.attrs[key] = val
+
+    def test_open_in_memory(self):
+        from micro_sam.util import _open_embeddings
+        # save_path=None returns an in-memory zarr group (z5py has no in-memory store).
+        f = _open_embeddings(None)
+        self.assertIsInstance(f, zarr.Group)
+
+    def test_roundtrip(self):
+        from micro_sam.util import _open_embeddings, _create_dataset_with_data, _create_dataset_without_data
+        save_path = os.path.join(self.tmp_folder, "embed.zarr")
+        data = np.random.rand(1, 256, 64, 64).astype("float32")
+
+        # On-disk embeddings use the z5py backend.
+        f = _open_embeddings(save_path, mode="a")
+        self.assertIsInstance(f, z5py.Group)
+        _create_dataset_with_data(f, "features", data=data)
+        _create_dataset_without_data(f, "empty", shape=data.shape, dtype="float32", chunks=data.shape)
+        f.attrs["input_size"] = [1024, 1024]
+        f.attrs["tile_shape"] = None
+
+        # Reload with the backend and check the contents (including tricky attrs: a list and None).
+        g = _open_embeddings(save_path, mode="r")
+        self.assertTrue(np.allclose(g["features"][:], data))
+        self.assertEqual(list(g.attrs["input_size"]), [1024, 1024])
+        self.assertIsNone(g.attrs["tile_shape"])
+
+        # z5py-written caches remain readable by zarr-python, and are written as zarr v3 with blosc.
+        z = zarr.open(save_path, mode="r")
+        self.assertTrue(np.allclose(z["features"][:], data))
+        self.assertEqual(z.metadata.zarr_format, 3)
+        self.assertTrue(any("blosc" in repr(codec).lower() for codec in z["features"].metadata.codecs))
+
+    def test_open_metadataless_dir(self):
+        # z5py cannot open a directory without zarr metadata; _open_embeddings must handle it
+        # gracefully, as the old zarr-python backend did (implicit group creation).
+        from micro_sam.util import _open_embeddings
+        save_path = os.path.join(self.tmp_folder, "empty.zarr")
+        os.makedirs(save_path)
+        f = _open_embeddings(save_path, mode="a")
+        self.assertNotIn("features", f)
+
+    def test_read_legacy_zarr_python_cache(self):
+        # Caches written by the old zarr-python backend (v2 and v3) must still load via z5py.
+        from micro_sam.util import _open_embeddings
+        data = np.random.rand(1, 256, 64, 64).astype("float32")
+        attrs = {
+            "input_size": [1024, 1024], "original_size": [512, 512], "tile_shape": None, "model_name": "vit_t",
+        }
+        for zarr_format in (2, 3):
+            save_path = os.path.join(self.tmp_folder, f"legacy_v{zarr_format}.zarr")
+            self._write_legacy_cache(save_path, data, attrs, zarr_format)
+
+            f = _open_embeddings(save_path, mode="a")
+            self.assertTrue(np.allclose(f["features"][:], data))
+            self.assertEqual(f.attrs["model_name"], "vit_t")
+            self.assertEqual(list(f.attrs["original_size"]), [512, 512])
+            self.assertIsNone(f.attrs["tile_shape"])
 
 
 if __name__ == "__main__":

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -6,11 +6,7 @@ import numpy as np
 import requests
 import torch
 import zarr
-
-try:
-    import z5py
-except ImportError:
-    z5py = None
+import z5py
 
 from skimage.data import binary_blobs
 from skimage.measure import label
@@ -392,7 +388,6 @@ class TestSAM2Util(unittest.TestCase):
         check_slices(embeddings)
 
 
-@unittest.skipUnless(z5py, "The z5py embedding backend requires z5py.")
 class TestEmbeddingBackend(unittest.TestCase):
     """Direct tests of the z5py embedding backend, without needing a SAM model."""
     tmp_folder = "tmp-backend"


### PR DESCRIPTION
Well this was a tiny bit more tricker than I anticipated hehe, but it worked out! (crazy speed ups even in my shallow benchmarks haha)

One caveat: zarr is still kept around for in-memory embeddings (i.e. tiled with no save_path). z5py does not have in-memory stores, and that path does no disk IO to accelerate anyway.

What do you think about this? @constantinpape 