### PR TITLE
Add support for scribble prompts

### DIFF
--- a/micro_sam/sam_annotator/_annotator.py
+++ b/micro_sam/sam_annotator/_annotator.py
@@ -89,15 +89,40 @@ class _AnnotatorBase(QtWidgets.QScrollArea):
             )
             self._point_prompt_layer.border_color_mode = "cycle"
 
-        if "prompts" not in self._viewer.layers:
+        if "prompts" in self._viewer.layers:
+            self._shape_prompt_layer = self._viewer.layers["prompts"]
+        else:
             # Add the shape layer for box and other shape prompts.
-            self._viewer.add_shapes(
+            self._shape_prompt_layer = self._viewer.add_shapes(
                 face_color="transparent",
-                edge_color="green",
+                edge_color="label",
+                edge_color_cycle=vutil.LABEL_COLOR_CYCLE,
                 edge_width=4,
                 name="prompts",
                 ndim=self._ndim,
+                property_choices={"label": self._point_labels},
             )
+            self._shape_prompt_layer.edge_color_mode = "cycle"
+
+        # Migrate a pre-existing prompt layer and keep boxes / dense mask prompts green. Open
+        # paths retain their positive / negative property and use the same colors as point prompts.
+        if "label" not in self._shape_prompt_layer.properties:
+            properties = dict(self._shape_prompt_layer.properties)
+            properties["label"] = np.full(len(self._shape_prompt_layer.data), "positive", dtype=object)
+            self._shape_prompt_layer.properties = properties
+            current_properties = self._shape_prompt_layer.current_properties
+            current_properties["label"] = np.array(["positive"])
+            self._shape_prompt_layer.current_properties = current_properties
+            self._shape_prompt_layer.edge_color_cycle = vutil.LABEL_COLOR_CYCLE
+            self._shape_prompt_layer.edge_color = "label"
+            self._shape_prompt_layer.edge_color_mode = "cycle"
+        if not self._shape_prompt_layer.metadata.get("micro_sam_prompt_labels_configured", False):
+            self._shape_prompt_layer.events.data.connect(vutil.normalize_prompt_shape_labels)
+            self._shape_prompt_layer.events.mode.connect(vutil.sync_prompt_shape_current_color)
+            self._shape_prompt_layer.events.current_properties.connect(vutil.sync_prompt_shape_current_color)
+            self._shape_prompt_layer.metadata["micro_sam_prompt_labels_configured"] = True
+        vutil.normalize_prompt_shape_labels(self._shape_prompt_layer)
+        vutil.sync_prompt_shape_current_color(self._shape_prompt_layer)
 
     # Child classes have to implement this function and create a dictionary with the widgets.
     def _get_widgets(self):
@@ -124,8 +149,10 @@ class _AnnotatorBase(QtWidgets.QScrollArea):
         # Create the prompt widget. (The same for all plugins.)
         # Child plugins decide whether to expose it as a separate group (e.g. tracking) or to
         # embed it into another widget (e.g. the interactive segmentation widget).
+        shape_prompt_layer = self._viewer.layers["prompts"]
+        linked_layers = [shape_prompt_layer] if "label" in shape_prompt_layer.current_properties else None
         self._prompt_widget = widgets.create_prompt_menu(
-            self._point_prompt_layer, self._point_labels
+            self._point_prompt_layer, self._point_labels, linked_layers=linked_layers
         )
 
         # Create the dictionary for the widgets and get the widgets of the child plugin.
@@ -151,13 +178,21 @@ class _AnnotatorBase(QtWidgets.QScrollArea):
         def _segment_point_prompts(event):
             self._widgets["segment"](self._viewer)
 
+        @prompt_layer.bind_key("t", overwrite=True)
+        def _toggle_shape_prompt_label(event=None):
+            vutil.toggle_label(self._point_prompt_layer, self._shape_prompt_layer)
+
+        @point_prompt_layer.bind_key("t", overwrite=True)
+        def _toggle_point_prompt_label(event=None):
+            vutil.toggle_label(self._point_prompt_layer, self._shape_prompt_layer)
+
         @self._viewer.bind_key("c", overwrite=True)
         def _commit(viewer):
             self._widgets["commit"](viewer)
 
         @self._viewer.bind_key("t", overwrite=True)
         def _toggle_label(event=None):
-            vutil.toggle_label(self._point_prompt_layer)
+            vutil.toggle_label(self._point_prompt_layer, self._shape_prompt_layer)
 
         @self._viewer.bind_key("Shift-C", overwrite=True)
         def _clear_annotations(viewer):
@@ -281,7 +316,11 @@ class _AnnotatorBase(QtWidgets.QScrollArea):
         self._require_layers()
 
         # The prompt widget is bound to the point prompt layer, so it is recreated alongside it.
-        self._prompt_widget = widgets.create_prompt_menu(self._point_prompt_layer, self._point_labels)
+        shape_prompt_layer = self._viewer.layers["prompts"]
+        linked_layers = [shape_prompt_layer] if "label" in shape_prompt_layer.current_properties else None
+        self._prompt_widget = widgets.create_prompt_menu(
+            self._point_prompt_layer, self._point_labels, linked_layers=linked_layers
+        )
 
         # Rebuild the dimension-specific widgets, keeping the shared embedding widget.
         self._widgets = {"embeddings": self._embedding_widget}

--- a/micro_sam/sam_annotator/_tooltips.py
+++ b/micro_sam/sam_annotator/_tooltips.py
@@ -30,6 +30,7 @@ tooltips = {
     "unified_segment": {
         "apply_to_volume": "Choose if segmentation is run for the current slice/frame only or for the full volume/all frames.",  # noqa
         "batched": "Enable to segment multiple objects at once: each positive point and each box defines a separate object. Only available for SAM2 models.",  # noqa
+        "batched_scribble_disabled": "Batched segmentation is unavailable while scribble prompts are present. Remove all path, polyline and line prompts to re-enable it.",  # noqa
         "segment_button": "Run Segment Anything 2 on the current point/box prompts to segment the object. Shortcut: S.",  # noqa
         "clear_button": "Clear the current prompts and the current-object segmentation (whole volume or current slice per 'Apply to Volume' for 3d data). Shortcut: Shift + C.",  # noqa
         "settings": "Settings for interactive segmentation across slices (projection mode and propagation parameters).",  # noqa

--- a/micro_sam/sam_annotator/_tooltips.py
+++ b/micro_sam/sam_annotator/_tooltips.py
@@ -72,7 +72,7 @@ tooltips = {
         "run_tracking": "Choose if to run tracking for the whole timeseries or if to segment only the current timeframe.",  # noqa
     },
     "prompt_menu": {
-        "labels": "Choose positive prompts to inlcude regions or negative ones to exclude regions. Toggle between the settings by pressing [t].",  # noqa
+        "labels": "Choose positive point/scribble prompts to include regions or negative ones to exclude regions. Toggle between the settings by pressing [t]. In 3d, a scribble belongs to the z-slice where it was drawn and can seed or correct volume propagation.",  # noqa
     },
     "annotator_tracking": {
         "track_id": "Select the id of the track you are currently annotating.",

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -1215,9 +1215,10 @@ def export_track(
 
 
 def create_prompt_menu(
-    points_layer, labels, menu_name="prompt", label_name="label"
+    points_layer, labels, menu_name="prompt", label_name="label", linked_layers=None,
 ):
-    """Create the menu for toggling point prompt labels."""
+    """Create a menu that keeps point and optional shape prompt labels synchronized."""
+    prompt_layers = [points_layer] + ([] if linked_layers is None else list(linked_layers))
     label_menu = ComboBox(
         label=menu_name,
         choices=labels,
@@ -1226,17 +1227,22 @@ def create_prompt_menu(
     label_widget = Container(widgets=[label_menu])
 
     def update_label_menu(event):
-        new_label = str(points_layer.current_properties[label_name][0])
+        new_label = str(event.source.current_properties[label_name][0])
         if new_label != label_menu.value:
             label_menu.value = new_label
 
-    points_layer.events.current_properties.connect(update_label_menu)
+    for layer in prompt_layers:
+        layer.events.current_properties.connect(update_label_menu)
 
     def label_changed(new_label):
-        current_properties = points_layer.current_properties
-        current_properties[label_name] = np.array([new_label])
-        points_layer.current_properties = current_properties
-        points_layer.refresh_colors()
+        for layer in prompt_layers:
+            if label_name == "label":
+                vutil.set_prompt_label(layer, new_label)
+            else:
+                current_properties = layer.current_properties
+                current_properties[label_name] = np.array([new_label])
+                layer.current_properties = current_properties
+                layer.refresh_colors()
 
     label_menu.changed.connect(label_changed)
 
@@ -1418,18 +1424,33 @@ def _segment_object_2d(viewer, batched=False):
 
     shape = viewer.layers["current_object"].data.shape
 
-    # get the current box and point prompts
+    # Get the current box, point and open-stroke prompts. Scribbles are encoded through SAM's
+    # existing sparse point prompt embeddings, so the predictor interface remains unchanged.
     boxes, masks = vutil.shape_layer_to_prompts(
         viewer.layers["prompts"], shape
     )
     points, labels = vutil.point_layer_to_prompts(
         viewer.layers["point_prompts"], with_stop_annotation=False
     )
+    scribble_points, scribble_labels = vutil.scribble_layer_to_prompts(
+        viewer.layers["prompts"], image_shape=shape
+    )
+    points, labels = vutil.merge_point_prompts(
+        (points, labels), (scribble_points, scribble_labels)
+    )
+
+    have_scribbles = len(scribble_points) > 0
+    if have_scribbles and not len(boxes) and not np.any(labels == 1):
+        msg = "A negative scribble needs a positive point, positive scribble, box or mask prompt."
+        return _generate_message("error", msg)
 
     state = AnnotatorState()
     predictor = state.predictor
     image_embeddings = state.image_embeddings
     batched = _batched_disabled_when_tiled(state, batched)
+    if have_scribbles and batched:
+        show_info("Batched segmentation is not supported with scribble prompts. Running single-object.")
+        batched = False
 
     if state.is_sam2:
         # When the embeddings are tiled (top-level 'input_size' is None), route the prompts to the
@@ -2587,20 +2608,35 @@ class UnifiedSegmentWidget(_WidgetBase):
         )
         z = int(position[0])
 
+        prompt_layer = self._viewer.layers["prompts"]
+        scribble_points, scribble_labels = vutil.scribble_layer_to_prompts(
+            prompt_layer, image_shape=shape, i=z
+        )
+        have_scribbles = len(scribble_points) > 0
         point_prompts = vutil.point_layer_to_prompts(
-            self._viewer.layers["point_prompts"], z
+            self._viewer.layers["point_prompts"], z, with_stop_annotation=not have_scribbles
         )
         # this is a stop prompt, we do nothing
         if not point_prompts:
             return
 
         boxes, masks = vutil.shape_layer_to_prompts(
-            self._viewer.layers["prompts"], shape, i=z
+            prompt_layer, shape, i=z
         )
-        points, labels = point_prompts
+        points, labels = vutil.merge_point_prompts(
+            point_prompts, (scribble_points, scribble_labels)
+        )
+        if have_scribbles and not boxes and not np.any(labels == 1):
+            return _generate_message(
+                "error",
+                "A negative scribble needs a positive point, positive scribble, box or mask prompt.",
+            )
 
         state = AnnotatorState()
         batched = _batched_disabled_when_tiled(state, bool(self.batched))
+        if have_scribbles and batched:
+            show_info("Batched segmentation is not supported with scribble prompts. Running single-object.")
+            batched = False
 
         if state.is_sam2:
             # Use the segment_slice method for SAM2.
@@ -2753,14 +2789,26 @@ class UnifiedSegmentWidget(_WidgetBase):
                 point_prompts = self._viewer.layers["point_prompts"]
                 box_prompts = self._viewer.layers["prompts"]
                 z_values_points = np.round(point_prompts.data[:, 0])
-                z_values_boxes = (
-                    np.concatenate([box[:1, 0] for box in box_prompts.data])
-                    if box_prompts.data
-                    else np.zeros(0, dtype="int")
-                )
+                z_values_scribbles = vutil.get_scribble_slices(box_prompts)
+                have_scribbles = len(z_values_scribbles) > 0
+                z_values_boxes = np.round(
+                    np.asarray([
+                        shape[0, 0]
+                        for shape, shape_type in zip(box_prompts.data, box_prompts.shape_type)
+                        if shape_type not in vutil.SCRIBBLE_SHAPE_TYPES
+                    ])
+                ).astype("int")
 
                 # Whether the user decide to provide batched prompts for multi-object segmentation.
                 is_batched = _batched_disabled_when_tiled(state, bool(self.batched))
+                if have_scribbles and is_batched:
+                    show_info("Batched segmentation is not supported with scribble prompts. Running single-object.")
+                    is_batched = False
+
+                # A scribble is expanded into several points. Rebuild the persistent video-predictor
+                # state so deleting or relabelling a stroke cannot leave stale samples behind.
+                if have_scribbles:
+                    state.interactive_segmenter.reset_predictor()
 
                 # Check batched mode validity and show warning if needed
                 if is_batched and not state.is_sam2:
@@ -2800,12 +2848,36 @@ class UnifiedSegmentWidget(_WidgetBase):
 
                 # Then add the point prompts. Iterate unique frames so each frame's points are added
                 # together; the segmenter skips points already pushed, so re-runs only add new ones.
-                for curr_z in np.unique(z_values_points):
+                point_slices = np.unique(np.concatenate([z_values_points, z_values_scribbles])).astype("int")
+                merged_prompts = []
+                for curr_z in point_slices:
+                    scribble_points, scribble_labels = vutil.scribble_layer_to_prompts(
+                        box_prompts, image_shape=shape_yx, i=curr_z
+                    )
                     # A slice whose only prompt is a single negative point is a 'stop' annotation; skip it.
-                    prompts = vutil.point_layer_to_prompts(layer=point_prompts, i=curr_z)
+                    prompts = vutil.point_layer_to_prompts(
+                        layer=point_prompts,
+                        i=curr_z,
+                        with_stop_annotation=len(scribble_points) == 0,
+                    )
                     if prompts is None:
                         continue
-                    points, labels = prompts
+                    points, labels = vutil.merge_point_prompts(
+                        prompts, (scribble_points, scribble_labels)
+                    )
+                    merged_prompts.append((curr_z, points, labels))
+
+                have_positive_points = any(np.any(labels == 1) for _, _, labels in merged_prompts)
+                have_shape_cue = len(z_values_boxes) > 0
+                if have_scribbles and not have_positive_points and not have_shape_cue:
+                    pbar_signals.pbar_stop.emit()
+                    _generate_message(
+                        "error",
+                        "A negative scribble needs a positive point, positive scribble, box or mask prompt.",
+                    )
+                    return None
+
+                for curr_z, points, labels in merged_prompts:
                     if is_batched:
                         point_ids = list(range(object_id + 1, object_id + 1 + len(points)))
                         object_id += len(points)
@@ -2843,6 +2915,13 @@ class UnifiedSegmentWidget(_WidgetBase):
                         update_progress=emit_progress,
                     )
                 )
+                if len(slices) == 0:
+                    pbar_signals.pbar_stop.emit()
+                    _generate_message(
+                        "error",
+                        "No valid slice prompts remain. Add a positive point, scribble, box or mask prompt.",
+                    )
+                    return None
 
                 # Step 2: Segment the rest of the volume based on projecting prompts.
                 seg, (z_min, z_max) = segment_mask_in_volume(
@@ -2869,6 +2948,8 @@ class UnifiedSegmentWidget(_WidgetBase):
             self._viewer.layers["current_object"].refresh()
 
         seg = volumetric_segmentation_impl()
+        if seg is None:
+            return None
         self._viewer.layers["current_object"].data = seg
         self._viewer.layers["current_object"].refresh()
         # worker = volumetric_segmentation_impl()

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -3300,8 +3300,28 @@ class InteractiveSegmentationWidget(_WidgetBase):
         button_row.addWidget(self.clear_button)
         self.layout().addLayout(button_row)
 
+        # Scribbles describe corrections for one object and cannot be assigned unambiguously to
+        # separate objects in batched mode. Keep the control in sync as scribbles are added or
+        # removed from the shared prompt layer.
+        self._viewer.layers["prompts"].events.data.connect(self._update_batched_visibility)
+
         # Hide the batched control if the (already loaded) embeddings are tiled.
         self._update_batched_visibility()
+
+    def _update_batched_visibility(self, event=None):
+        """Disable batched segmentation while one or more scribble prompts are present."""
+        super()._update_batched_visibility()
+
+        prompt_layer = self._viewer.layers["prompts"]
+        have_scribbles = any(
+            shape_type in vutil.SCRIBBLE_SHAPE_TYPES for shape_type in prompt_layer.shape_type
+        )
+        if have_scribbles and self.batched_checkbox.isChecked():
+            self.batched_checkbox.setChecked(False)
+
+        self.batched_checkbox.setEnabled(not have_scribbles)
+        tooltip_key = "batched_scribble_disabled" if have_scribbles else "batched"
+        self.batched_checkbox.setToolTip(get_tooltip("unified_segment", tooltip_key))
 
     def _create_propagation_settings(self):
         """Build the SAM2 volume-mode propagation controls (early stopping + z-range slider).

--- a/micro_sam/sam_annotator/annotator.py
+++ b/micro_sam/sam_annotator/annotator.py
@@ -132,13 +132,21 @@ class Annotator(_AnnotatorBase):
         def _segment_point_prompts(event):
             interactive.segment(self._viewer)
 
+        @prompt_layer.bind_key("t", overwrite=True)
+        def _toggle_shape_prompt_label(event=None):
+            vutil.toggle_label(self._point_prompt_layer, self._shape_prompt_layer)
+
+        @point_prompt_layer.bind_key("t", overwrite=True)
+        def _toggle_point_prompt_label(event=None):
+            vutil.toggle_label(self._point_prompt_layer, self._shape_prompt_layer)
+
         @self._viewer.bind_key("c", overwrite=True)
         def _commit(viewer):
             self._widgets["commit"](viewer)
 
         @self._viewer.bind_key("t", overwrite=True)
         def _toggle_label(event=None):
-            vutil.toggle_label(self._point_prompt_layer)
+            vutil.toggle_label(self._point_prompt_layer, self._shape_prompt_layer)
 
         @self._viewer.bind_key("Shift-C", overwrite=True)
         def _clear_annotations(viewer):

--- a/micro_sam/sam_annotator/util.py
+++ b/micro_sam/sam_annotator/util.py
@@ -20,6 +20,12 @@ from ..v1.multi_dimensional_segmentation import _validate_projection
 LABEL_COLOR_CYCLE = ["#00FF00", "#FF0000"]
 """@private"""
 
+SCRIBBLE_SHAPE_TYPES = ("path", "line")
+"""Napari shape types interpreted as sparse scribble prompts."""
+
+SCRIBBLE_DRAW_MODES = ("add_path", "add_polyline", "add_line")
+"""Napari Shapes modes that create open scribble prompts."""
+
 
 #
 # Misc helper functions
@@ -119,16 +125,94 @@ def prepare_annotation_image(image: np.ndarray, ndim: Optional[int] = None) -> T
     raise ValueError(f"Invalid image shape: {image.shape}. Expected 2D or 3D image data.")
 
 
-def toggle_label(prompts):
-    """@private"""
-    # get the currently selected label
-    current_properties = prompts.current_properties
-    current_label = current_properties["label"][0]
-    new_label = "negative" if current_label == "positive" else "positive"
+def set_prompt_label(layer, new_label):
+    """Set the current prompt label and relabel selected shapes consistently.
+
+    Napari Points applies ``current_properties`` changes to selected points in all modes. Shapes,
+    however, only applies them to selected shapes in select or pan/zoom mode. Explicitly updating
+    the selected open shapes here keeps changing the prompt menu or pressing ``T`` consistent for
+    both layer types, including immediately after drawing a path, polyline or line.
+    """
+    current_properties = layer.current_properties
     current_properties["label"] = np.array([new_label])
-    prompts.current_properties = current_properties
-    prompts.refresh()
-    prompts.refresh_colors()
+    layer.current_properties = current_properties
+
+    if isinstance(layer, napari.layers.Shapes) and layer.selected_data:
+        properties = dict(layer.properties)
+        labels = np.asarray(properties.get("label", []), dtype=object).copy()
+        shape_types = list(layer.shape_type)
+        if len(labels) == len(shape_types):
+            for index in layer.selected_data:
+                if shape_types[index] in SCRIBBLE_SHAPE_TYPES:
+                    labels[index] = new_label
+            properties["label"] = labels
+            layer.properties = properties
+
+            # Keep the drawing default on the requested label. Updating the feature table above
+            # may infer a current value from the edited selection.
+            current_properties = layer.current_properties
+            current_properties["label"] = np.array([new_label])
+            layer.current_properties = current_properties
+
+    layer.refresh()
+    if isinstance(layer, napari.layers.Shapes):
+        # During layer reset/teardown napari can briefly clear shape geometry before shrinking the
+        # feature table. Refreshing mapped colors in that transient state raises because the color
+        # array and ShapeList have different lengths; the subsequent data/features event will
+        # refresh once they are aligned again.
+        n_shapes = len(layer.data)
+        if any(len(values) != n_shapes for values in layer.properties.values()):
+            return
+    layer.refresh_colors()
+
+
+def toggle_label(prompts, *linked_prompts):
+    """Toggle the positive/negative label for one or more prompt layers."""
+    # Use the first layer as the source of truth, then keep all linked prompt layers in sync.
+    current_label = prompts.current_properties["label"][0]
+    new_label = "negative" if current_label == "positive" else "positive"
+    for layer in (prompts,) + linked_prompts:
+        set_prompt_label(layer, new_label)
+
+
+def normalize_prompt_shape_labels(layer_or_event):
+    """Keep closed shape prompts positive while preserving labels for open scribbles.
+
+    The shared Shapes layer uses its ``label`` property for edge coloring. Boxes and dense mask
+    shapes do not support negative semantics, so they are normalized to positive after creation.
+    The current label is restored afterwards so drawing a box does not change the label selected
+    for the next point or scribble.
+    """
+    layer = layer_or_event if hasattr(layer_or_event, "shape_type") else layer_or_event.source
+    shape_types = list(layer.shape_type)
+    labels = np.asarray(layer.properties.get("label", []), dtype=object)
+    if len(shape_types) != len(labels):
+        return
+
+    normalized = labels.copy()
+    for index, shape_type in enumerate(shape_types):
+        if shape_type not in SCRIBBLE_SHAPE_TYPES:
+            normalized[index] = "positive"
+    if np.array_equal(labels, normalized):
+        return
+
+    current_label = layer.current_properties.get("label", np.array(["positive"]))[0]
+    properties = dict(layer.properties)
+    properties["label"] = normalized
+    layer.properties = properties
+    current_properties = layer.current_properties
+    current_properties["label"] = np.array([current_label])
+    layer.current_properties = current_properties
+    layer.refresh_colors()
+
+
+def sync_prompt_shape_current_color(layer_or_event):
+    """Synchronize the Shapes drawing color with the current scribble label and tool."""
+    layer = layer_or_event if hasattr(layer_or_event, "shape_type") else layer_or_event.source
+    label = layer.current_properties.get("label", np.array(["positive"]))[0]
+    is_scribble_tool = layer.mode in SCRIBBLE_DRAW_MODES
+    color_index = 1 if is_scribble_tool and label == "negative" else 0
+    layer.current_edge_color = LABEL_COLOR_CYCLE[color_index]
 
 
 def clear_annotations(viewer: napari.Viewer, clear_segmentations=True) -> None:
@@ -155,10 +239,12 @@ def clear_annotations_slice(viewer: napari.Viewer, i: int, clear_segmentations=T
     viewer.layers["point_prompts"].data = point_prompts
     viewer.layers["point_prompts"].refresh()
     if "prompts" in viewer.layers:
-        prompts = viewer.layers["prompts"].data
-        prompts = [prompt for prompt in prompts if not (prompt[:, 0] == i).all()]
-        viewer.layers["prompts"].data = prompts
-        viewer.layers["prompts"].refresh()
+        prompt_layer = viewer.layers["prompts"]
+        prompt_layer.selected_data = {
+            index for index, prompt in enumerate(prompt_layer.data) if (prompt[:, 0] == i).all()
+        }
+        prompt_layer.remove_selected()
+        prompt_layer.refresh()
     if not clear_segmentations:
         return
     viewer.layers["current_object"].data[i] = 0
@@ -224,6 +310,170 @@ def point_layer_to_prompts(
     return this_points, this_labels
 
 
+def _resample_scribble(vertices, image_shape, spacing, max_points):
+    """Resample an open stroke uniformly in SAM's normalized input coordinate system."""
+    vertices = np.asarray(vertices, dtype="float64")
+    if vertices.ndim != 2 or vertices.shape[1] != 2 or len(vertices) == 0:
+        raise ValueError("A scribble must have shape (N, 2) with at least one vertex.")
+
+    image_shape = np.asarray(image_shape, dtype="float64")
+    if image_shape.shape != (2,) or np.any(image_shape <= 0):
+        raise ValueError(f"Invalid 2D image shape: {tuple(image_shape)}.")
+
+    # SAM2 embeds prompts in a square 1024-pixel input frame. Measuring the stroke there makes the
+    # sampling density independent of the source image resolution and aspect ratio.
+    model_vertices = vertices * (1024.0 / image_shape)
+    if len(model_vertices) == 1:
+        return vertices.copy()
+
+    segment_lengths = np.linalg.norm(np.diff(model_vertices, axis=0), axis=1)
+    cumulative = np.concatenate([[0.0], np.cumsum(segment_lengths)])
+    total_length = cumulative[-1]
+    if total_length == 0:
+        return vertices[:1].copy()
+
+    n_points = min(max_points, max(2, int(np.ceil(total_length / spacing)) + 1))
+    sample_distances = np.linspace(0.0, total_length, n_points)
+    segment_ids = np.searchsorted(cumulative, sample_distances, side="right") - 1
+    segment_ids = np.clip(segment_ids, 0, len(segment_lengths) - 1)
+
+    local_lengths = sample_distances - cumulative[segment_ids]
+    fractions = np.divide(
+        local_lengths,
+        segment_lengths[segment_ids],
+        out=np.zeros_like(local_lengths),
+        where=segment_lengths[segment_ids] > 0,
+    )
+    sampled_model = model_vertices[segment_ids] + fractions[:, None] * (
+        model_vertices[segment_ids + 1] - model_vertices[segment_ids]
+    )
+    return sampled_model * (image_shape / 1024.0)
+
+
+def scribble_layer_to_prompts(
+    layer: napari.layers.Shapes,
+    image_shape: Tuple[int, int],
+    i=None,
+    spacing: float = 32.0,
+    max_points_per_stroke: int = 16,
+) -> Tuple[np.ndarray, np.ndarray]:
+    """Convert positive/negative open strokes into sparse SAM point prompts.
+
+    Napari stores both its freehand path and click-defined polyline tools as ``path`` shapes; a
+    two-vertex stroke is stored as ``line``. Each accepted stroke is resampled uniformly by arc
+    length in SAM's normalized 1024-pixel input space. This keeps prompt density stable across
+    source resolutions while limiting the number of sparse prompt tokens generated by long strokes.
+
+    Args:
+        layer: The shared ``prompts`` Shapes layer. Non-scribble shapes are ignored.
+        image_shape: The ``(height, width)`` of the image or volume slice.
+        i: Slice index for a 3D layer. Must be omitted for a 2D layer.
+        spacing: Approximate spacing between samples in SAM's 1024-pixel input space.
+        max_points_per_stroke: Maximum number of point prompts generated per stroke.
+
+    Returns:
+        Sampled coordinates in ``(y, x)`` order and SAM labels (positive ``1``, negative ``0``).
+    """
+    if spacing <= 0:
+        raise ValueError("'spacing' must be positive.")
+    if max_points_per_stroke <= 0:
+        raise ValueError("'max_points_per_stroke' must be positive.")
+
+    shape_data = layer.data
+    shape_types = layer.shape_type
+    stroke_labels = layer.properties.get("label", [])
+    if not (len(shape_data) == len(shape_types) == len(stroke_labels)):
+        raise AssertionError("Scribble shapes, shape types and labels must have matching lengths.")
+
+    points, labels = [], []
+    seen = set()
+    for vertices, shape_type, stroke_label in zip(shape_data, shape_types, stroke_labels):
+        if shape_type in ("rectangle", "ellipse", "polygon"):
+            continue
+        if shape_type not in SCRIBBLE_SHAPE_TYPES:
+            warnings.warn(
+                f"Shape type {shape_type} is not a scribble and will be ignored. "
+                "Use path, polyline or line in the 'prompts' layer.",
+                stacklevel=2,
+            )
+            continue
+        if stroke_label not in ("positive", "negative"):
+            warnings.warn(
+                f"Unknown scribble label {stroke_label!r}; the stroke will be ignored.", stacklevel=2
+            )
+            continue
+
+        vertices = np.asarray(vertices)
+        if i is None:
+            if vertices.ndim != 2 or vertices.shape[1] != 2:
+                raise ValueError("2D scribble vertices must have shape (N, 2).")
+            vertices_yx = vertices
+        else:
+            if vertices.ndim != 2 or vertices.shape[1] != 3:
+                raise ValueError("3D scribble vertices must have shape (N, 3).")
+            stroke_slices = np.round(vertices[:, 0]).astype(int)
+            if not np.all(stroke_slices == i):
+                continue
+            vertices_yx = vertices[:, 1:]
+
+        sampled = _resample_scribble(
+            vertices_yx, image_shape=image_shape, spacing=spacing, max_points=max_points_per_stroke
+        )
+        sam_label = 1 if stroke_label == "positive" else 0
+        for point in sampled:
+            # Deduplicate at image-pixel resolution while retaining opposite-label conflicts so they
+            # remain visible to the caller instead of silently changing the user's annotation.
+            signature = (int(round(point[0])), int(round(point[1])), sam_label)
+            if signature in seen:
+                continue
+            seen.add(signature)
+            points.append(point)
+            labels.append(sam_label)
+
+    if not points:
+        return np.empty((0, 2), dtype="float64"), np.empty((0,), dtype="int64")
+    return np.asarray(points), np.asarray(labels, dtype="int64")
+
+
+def get_scribble_slices(layer: napari.layers.Shapes) -> np.ndarray:
+    """Return the sorted z-slices containing open scribble shapes in a 3D Shapes layer."""
+    shape_data = layer.data
+    shape_types = layer.shape_type
+    if len(shape_data) != len(shape_types):
+        raise AssertionError("Scribble shapes and shape types must have matching lengths.")
+
+    slices = []
+    for vertices, shape_type in zip(shape_data, shape_types):
+        if shape_type not in SCRIBBLE_SHAPE_TYPES:
+            continue
+        vertices = np.asarray(vertices)
+        if vertices.ndim != 2 or vertices.shape[1] != 3:
+            continue
+        stroke_slices = np.round(vertices[:, 0]).astype(int)
+        if not np.all(stroke_slices == stroke_slices[0]):
+            warnings.warn("A 3D scribble must stay on one z-slice and will be ignored.", stacklevel=2)
+            continue
+        slices.append(stroke_slices[0])
+
+    return np.unique(slices).astype("int64") if slices else np.empty((0,), dtype="int64")
+
+
+def merge_point_prompts(*prompt_sets):
+    """Merge ``(points, labels)`` prompt tuples, preserving an empty ``(0, 2)`` convention."""
+    point_arrays, label_arrays = [], []
+    for points, labels in prompt_sets:
+        points = np.asarray(points).reshape(-1, 2)
+        labels = np.asarray(labels).reshape(-1)
+        if len(points) != len(labels):
+            raise AssertionError("The number of prompt coordinates and labels must match.")
+        if len(points):
+            point_arrays.append(points)
+            label_arrays.append(labels)
+    if not point_arrays:
+        return np.empty((0, 2), dtype="float64"), np.empty((0,), dtype="int64")
+    return np.concatenate(point_arrays), np.concatenate(label_arrays)
+
+
 def shape_layer_to_prompts(
     layer: napari.layers.Shapes, shape: Tuple[int, int], i=None, track_id=None
 ) -> Tuple[List[np.ndarray], List[Optional[np.ndarray]]]:
@@ -268,6 +518,9 @@ def shape_layer_to_prompts(
                 mask = np.zeros(shape, dtype=bool)
                 mask[rr, cc] = 1
                 masks.append(mask)
+
+            elif type_ in SCRIBBLE_SHAPE_TYPES:
+                continue
 
             else:
                 warnings.warn(f"Shape type {type_} is not supported and will be ignored.")
@@ -381,6 +634,7 @@ def segment_slices_with_prompts(
     z_values = np.round(point_prompts.data[:, 0])
     z_values_boxes = np.concatenate([box[:1, 0] for box in box_prompts.data]) if box_prompts.data else\
         np.zeros(0, dtype="int")
+    z_values_scribbles = get_scribble_slices(box_prompts) if track_id is None else np.zeros(0, dtype="int")
 
     if track_id is not None:
         track_ids_points = np.array(list(map(int, point_prompts.properties["track_id"])))
@@ -392,7 +646,7 @@ def segment_slices_with_prompts(
             assert len(track_ids_boxes) == len(z_values_boxes), f"{len(track_ids_boxes)}, {len(z_values_boxes)}"
             z_values_boxes = z_values_boxes[track_ids_boxes == track_id]
 
-    slices = np.unique(np.concatenate([z_values, z_values_boxes])).astype("int")
+    slices = np.unique(np.concatenate([z_values, z_values_boxes, z_values_scribbles])).astype("int")
     stop_lower, stop_upper = False, False
 
     if update_progress is None:
@@ -400,7 +654,13 @@ def segment_slices_with_prompts(
             pass
 
     for i in slices:
-        points_i = point_layer_to_prompts(point_prompts, i, track_id)
+        scribble_points, scribble_labels = scribble_layer_to_prompts(
+            box_prompts, image_shape=image_shape, i=i
+        )
+        have_scribbles = len(scribble_points) > 0
+        points_i = point_layer_to_prompts(
+            point_prompts, i, track_id, with_stop_annotation=not have_scribbles
+        )
 
         # do we end the segmentation at the outer slices?
         if points_i is None:
@@ -423,7 +683,16 @@ def segment_slices_with_prompts(
             continue
 
         boxes, masks = shape_layer_to_prompts(box_prompts, image_shape, i=i, track_id=track_id)
-        points, labels = points_i
+        points, labels = merge_point_prompts(points_i, (scribble_points, scribble_labels))
+        if have_scribbles and not boxes and not np.any(labels == 1):
+            warnings.warn(
+                f"Ignoring negative-only scribbles on slice {i}: add a positive point, scribble, "
+                "box or mask prompt on the same slice.",
+                stacklevel=2,
+            )
+            slices = np.setdiff1d(slices, i)
+            update_progress(1)
+            continue
 
         seg_i = prompt_segmentation(
             predictor, points, labels, boxes, masks, image_shape, multiple_box_prompts=False,

--- a/micro_sam/sam_annotator/util.py
+++ b/micro_sam/sam_annotator/util.py
@@ -133,6 +133,16 @@ def set_prompt_label(layer, new_label):
     the selected open shapes here keeps changing the prompt menu or pressing ``T`` consistent for
     both layer types, including immediately after drawing a path, polyline or line.
     """
+    if isinstance(layer, napari.layers.Shapes):
+        # Napari may briefly retain a selected shape index after the corresponding geometry and
+        # feature row have been removed. Setting current_properties in that state tries to update a
+        # missing pandas row. Drop these stale indices before applying the new drawing label.
+        valid_selection = {
+            index for index in layer.selected_data if 0 <= index < len(layer.data)
+        }
+        if valid_selection != layer.selected_data:
+            layer.selected_data = valid_selection
+
     current_properties = layer.current_properties
     current_properties["label"] = np.array([new_label])
     layer.current_properties = current_properties
@@ -310,8 +320,8 @@ def point_layer_to_prompts(
     return this_points, this_labels
 
 
-def _resample_scribble(vertices, image_shape, spacing, max_points):
-    """Resample an open stroke uniformly in SAM's normalized input coordinate system."""
+def _scribble_geometry(vertices, image_shape, spacing):
+    """Return normalized stroke geometry and bend information for adaptive sampling."""
     vertices = np.asarray(vertices, dtype="float64")
     if vertices.ndim != 2 or vertices.shape[1] != 2 or len(vertices) == 0:
         raise ValueError("A scribble must have shape (N, 2) with at least one vertex.")
@@ -323,21 +333,154 @@ def _resample_scribble(vertices, image_shape, spacing, max_points):
     # SAM2 embeds prompts in a square 1024-pixel input frame. Measuring the stroke there makes the
     # sampling density independent of the source image resolution and aspect ratio.
     model_vertices = vertices * (1024.0 / image_shape)
-    if len(model_vertices) == 1:
-        return vertices.copy()
+
+    # Remove consecutive duplicate vertices before measuring length or curvature. Freehand paths
+    # may contain these when the mouse briefly stops moving.
+    if len(model_vertices) > 1:
+        keep = np.concatenate([[True], np.linalg.norm(np.diff(model_vertices, axis=0), axis=1) > 0])
+        model_vertices = model_vertices[keep]
 
     segment_lengths = np.linalg.norm(np.diff(model_vertices, axis=0), axis=1)
     cumulative = np.concatenate([[0.0], np.cumsum(segment_lengths)])
-    total_length = cumulative[-1]
-    if total_length == 0:
-        return vertices[:1].copy()
+    total_length = float(cumulative[-1])
 
-    n_points = min(max_points, max(2, int(np.ceil(total_length / spacing)) + 1))
-    sample_distances = np.linspace(0.0, total_length, n_points)
+    # Ramer-Douglas-Peucker simplification removes freehand jitter before curvature is measured.
+    # The retained inner vertices are meaningful bends that we try to preserve in the samples.
+    bend_indices = np.empty((0,), dtype="int64")
+    bend_angles = np.empty((0,), dtype="float64")
+    if len(model_vertices) > 2 and total_length > 0:
+        tolerance = spacing / 4.0
+        retained = {0, len(model_vertices) - 1}
+        pending = [(0, len(model_vertices) - 1)]
+        while pending:
+            start, stop = pending.pop()
+            if stop <= start + 1:
+                continue
+            start_point, stop_point = model_vertices[start], model_vertices[stop]
+            direction = stop_point - start_point
+            relative = model_vertices[start + 1:stop] - start_point
+            length_squared = float(np.dot(direction, direction))
+            if length_squared == 0:
+                distances = np.linalg.norm(relative, axis=1)
+            else:
+                fractions = np.clip(relative @ direction / length_squared, 0.0, 1.0)
+                projections = start_point + fractions[:, None] * direction
+                distances = np.linalg.norm(model_vertices[start + 1:stop] - projections, axis=1)
+            split = int(np.argmax(distances)) + start + 1
+            if distances[split - start - 1] > tolerance:
+                retained.add(split)
+                pending.extend([(start, split), (split, stop)])
+
+        retained = np.asarray(sorted(retained), dtype="int64")
+        simplified = model_vertices[retained]
+        if len(simplified) > 2:
+            incoming = simplified[1:-1] - simplified[:-2]
+            outgoing = simplified[2:] - simplified[1:-1]
+            cosine = np.sum(incoming * outgoing, axis=1) / (
+                np.linalg.norm(incoming, axis=1) * np.linalg.norm(outgoing, axis=1)
+            )
+            bend_indices = retained[1:-1]
+            bend_angles = np.arccos(np.clip(cosine, -1.0, 1.0))
+
+    return model_vertices, image_shape, cumulative, total_length, bend_indices, bend_angles
+
+
+def _scribble_sample_count(vertices, image_shape, spacing):
+    """Determine the sample demand from a stroke's length and simplified curvature."""
+    geometry = _scribble_geometry(vertices, image_shape, spacing)
+    total_length, bend_angles = geometry[3], geometry[5]
+    if total_length == 0:
+        return 1, total_length
+
+    length_samples = max(2, int(np.ceil(total_length / spacing)) + 1)
+    # Add one sample per 90 degrees of accumulated, de-jittered turning. This gives compact curved
+    # strokes more representation without letting every raw freehand vertex consume the budget.
+    curvature_samples = int(np.ceil(bend_angles.sum() / (np.pi / 2.0))) if len(bend_angles) else 0
+    return length_samples + curvature_samples, total_length
+
+
+def _allocate_scribble_samples(desired_counts, lengths, max_points):
+    """Share a global sample budget fairly, favouring strokes with greater demand."""
+    desired_counts = np.asarray(desired_counts, dtype="int64")
+    lengths = np.asarray(lengths, dtype="float64")
+    if len(desired_counts) == 0:
+        return desired_counts
+
+    # Every stroke must influence the prediction. If there are more strokes than the configured
+    # budget, expand it just enough to retain one representative point from each instead of
+    # silently dropping annotations.
+    budget = max(int(max_points), len(desired_counts))
+    if desired_counts.sum() <= budget:
+        return desired_counts
+
+    allocated = np.ones_like(desired_counts)
+    remaining = budget - len(allocated)
+
+    # Preserve both endpoints where the budget permits, prioritizing longer strokes if it does not.
+    endpoint_candidates = np.flatnonzero(desired_counts > 1)
+    endpoint_candidates = endpoint_candidates[np.argsort(-lengths[endpoint_candidates], kind="stable")]
+    n_endpoints = min(remaining, len(endpoint_candidates))
+    allocated[endpoint_candidates[:n_endpoints]] += 1
+    remaining -= n_endpoints
+    if remaining == 0:
+        return allocated
+
+    # Allocate the rest proportionally to each stroke's unmet length/curvature demand. Largest
+    # remainders make the result deterministic while using the complete budget.
+    demand = desired_counts - allocated
+    quotas = remaining * demand / demand.sum()
+    additions = np.floor(quotas).astype("int64")
+    allocated += additions
+    remaining -= int(additions.sum())
+    if remaining:
+        residual = quotas - additions
+        candidates = np.flatnonzero(demand > additions)
+        candidates = candidates[np.argsort(-residual[candidates], kind="stable")]
+        allocated[candidates[:remaining]] += 1
+    return allocated
+
+
+def _resample_scribble(vertices, image_shape, spacing, n_points):
+    """Resample one stroke while preserving endpoints and its strongest bends."""
+    model_vertices, image_shape, cumulative, total_length, bend_indices, bend_angles = (
+        _scribble_geometry(vertices, image_shape, spacing)
+    )
+    if total_length == 0:
+        return model_vertices[:1] * (image_shape / 1024.0)
+    if n_points == 1:
+        sample_distances = np.array([total_length / 2.0])
+    else:
+        n_bends = min(max(0, n_points - 2), len(bend_indices))
+        if n_bends:
+            strongest = np.argsort(-bend_angles, kind="stable")[:n_bends]
+            mandatory = np.concatenate([[0.0], cumulative[bend_indices[strongest]], [total_length]])
+            mandatory = np.unique(mandatory)
+        else:
+            mandatory = np.array([0.0, total_length])
+
+        n_extra = n_points - len(mandatory)
+        if n_extra > 0:
+            interval_lengths = np.diff(mandatory)
+            quotas = n_extra * interval_lengths / total_length
+            per_interval = np.floor(quotas).astype("int64")
+            remainder = n_extra - int(per_interval.sum())
+            if remainder:
+                order = np.argsort(-(quotas - per_interval), kind="stable")
+                per_interval[order[:remainder]] += 1
+
+            extra_distances = []
+            for start, stop, count in zip(mandatory[:-1], mandatory[1:], per_interval):
+                if count:
+                    extra_distances.extend(np.linspace(start, stop, count + 2)[1:-1])
+            sample_distances = np.sort(np.concatenate([mandatory, extra_distances]))
+        else:
+            sample_distances = mandatory
+
     segment_ids = np.searchsorted(cumulative, sample_distances, side="right") - 1
-    segment_ids = np.clip(segment_ids, 0, len(segment_lengths) - 1)
+    segment_ids = np.clip(segment_ids, 0, len(model_vertices) - 2)
 
     local_lengths = sample_distances - cumulative[segment_ids]
+    segment_lengths = np.diff(cumulative)
     fractions = np.divide(
         local_lengths,
         segment_lengths[segment_ids],
@@ -355,29 +498,42 @@ def scribble_layer_to_prompts(
     image_shape: Tuple[int, int],
     i=None,
     spacing: float = 32.0,
-    max_points_per_stroke: int = 16,
+    max_points_per_stroke: Optional[int] = None,
+    max_points: int = 64,
+    deduplication_distance: float = 4.0,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Convert positive/negative open strokes into sparse SAM point prompts.
 
     Napari stores both its freehand path and click-defined polyline tools as ``path`` shapes; a
     two-vertex stroke is stored as ``line``. Each accepted stroke is resampled uniformly by arc
-    length in SAM's normalized 1024-pixel input space. This keeps prompt density stable across
-    source resolutions while limiting the number of sparse prompt tokens generated by long strokes.
+    length in SAM's normalized 1024-pixel input space. A global prompt budget is shared according
+    to stroke length and simplified curvature, and nearby same-label samples from overlapping
+    strokes are collapsed. This keeps prompt density stable across source resolutions without
+    undersampling every long stroke at the same per-stroke cutoff.
 
     Args:
         layer: The shared ``prompts`` Shapes layer. Non-scribble shapes are ignored.
         image_shape: The ``(height, width)`` of the image or volume slice.
         i: Slice index for a 3D layer. Must be omitted for a 2D layer.
         spacing: Approximate spacing between samples in SAM's 1024-pixel input space.
-        max_points_per_stroke: Maximum number of point prompts generated per stroke.
+        max_points_per_stroke: Optional compatibility cap for each stroke. By default there is no
+            per-stroke cap and ``max_points`` governs all strokes together.
+        max_points: Target maximum number of samples across all accepted scribbles. If there are
+            more strokes than this limit, it expands to retain one representative per stroke.
+        deduplication_distance: Distance in normalized model pixels below which samples from
+            overlapping strokes with the same label are considered duplicates.
 
     Returns:
         Sampled coordinates in ``(y, x)`` order and SAM labels (positive ``1``, negative ``0``).
     """
     if spacing <= 0:
         raise ValueError("'spacing' must be positive.")
-    if max_points_per_stroke <= 0:
+    if max_points_per_stroke is not None and max_points_per_stroke <= 0:
         raise ValueError("'max_points_per_stroke' must be positive.")
+    if max_points <= 0:
+        raise ValueError("'max_points' must be positive.")
+    if deduplication_distance < 0:
+        raise ValueError("'deduplication_distance' must be non-negative.")
 
     shape_data = layer.data
     shape_types = layer.shape_type
@@ -385,8 +541,7 @@ def scribble_layer_to_prompts(
     if not (len(shape_data) == len(shape_types) == len(stroke_labels)):
         raise AssertionError("Scribble shapes, shape types and labels must have matching lengths.")
 
-    points, labels = [], []
-    seen = set()
+    strokes = []
     for vertices, shape_type, stroke_label in zip(shape_data, shape_types, stroke_labels):
         if shape_type in ("rectangle", "ellipse", "polygon"):
             continue
@@ -416,22 +571,42 @@ def scribble_layer_to_prompts(
                 continue
             vertices_yx = vertices[:, 1:]
 
+        desired_count, length = _scribble_sample_count(vertices_yx, image_shape, spacing)
+        if max_points_per_stroke is not None:
+            desired_count = min(desired_count, max_points_per_stroke)
+        strokes.append((vertices_yx, stroke_label, desired_count, length))
+
+    if not strokes:
+        return np.empty((0, 2), dtype="float64"), np.empty((0,), dtype="int64")
+
+    sample_counts = _allocate_scribble_samples(
+        [stroke[2] for stroke in strokes], [stroke[3] for stroke in strokes], max_points
+    )
+    image_shape_array = np.asarray(image_shape, dtype="float64")
+    points, labels = [], []
+    previous_model_points = {0: [], 1: []}
+    for (vertices_yx, stroke_label, _, _), sample_count in zip(strokes, sample_counts):
         sampled = _resample_scribble(
-            vertices_yx, image_shape=image_shape, spacing=spacing, max_points=max_points_per_stroke
+            vertices_yx, image_shape=image_shape, spacing=spacing, n_points=sample_count
         )
         sam_label = 1 if stroke_label == "positive" else 0
+        current_model_points = []
         for point in sampled:
-            # Deduplicate at image-pixel resolution while retaining opposite-label conflicts so they
-            # remain visible to the caller instead of silently changing the user's annotation.
-            signature = (int(round(point[0])), int(round(point[1])), sam_label)
-            if signature in seen:
+            model_point = point * (1024.0 / image_shape_array)
+            # Deduplicate only against earlier strokes so both endpoints of a very short individual
+            # stroke survive. Opposite-label conflicts are intentionally retained.
+            previous = previous_model_points[sam_label]
+            if previous and np.min(np.linalg.norm(np.asarray(previous) - model_point, axis=1)) <= deduplication_distance:
                 continue
-            seen.add(signature)
+            if current_model_points and np.min(
+                np.linalg.norm(np.asarray(current_model_points) - model_point, axis=1)
+            ) == 0:
+                continue
+            current_model_points.append(model_point)
             points.append(point)
             labels.append(sam_label)
+        previous_model_points[sam_label].extend(current_model_points)
 
-    if not points:
-        return np.empty((0, 2), dtype="float64"), np.empty((0,), dtype="int64")
     return np.asarray(points), np.asarray(labels, dtype="int64")
 
 

--- a/test/test_sam_annotator/test_annotator.py
+++ b/test/test_sam_annotator/test_annotator.py
@@ -274,6 +274,50 @@ class TestAnnotatorClass:
 
         viewer.close()
 
+    @pytest.mark.parametrize("ndim", [2, 3])
+    def test_batched_checkbox_disabled_with_scribbles(self, make_napari_viewer_proxy, ndim):
+        """Batched mode is unavailable exactly while the prompt layer contains a scribble."""
+        from micro_sam.sam_annotator._state import AnnotatorState
+
+        image = binary_blobs(256) if ndim == 2 else np.stack(4 * [binary_blobs(256)])
+        shape = (256, 256) if ndim == 2 else (4, 256, 256)
+        scribble = (
+            np.array([[1, 1], [7, 7]])
+            if ndim == 2 else np.array([[1, 1, 1], [1, 7, 7]])
+        )
+
+        viewer = make_napari_viewer_proxy()
+        viewer.add_image(image, name="image")
+        widget = Annotator(viewer)
+        interactive = widget._widgets["interactive"]
+        prompt_layer = viewer.layers["prompts"]
+
+        # Start in the normal, non-tiled state and enable batched mode.
+        AnnotatorState().image_embeddings = {
+            "input_size": (256, 256), "original_size": shape, "features": None,
+        }
+        interactive._update_batched_visibility()
+        assert interactive.batched_checkbox.isEnabled()
+        normal_tooltip = interactive.batched_checkbox.toolTip()
+        interactive.batched_checkbox.setChecked(True)
+
+        # Adding a scribble immediately resets and disables batched mode.
+        prompt_layer.add_paths(scribble)
+        assert not interactive.batched_checkbox.isChecked()
+        assert not interactive.batched_checkbox.isEnabled()
+        assert not interactive.batched
+        assert "unavailable while scribble prompts are present" in interactive.batched_checkbox.toolTip()
+        if ndim == 3:
+            assert not interactive._segment_widget.batched
+
+        # Removing the last scribble restores normal batched availability.
+        prompt_layer.selected_data = {0}
+        prompt_layer.remove_selected()
+        assert interactive.batched_checkbox.isEnabled()
+        assert interactive.batched_checkbox.toolTip() == normal_tooltip
+
+        viewer.close()
+
 
 @pytest.mark.gui
 @pytest.mark.skipif(platform.system() in ("Windows",), reason="Gui test is not working on windows.")

--- a/test/test_sam_annotator/test_annotator.py
+++ b/test/test_sam_annotator/test_annotator.py
@@ -119,6 +119,30 @@ class TestAnnotatorClass:
         viewer = make_napari_viewer_proxy()
         widget = Annotator(viewer)
         assert widget._ndim == 2
+        assert "scribble_prompts" not in viewer.layers
+        assert viewer.layers["prompts"].ndim == 2
+        assert viewer.layers["prompts"].current_properties["label"][0] == "positive"
+        viewer.layers["prompts"].mode = "add_polyline"
+        toggle_binding = next(
+            callback for key, callback in viewer.layers["prompts"].keymap.items() if str(key) == "T"
+        )
+        toggle_binding(viewer.layers["prompts"])
+        assert widget._prompt_widget[0].value == "negative"
+        assert viewer.layers["point_prompts"].current_properties["label"][0] == "negative"
+        assert viewer.layers["prompts"].current_properties["label"][0] == "negative"
+        assert viewer.layers["prompts"].current_edge_color == "red"
+        toggle_binding(viewer.layers["prompts"])
+        assert widget._prompt_widget[0].value == "positive"
+        widget._prompt_widget[0].value = "negative"
+        assert viewer.layers["point_prompts"].current_properties["label"][0] == "negative"
+        assert viewer.layers["prompts"].current_properties["label"][0] == "negative"
+        assert viewer.layers["prompts"].current_edge_color == "red"
+        viewer.layers["prompts"].add_rectangles(np.array([[0, 0], [8, 8]]))
+        viewer.layers["prompts"].add_paths(np.array([[1, 1], [7, 7]]))
+        np.testing.assert_array_equal(viewer.layers["prompts"].properties["label"], ["positive", "negative"])
+        viewer.layers["prompts"].selected_data = {1}
+        widget._prompt_widget[0].value = "positive"
+        np.testing.assert_array_equal(viewer.layers["prompts"].properties["label"], ["positive", "positive"])
         viewer.close()
 
     def test_widget_detects_ndim_from_loaded_image(self, make_napari_viewer_proxy):
@@ -141,6 +165,7 @@ class TestAnnotatorClass:
         assert widget._ndim == 3
         # The prompt layers must be recreated with the new dimensionality.
         assert viewer.layers["point_prompts"].ndim == 3
+        assert viewer.layers["prompts"].ndim == 3
         viewer.close()
 
     def test_annotator_3d(self, make_napari_viewer_proxy):
@@ -283,6 +308,7 @@ class TestNdimOverride:
         assert viewer.layers["image"].rgb is True
         assert tuple(viewer.layers["image"].data.shape) == (64, 64, 3)
         assert viewer.layers["point_prompts"].ndim == 2
+        assert viewer.layers["prompts"].ndim == 2
         viewer.close()
 
     def test_channels_last_two_channel_auto(self, make_napari_viewer_proxy):

--- a/test/test_sam_annotator/test_scribble_prompts.py
+++ b/test/test_sam_annotator/test_scribble_prompts.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 from napari.layers import Points, Shapes
 
 from micro_sam.sam_annotator import util as annotator_util
@@ -640,5 +641,76 @@ def test_2d_segmentation_merges_scribbles_with_clicks(monkeypatch):
     assert captured["batched"] is False
     assert "not supported with scribble prompts" in captured["message"]
     assert converted_layers == {"shape": prompt_layer, "scribble": prompt_layer}
+    np.testing.assert_array_equal(current_object.data, 1)
+    assert current_object.refresh_count == 1
+
+
+@pytest.mark.parametrize("is_sam2", [False, True])
+def test_point_and_box_only_segmentation_is_unchanged(monkeypatch, is_sam2):
+    """The scribble integration must be a no-op for the existing point/box-only workflow."""
+    from micro_sam.sam_annotator import _widgets
+    from micro_sam.v2 import prompt_based_segmentation
+
+    class _Layer:
+        def __init__(self, data):
+            self.data = data
+            self.refresh_count = 0
+
+        def refresh(self):
+            self.refresh_count += 1
+
+    current_object = _Layer(np.zeros((32, 32), dtype="uint32"))
+    prompt_layer = _Layer([np.array([[2, 3], [20, 21]])])
+    point_layer = _Layer(np.array([[7.0, 8.0]]))
+    viewer = SimpleNamespace(layers={
+        "current_object": current_object,
+        "prompts": prompt_layer,
+        "point_prompts": point_layer,
+    })
+    state = SimpleNamespace(
+        predictor=object(), image_embeddings={"input_size": (1024, 1024)}, is_sam2=is_sam2,
+    )
+    boxes = np.array([[2.0, 3.0, 20.0, 21.0]])
+    points = np.array([[7.0, 8.0]])
+    labels = np.array([1])
+
+    monkeypatch.setattr(_widgets, "_validate_embeddings", lambda viewer: False)
+    monkeypatch.setattr(_widgets, "_validate_layers", lambda viewer: False)
+    monkeypatch.setattr(_widgets, "AnnotatorState", lambda: state)
+    monkeypatch.setattr(
+        _widgets.vutil, "shape_layer_to_prompts", lambda layer, shape: (boxes, [None]),
+    )
+    monkeypatch.setattr(
+        _widgets.vutil, "point_layer_to_prompts",
+        lambda layer, with_stop_annotation: (points, labels),
+    )
+    monkeypatch.setattr(
+        _widgets.vutil, "scribble_layer_to_prompts",
+        lambda layer, image_shape: (np.empty((0, 2)), np.empty((0,), dtype="int64")),
+    )
+    captured = {}
+
+    if is_sam2:
+        def _predict(**kwargs):
+            captured.update(kwargs)
+            return np.ones((32, 32), dtype="uint8")
+
+        monkeypatch.setattr(prompt_based_segmentation, "promptable_segmentation_2d", _predict)
+    else:
+        def _predict(predictor, points, labels, boxes, masks, shape, **kwargs):
+            captured.update(
+                points=points, labels=labels, boxes=boxes, masks=masks, shape=shape, **kwargs
+            )
+            return np.ones(shape, dtype="uint8")
+
+        monkeypatch.setattr(_widgets.vutil, "prompt_segmentation", _predict)
+
+    _widgets._segment_object_2d(viewer, batched=True)
+
+    np.testing.assert_array_equal(captured["points"], points)
+    np.testing.assert_array_equal(captured["labels"], labels)
+    np.testing.assert_array_equal(captured["boxes"], boxes)
+    assert captured["masks"] == [None]
+    assert captured["batched"] is True
     np.testing.assert_array_equal(current_object.data, 1)
     assert current_object.refresh_count == 1

--- a/test/test_sam_annotator/test_scribble_prompts.py
+++ b/test/test_sam_annotator/test_scribble_prompts.py
@@ -55,6 +55,88 @@ def test_scribble_sampling_is_resolution_independent_and_capped():
     np.testing.assert_allclose(low_points / 256.0, high_points / 2048.0)
 
 
+def test_scribble_sampling_shares_a_global_budget_by_demand():
+    layer = _PromptShapesLayer(
+        data=[
+            np.array([[0.0, 0.0], [0.0, 64.0]]),
+            np.array([[128.0, 0.0], [128.0, 256.0]]),
+            np.array([[256.0, 0.0], [256.0, 512.0]]),
+        ],
+        shape_type=["line", "line", "line"],
+        labels=["positive", "negative", "positive"],
+    )
+
+    points, _ = annotator_util.scribble_layer_to_prompts(
+        layer, image_shape=(1024, 1024), spacing=32.0, max_points=12
+    )
+
+    counts = [np.count_nonzero(points[:, 0] == row) for row in (0.0, 128.0, 256.0)]
+    assert counts == [2, 4, 6]
+    assert len(points) == 12
+
+
+def test_curved_scribble_gets_more_samples_and_preserves_bends():
+    layer = _PromptShapesLayer(
+        data=[
+            np.array([[0.0, 0.0], [0.0, 256.0]]),
+            np.array([[200.0, 0.0], [136.0, 0.0], [136.0, 128.0], [200.0, 128.0]]),
+        ],
+        shape_type=["line", "path"],
+        labels=["positive", "negative"],
+    )
+
+    points, labels = annotator_util.scribble_layer_to_prompts(
+        layer, image_shape=(1024, 1024), spacing=32.0
+    )
+
+    assert np.count_nonzero(labels == 0) > np.count_nonzero(labels == 1)
+    negative_points = points[labels == 0]
+    assert any(np.allclose(point, [136.0, 0.0]) for point in negative_points)
+    assert any(np.allclose(point, [136.0, 128.0]) for point in negative_points)
+
+
+def test_nearby_same_label_strokes_are_deduplicated_but_conflicts_remain():
+    same_label = _PromptShapesLayer(
+        data=[
+            np.array([[0.0, 0.0], [0.0, 64.0]]),
+            np.array([[2.0, 0.0], [2.0, 64.0]]),
+        ],
+        shape_type=["line", "line"],
+        labels=["positive", "positive"],
+    )
+    conflicting = _PromptShapesLayer(
+        data=same_label.data,
+        shape_type=same_label.shape_type,
+        labels=["positive", "negative"],
+    )
+
+    deduplicated, _ = annotator_util.scribble_layer_to_prompts(
+        same_label, image_shape=(1024, 1024), spacing=32.0, deduplication_distance=4.0
+    )
+    conflict_points, conflict_labels = annotator_util.scribble_layer_to_prompts(
+        conflicting, image_shape=(1024, 1024), spacing=32.0, deduplication_distance=4.0
+    )
+
+    assert len(deduplicated) == 3
+    assert len(conflict_points) == 6
+    np.testing.assert_array_equal(conflict_labels, [1, 1, 1, 0, 0, 0])
+
+
+def test_short_scribble_preserves_both_endpoints():
+    layer = _PromptShapesLayer(
+        data=[np.array([[10.0, 10.0], [10.0, 12.0]])],
+        shape_type=["line"],
+        labels=["positive"],
+    )
+
+    points, labels = annotator_util.scribble_layer_to_prompts(
+        layer, image_shape=(1024, 1024), spacing=32.0
+    )
+
+    np.testing.assert_allclose(points, [[10.0, 10.0], [10.0, 12.0]])
+    np.testing.assert_array_equal(labels, [1, 1])
+
+
 def test_scribbles_are_selected_per_volume_slice():
     layer = _PromptShapesLayer(
         data=[
@@ -229,6 +311,23 @@ def test_selected_scribble_is_relabelled_while_polyline_tool_is_active():
     np.testing.assert_allclose(layer.edge_color[0], [1, 0, 0, 1])
     _, labels = annotator_util.scribble_layer_to_prompts(layer, image_shape=(16, 16))
     np.testing.assert_array_equal(labels, np.zeros(len(labels), dtype="int64"))
+
+
+def test_prompt_label_change_drops_stale_shape_selection():
+    layer = Shapes(
+        ndim=3,
+        property_choices={"label": ["positive", "negative"]},
+        edge_color="label",
+        edge_color_cycle=annotator_util.LABEL_COLOR_CYCLE,
+    )
+    # Simulate the transient state seen after napari removes the final shape: geometry/features are
+    # already empty, while Selection has not emitted its clearing event yet.
+    layer._selected_data._data = {0: None}
+
+    annotator_util.set_prompt_label(layer, "negative")
+
+    assert layer.selected_data == set()
+    assert layer.current_properties["label"][0] == "negative"
 
 
 def test_merge_point_and_scribble_prompts():

--- a/test/test_sam_annotator/test_scribble_prompts.py
+++ b/test/test_sam_annotator/test_scribble_prompts.py
@@ -1,0 +1,545 @@
+from types import SimpleNamespace
+
+import numpy as np
+from napari.layers import Points, Shapes
+
+from micro_sam.sam_annotator import util as annotator_util
+
+
+class _PromptShapesLayer:
+    def __init__(self, data, shape_type, labels):
+        self.data = data
+        self.shape_type = shape_type
+        self.properties = {"label": np.asarray(labels)}
+
+
+def test_positive_and_negative_scribbles_are_resampled():
+    layer = _PromptShapesLayer(
+        data=[
+            np.array([[0.0, 0.0], [0.0, 64.0]]),
+            np.array([[0.0, 0.0], [32.0, 0.0]]),
+        ],
+        shape_type=["path", "line"],
+        labels=["positive", "negative"],
+    )
+
+    points, labels = annotator_util.scribble_layer_to_prompts(
+        layer, image_shape=(256, 256), spacing=64.0
+    )
+
+    np.testing.assert_allclose(points[:5], [[0, 0], [0, 16], [0, 32], [0, 48], [0, 64]])
+    np.testing.assert_allclose(points[5:], [[0, 0], [16, 0], [32, 0]])
+    np.testing.assert_array_equal(labels, [1, 1, 1, 1, 1, 0, 0, 0])
+
+
+def test_scribble_sampling_is_resolution_independent_and_capped():
+    low_res = _PromptShapesLayer(
+        data=[np.array([[0.0, 0.0], [0.0, 256.0]])],
+        shape_type=["path"],
+        labels=["positive"],
+    )
+    high_res = _PromptShapesLayer(
+        data=[np.array([[0.0, 0.0], [0.0, 2048.0]])],
+        shape_type=["path"],
+        labels=["positive"],
+    )
+
+    low_points, _ = annotator_util.scribble_layer_to_prompts(
+        low_res, image_shape=(256, 256), spacing=32.0, max_points_per_stroke=8
+    )
+    high_points, _ = annotator_util.scribble_layer_to_prompts(
+        high_res, image_shape=(2048, 2048), spacing=32.0, max_points_per_stroke=8
+    )
+
+    assert len(low_points) == len(high_points) == 8
+    np.testing.assert_allclose(low_points / 256.0, high_points / 2048.0)
+
+
+def test_scribbles_are_selected_per_volume_slice():
+    layer = _PromptShapesLayer(
+        data=[
+            np.array([[2.0, 0.0, 0.0], [2.0, 0.0, 64.0]]),
+            np.array([[3.0, 0.0, 0.0], [3.0, 64.0, 0.0]]),
+        ],
+        shape_type=["path", "path"],
+        labels=["positive", "negative"],
+    )
+
+    points, labels = annotator_util.scribble_layer_to_prompts(
+        layer, image_shape=(256, 256), i=3, spacing=64.0
+    )
+
+    np.testing.assert_allclose(points, [[0, 0], [16, 0], [32, 0], [48, 0], [64, 0]])
+    np.testing.assert_array_equal(labels, np.zeros(5, dtype="int64"))
+
+
+def test_closed_shape_in_shared_prompt_layer_is_ignored_by_scribble_converter():
+    layer = _PromptShapesLayer(
+        data=[np.array([[0.0, 0.0], [0.0, 8.0], [8.0, 8.0]])],
+        shape_type=["polygon"],
+        labels=["positive"],
+    )
+
+    points, labels = annotator_util.scribble_layer_to_prompts(layer, image_shape=(16, 16))
+
+    assert points.shape == (0, 2)
+    assert labels.shape == (0,)
+
+
+def test_shared_layer_routes_closed_and_open_shapes_separately():
+    layer = _PromptShapesLayer(
+        data=[
+            np.array([[1.0, 1.0], [1.0, 8.0], [8.0, 8.0], [8.0, 1.0]]),
+            np.array([[2.0, 2.0], [12.0, 12.0]]),
+        ],
+        shape_type=["rectangle", "path"],
+        labels=["positive", "negative"],
+    )
+
+    boxes, masks = annotator_util.shape_layer_to_prompts(layer, shape=(16, 16))
+    points, labels = annotator_util.scribble_layer_to_prompts(
+        layer, image_shape=(16, 16), spacing=128.0
+    )
+
+    assert len(boxes) == len(masks) == 1
+    np.testing.assert_array_equal(boxes[0], [1, 1, 8, 8])
+    assert masks[0] is None
+    assert len(points) > 1
+    np.testing.assert_array_equal(labels, np.zeros(len(points), dtype="int64"))
+
+
+def test_existing_point_and_box_prompt_conversion_in_2d_and_3d():
+    point_layer_2d = Points(
+        data=np.array([[2.0, 3.0], [4.0, 5.0]]),
+        properties={"label": np.array(["positive", "negative"])},
+    )
+    points, labels = annotator_util.point_layer_to_prompts(
+        point_layer_2d, with_stop_annotation=False
+    )
+    np.testing.assert_array_equal(points, [[2.0, 3.0], [4.0, 5.0]])
+    np.testing.assert_array_equal(labels, [1, 0])
+
+    shape_layer_2d = Shapes(
+        data=[np.array([[1.0, 2.0], [1.0, 8.0], [7.0, 8.0], [7.0, 2.0]])],
+        shape_type=["rectangle"],
+    )
+    boxes, masks = annotator_util.shape_layer_to_prompts(shape_layer_2d, shape=(16, 16))
+    np.testing.assert_array_equal(boxes, [[1.0, 2.0, 7.0, 8.0]])
+    assert masks == [None]
+
+    point_layer_3d = Points(
+        data=np.array([[0.0, 1.0, 2.0], [1.0, 3.0, 4.0], [1.0, 5.0, 6.0]]),
+        properties={"label": np.array(["negative", "positive", "negative"])},
+    )
+    points, labels = annotator_util.point_layer_to_prompts(
+        point_layer_3d, i=1, with_stop_annotation=False
+    )
+    np.testing.assert_array_equal(points, [[3.0, 4.0], [5.0, 6.0]])
+    np.testing.assert_array_equal(labels, [1, 0])
+
+    shape_layer_3d = Shapes(
+        data=[
+            np.array(
+                [[1.0, 2.0, 3.0], [1.0, 2.0, 8.0], [1.0, 7.0, 8.0], [1.0, 7.0, 3.0]]
+            )
+        ],
+        shape_type=["rectangle"],
+    )
+    boxes, masks = annotator_util.shape_layer_to_prompts(shape_layer_3d, shape=(16, 16), i=1)
+    np.testing.assert_array_equal(boxes, [[2.0, 3.0, 7.0, 8.0]])
+    assert masks == [None]
+
+
+def test_clear_slice_keeps_shape_properties_aligned():
+    point_layer = Points(
+        data=np.array([[1.0, 3.0, 4.0], [2.0, 5.0, 6.0]]),
+        properties={"label": np.array(["negative", "positive"])},
+    )
+    prompt_layer = Shapes(
+        data=[
+            np.array([[1.0, 2.0, 2.0], [1.0, 8.0, 8.0]]),
+            np.array(
+                [[2.0, 2.0, 3.0], [2.0, 2.0, 8.0], [2.0, 7.0, 8.0], [2.0, 7.0, 3.0]]
+            ),
+        ],
+        shape_type=["path", "rectangle"],
+        properties={"label": np.array(["negative", "positive"])},
+    )
+    viewer = SimpleNamespace(layers={"point_prompts": point_layer, "prompts": prompt_layer})
+
+    annotator_util.clear_annotations_slice(viewer, i=1, clear_segmentations=False)
+
+    np.testing.assert_array_equal(point_layer.data, [[2.0, 5.0, 6.0]])
+    assert prompt_layer.shape_type == ["rectangle"]
+    np.testing.assert_array_equal(prompt_layer.properties["label"], ["positive"])
+
+
+def test_closed_shapes_stay_green_while_negative_scribbles_are_red():
+    layer = Shapes(
+        ndim=2,
+        property_choices={"label": ["positive", "negative"]},
+        edge_color="label",
+        edge_color_cycle=annotator_util.LABEL_COLOR_CYCLE,
+    )
+    layer.edge_color_mode = "cycle"
+    current_properties = layer.current_properties
+    current_properties["label"] = np.array(["negative"])
+    layer.current_properties = current_properties
+    layer.mode = "add_polyline"
+    annotator_util.sync_prompt_shape_current_color(layer)
+    assert layer.current_edge_color == "red"
+
+    layer.add_rectangles(np.array([[1, 1], [8, 8]]))
+    annotator_util.normalize_prompt_shape_labels(layer)
+    layer.add_paths(np.array([[2, 2], [12, 12]]))
+    annotator_util.normalize_prompt_shape_labels(layer)
+
+    np.testing.assert_array_equal(layer.properties["label"], ["positive", "negative"])
+    np.testing.assert_allclose(layer.edge_color[0], [0, 1, 0, 1])
+    np.testing.assert_allclose(layer.edge_color[1], [1, 0, 0, 1])
+    assert layer.current_properties["label"][0] == "negative"
+
+    points, labels = annotator_util.scribble_layer_to_prompts(layer, image_shape=(16, 16))
+    assert len(points) > 0
+    np.testing.assert_array_equal(labels, np.zeros(len(points), dtype="int64"))
+
+
+def test_selected_scribble_is_relabelled_while_polyline_tool_is_active():
+    layer = Shapes(
+        ndim=2,
+        property_choices={"label": ["positive", "negative"]},
+        edge_color="label",
+        edge_color_cycle=annotator_util.LABEL_COLOR_CYCLE,
+    )
+    layer.edge_color_mode = "cycle"
+    annotator_util.set_prompt_label(layer, "negative")
+    layer.add_paths(np.array([[2.0, 2.0], [12.0, 12.0]]))
+    layer.mode = "add_polyline"
+    layer.selected_data = {0}
+
+    annotator_util.set_prompt_label(layer, "positive")
+    assert layer.current_properties["label"][0] == "positive"
+    assert layer.properties["label"][0] == "positive"
+    np.testing.assert_allclose(layer.edge_color[0], [0, 1, 0, 1])
+    _, labels = annotator_util.scribble_layer_to_prompts(layer, image_shape=(16, 16))
+    np.testing.assert_array_equal(labels, np.ones(len(labels), dtype="int64"))
+
+    annotator_util.set_prompt_label(layer, "negative")
+    assert layer.properties["label"][0] == "negative"
+    np.testing.assert_allclose(layer.edge_color[0], [1, 0, 0, 1])
+    _, labels = annotator_util.scribble_layer_to_prompts(layer, image_shape=(16, 16))
+    np.testing.assert_array_equal(labels, np.zeros(len(labels), dtype="int64"))
+
+
+def test_merge_point_and_scribble_prompts():
+    points, labels = annotator_util.merge_point_prompts(
+        (np.array([[4, 5]]), np.array([1])),
+        (np.array([[8, 9], [10, 11]]), np.array([1, 0])),
+    )
+
+    np.testing.assert_array_equal(points, [[4, 5], [8, 9], [10, 11]])
+    np.testing.assert_array_equal(labels, [1, 1, 0])
+
+
+def test_volume_scribbles_pass_layer_validation(monkeypatch):
+    from micro_sam.sam_annotator import _widgets
+
+    prompt_layer = _PromptShapesLayer(
+        data=[np.array([[2, 2, 2], [2, 8, 8]])],
+        shape_type=["path"],
+        labels=["positive"],
+    )
+    viewer = SimpleNamespace(layers={
+        "current_object": SimpleNamespace(data=np.zeros((4, 16, 16), dtype="uint32")),
+        "prompts": prompt_layer,
+        "point_prompts": SimpleNamespace(data=[]),
+    })
+    annotator = SimpleNamespace(_require_layers=lambda: None)
+    monkeypatch.setattr(_widgets, "AnnotatorState", lambda: SimpleNamespace(annotator=annotator))
+    result = _widgets._validate_layers(viewer)
+
+    assert result is False
+
+
+def test_slice_segmentation_merges_3d_scribbles_with_points(monkeypatch):
+    from micro_sam.sam_annotator import _widgets
+
+    class _CurrentObject:
+        def __init__(self):
+            self.data = np.zeros((3, 32, 32), dtype="uint32")
+            self.refresh_count = 0
+
+        def refresh(self):
+            self.refresh_count += 1
+
+    class _Segmenter:
+        def __init__(self):
+            self.captured = None
+
+        def segment_slice(self, **kwargs):
+            self.captured = kwargs
+            return np.ones((32, 32), dtype="uint32")
+
+    current_object = _CurrentObject()
+    point_layer = Points(
+        data=np.array([[1.0, 3.0, 4.0]]),
+        properties={"label": np.array(["positive"])},
+    )
+    prompt_layer = Shapes(
+        data=[np.array([[1.0, 8.0, 8.0], [1.0, 16.0, 16.0]])],
+        shape_type=["path"],
+        properties={"label": np.array(["negative"])},
+    )
+    viewer = SimpleNamespace(
+        layers={
+            "current_object": current_object,
+            "point_prompts": point_layer,
+            "prompts": prompt_layer,
+        },
+        dims=SimpleNamespace(point=(1.0, 0.0, 0.0)),
+    )
+    segmenter = _Segmenter()
+    state = SimpleNamespace(
+        is_sam2=True,
+        image_embeddings={"input_size": (1024, 1024)},
+        interactive_segmenter=segmenter,
+    )
+    widget = SimpleNamespace(_viewer=viewer, batched=True)
+    messages = []
+    monkeypatch.setattr(_widgets, "AnnotatorState", lambda: state)
+    monkeypatch.setattr(_widgets, "show_info", messages.append)
+
+    _widgets.UnifiedSegmentWidget._run_slice_segmentation(widget)
+
+    captured = segmenter.captured
+    assert captured["frame_idx"] == 1
+    np.testing.assert_array_equal(captured["labels"][0], 1)
+    np.testing.assert_array_equal(captured["labels"][1:], 0)
+    np.testing.assert_array_equal(captured["points"][0], [4.0, 3.0])
+    assert captured["boxes"] == []
+    assert "not supported with scribble prompts" in messages[0]
+    np.testing.assert_array_equal(current_object.data[1], 1)
+    assert current_object.refresh_count == 1
+
+
+def test_sam2_volume_propagation_merges_3d_scribbles_points_and_boxes(monkeypatch):
+    from micro_sam.sam_annotator import _widgets
+
+    class _Signal:
+        def emit(self, *args):
+            pass
+
+    class _CurrentObject:
+        def __init__(self):
+            self.data = np.zeros((3, 32, 32), dtype="uint32")
+            self.refresh_count = 0
+
+        def refresh(self):
+            self.refresh_count += 1
+
+    class _Segmenter:
+        def __init__(self):
+            self.reset_count = 0
+            self.point_calls = []
+            self.box_calls = []
+
+        def reset_predictor(self):
+            self.reset_count += 1
+
+        def add_point_prompts(self, **kwargs):
+            self.point_calls.append(kwargs)
+
+        def add_box_prompts(self, **kwargs):
+            self.box_calls.append(kwargs)
+
+        def add_mask_prompts(self, **kwargs):
+            raise AssertionError("No mask prompt was expected.")
+
+        def get_progress_total(self, z_range):
+            return 3
+
+        def predict(self, **kwargs):
+            return np.ones((3, 32, 32), dtype="uint32")
+
+    current_object = _CurrentObject()
+    point_layer = Points(
+        data=np.array([[1.0, 3.0, 4.0]]),
+        properties={"label": np.array(["positive"])},
+    )
+    prompt_layer = Shapes(
+        data=[
+            np.array([[1.0, 8.0, 8.0], [1.0, 16.0, 16.0]]),
+            np.array(
+                [[2.0, 2.0, 3.0], [2.0, 2.0, 8.0], [2.0, 7.0, 8.0], [2.0, 7.0, 3.0]]
+            ),
+        ],
+        shape_type=["path", "rectangle"],
+        properties={"label": np.array(["negative", "positive"])},
+    )
+    viewer = SimpleNamespace(layers={
+        "current_object": current_object,
+        "point_prompts": point_layer,
+        "prompts": prompt_layer,
+    })
+    segmenter = _Segmenter()
+    state = SimpleNamespace(
+        is_sam2=True,
+        image_shape=(3, 32, 32),
+        image_embeddings={"input_size": (1024, 1024)},
+        interactive_segmenter=segmenter,
+    )
+    widget = SimpleNamespace(
+        _viewer=viewer,
+        batched=True,
+        early_stop_patience=0,
+        z_range=None,
+    )
+    signals = SimpleNamespace(
+        pbar_total=_Signal(),
+        pbar_description=_Signal(),
+        pbar_update=_Signal(),
+        pbar_stop=_Signal(),
+    )
+    messages = []
+    monkeypatch.setattr(_widgets, "AnnotatorState", lambda: state)
+    monkeypatch.setattr(_widgets, "_create_pbar_for_threadworker", lambda: (None, signals))
+    monkeypatch.setattr(_widgets, "show_info", messages.append)
+
+    _widgets.UnifiedSegmentWidget._run_volumetric_segmentation(widget)
+
+    assert segmenter.reset_count == 1
+    assert len(segmenter.box_calls) == 1
+    assert segmenter.box_calls[0]["frame_ids"] == 2
+    assert len(segmenter.point_calls) == 1
+    point_call = segmenter.point_calls[0]
+    assert point_call["frame_ids"] == 1
+    np.testing.assert_array_equal(point_call["point_labels"][0], 1)
+    np.testing.assert_array_equal(point_call["point_labels"][1:], 0)
+    assert point_call["object_id"] is None
+    assert "not supported with scribble prompts" in messages[0]
+    np.testing.assert_array_equal(current_object.data, 1)
+    assert current_object.refresh_count == 1
+
+
+def test_legacy_volume_segmentation_merges_slice_scribbles(monkeypatch):
+    point_layer = Points(ndim=3, properties={"label": np.empty((0,), dtype=str)})
+    prompt_layer = Shapes(
+        data=[np.array([[1.0, 4.0, 5.0], [1.0, 12.0, 13.0]])],
+        shape_type=["path"],
+        properties={"label": np.array(["positive"])},
+    )
+    captured = {}
+
+    def _prompt_segmentation(predictor, points, labels, boxes, masks, shape, **kwargs):
+        captured.update(points=points, labels=labels, boxes=boxes, masks=masks, shape=shape, kwargs=kwargs)
+        return np.ones(shape, dtype="uint32")
+
+    monkeypatch.setattr(annotator_util, "prompt_segmentation", _prompt_segmentation)
+
+    seg, slices, stop_lower, stop_upper = annotator_util.segment_slices_with_prompts(
+        predictor=object(),
+        point_prompts=point_layer,
+        box_prompts=prompt_layer,
+        image_embeddings=object(),
+        shape=(3, 32, 32),
+    )
+
+    np.testing.assert_array_equal(slices, [1])
+    assert stop_lower is False
+    assert stop_upper is False
+    assert len(captured["points"]) > 1
+    np.testing.assert_array_equal(captured["labels"], np.ones(len(captured["labels"]), dtype="int64"))
+    assert captured["boxes"] == []
+    np.testing.assert_array_equal(seg[1], 1)
+
+
+def test_negative_only_scribble_is_rejected_before_prediction(monkeypatch):
+    from micro_sam.sam_annotator import _widgets
+
+    prompt_layer = _PromptShapesLayer(
+        data=[np.array([[2.0, 2.0], [16.0, 16.0]])],
+        shape_type=["path"],
+        labels=["negative"],
+    )
+    viewer = SimpleNamespace(layers={
+        "current_object": SimpleNamespace(data=np.zeros((32, 32), dtype="uint32")),
+        "prompts": prompt_layer,
+        "point_prompts": SimpleNamespace(data=[]),
+    })
+    monkeypatch.setattr(_widgets, "_validate_embeddings", lambda viewer: False)
+    monkeypatch.setattr(_widgets, "_validate_layers", lambda viewer: False)
+    monkeypatch.setattr(
+        _widgets.vutil, "point_layer_to_prompts",
+        lambda layer, with_stop_annotation: (np.empty((0, 2)), np.empty((0,), dtype="int64")),
+    )
+    monkeypatch.setattr(_widgets, "_generate_message", lambda message_type, message: (message_type, message))
+
+    result = _widgets._segment_object_2d(viewer)
+
+    assert result == (
+        "error",
+        "A negative scribble needs a positive point, positive scribble, box or mask prompt.",
+    )
+
+
+def test_2d_segmentation_merges_scribbles_with_clicks(monkeypatch):
+    from micro_sam.sam_annotator import _widgets
+    from micro_sam.v2 import prompt_based_segmentation
+
+    class _Layer:
+        def __init__(self, data):
+            self.data = data
+            self.refresh_count = 0
+
+        def refresh(self):
+            self.refresh_count += 1
+
+    current_object = _Layer(np.zeros((32, 32), dtype="uint32"))
+    prompt_layer = _Layer([np.array([[2, 2], [20, 20]])])
+    viewer = SimpleNamespace(layers={
+        "current_object": current_object,
+        "prompts": prompt_layer,
+        "point_prompts": _Layer(np.empty((0, 2))),
+    })
+    state = SimpleNamespace(
+        predictor=object(), image_embeddings={"input_size": (1024, 1024)}, is_sam2=True,
+    )
+
+    monkeypatch.setattr(_widgets, "_validate_embeddings", lambda viewer: False)
+    monkeypatch.setattr(_widgets, "_validate_layers", lambda viewer: False)
+    monkeypatch.setattr(_widgets, "AnnotatorState", lambda: state)
+    converted_layers = {}
+
+    def _shape_prompts(layer, shape):
+        converted_layers["shape"] = layer
+        return [], []
+
+    monkeypatch.setattr(_widgets.vutil, "shape_layer_to_prompts", _shape_prompts)
+    monkeypatch.setattr(
+        _widgets.vutil, "point_layer_to_prompts",
+        lambda layer, with_stop_annotation: (np.array([[3.0, 4.0]]), np.array([1])),
+    )
+
+    def _scribble_prompts(layer, image_shape):
+        converted_layers["scribble"] = layer
+        return np.array([[8.0, 9.0], [10.0, 11.0]]), np.array([1, 0])
+
+    monkeypatch.setattr(_widgets.vutil, "scribble_layer_to_prompts", _scribble_prompts)
+    captured = {}
+
+    def _predict(**kwargs):
+        captured.update(kwargs)
+        return np.ones((32, 32), dtype="uint8")
+
+    monkeypatch.setattr(prompt_based_segmentation, "promptable_segmentation_2d", _predict)
+    monkeypatch.setattr(_widgets, "show_info", lambda message: captured.setdefault("message", message))
+
+    _widgets._segment_object_2d(viewer, batched=True)
+
+    np.testing.assert_array_equal(captured["points"], [[3, 4], [8, 9], [10, 11]])
+    np.testing.assert_array_equal(captured["labels"], [1, 1, 0])
+    assert captured["batched"] is False
+    assert "not supported with scribble prompts" in captured["message"]
+    assert converted_layers == {"shape": prompt_layer, "scribble": prompt_layer}
+    np.testing.assert_array_equal(current_object.data, 1)
+    assert current_object.refresh_count == 1


### PR DESCRIPTION
I thought of this idea a while ago and decided to implement this now. The cool part -- it helps with neuron segmentation and weird structures by like a freaking lot (which is very cool improvement to observe instead of putting tons of points around).

I need to make a few final tests before I merge this!

Could you give this a quick shot? @constantinpape 

PS. Use the "Add path" (or line / poyline) tool in layer controls for scribbles, a "T" keybinding to switch between positive and negative scribbles!