### PR TITLE
Fix SAM2 3d interactive segmentation on MPS

### DIFF
--- a/micro_sam/v2/models/_video_predictor.py
+++ b/micro_sam/v2/models/_video_predictor.py
@@ -258,14 +258,13 @@ class CustomVideoPredictor(SAM2VideoPredictor):
             if embeddings is None:
                 return super()._get_image_feature(inference_state, frame_idx, batch_size)
 
+            from micro_sam.v2.util import _to_device_tensor
             device = inference_state["device"]
             image = inference_state["images"][frame_idx].to(device).float().unsqueeze(0)
-            vision_pos_enc = [
-                torch.as_tensor(np.asarray(t[frame_idx]), device=device).float() for t in embeddings["pos_enc"]
-            ]
-            backbone_fpn = [
-                torch.as_tensor(np.asarray(t[frame_idx]), device=device).float() for t in embeddings["fpn"]
-            ]
+            # In-memory embeddings keep 'pos_enc'/'fpn' as device tensors, which 'np.asarray' cannot
+            # convert (fails on mps/cuda); '_to_device_tensor' handles both tensors and numpy/zarr.
+            vision_pos_enc = [_to_device_tensor(t[frame_idx], device) for t in embeddings["pos_enc"]]
+            backbone_fpn = [_to_device_tensor(t[frame_idx], device) for t in embeddings["fpn"]]
             backbone_out = {"backbone_fpn": backbone_fpn, "vision_pos_enc": vision_pos_enc}
             # Cache the few most recent frames (not just one) so repeatedly segmenting the same or a
             # nearby slice does not re-read the (possibly zarr-backed, tiled) embeddings and re-upload

--- a/micro_sam/v2/prompt_based_segmentation.py
+++ b/micro_sam/v2/prompt_based_segmentation.py
@@ -429,16 +429,20 @@ class PromptableSegmentation3D:
     """
     def __init__(
         self, predictor, volume, volume_embeddings, device=None,
-        offload_video_to_cpu=True, offload_state_to_cpu=True,
+        offload_video_to_cpu=None, offload_state_to_cpu=None,
     ):
+        from micro_sam.v2.util import _get_device
         self.predictor = predictor
         self.volume = volume
         self.volume_embeddings = volume_embeddings
-        # 'device=None' uses the predictor's auto-detected device. Offloading the frames and tracking
-        # state to CPU keeps GPU memory bounded for large volumes (a no-op when already on CPU).
+        # 'device=None' uses the predictor's auto-detected device.
         self.device = device
-        self.offload_video_to_cpu = offload_video_to_cpu
-        self.offload_state_to_cpu = offload_state_to_cpu
+        # Offloading frames/state to CPU bounds GPU memory for large volumes on CUDA. On MPS it is off
+        # by default: unified memory saves nothing, and SAM2's CPU->MPS 'non_blocking' transfer of the
+        # consolidated masks races, giving intermittent garbage/NaN masks (patchy interactive results).
+        is_mps = str(_get_device(device)) == "mps"
+        self.offload_video_to_cpu = (not is_mps) if offload_video_to_cpu is None else offload_video_to_cpu
+        self.offload_state_to_cpu = (not is_mps) if offload_state_to_cpu is None else offload_state_to_cpu
 
         if self.volume.ndim != 3:
             raise AssertionError(f"The dimensionality of the volume should be 3, got '{self.volume.ndim}'")

--- a/micro_sam/v2/util.py
+++ b/micro_sam/v2/util.py
@@ -461,7 +461,7 @@ def _compute_tiled_3d(input_, predictor, tile_shape, halo, f, save_path, pbar_in
 
         # Compute the per-slice video-style features for this tile-column (as in '_compute_3d').
         inference_state = predictor.init_state(
-            volume=sub_volume, volume_embeddings=None, ignore_caching_features=True,
+            volume=sub_volume, volume_embeddings=None, device=predictor.device, ignore_caching_features=True,
         )
         batched_images = [_to_image(sub_volume[z]) for z in range(n_slices)]
         vision_feats, pos_encs, fpns, original_sizes, input_sizes = _compute_embeddings_batched_3d(
@@ -599,9 +599,11 @@ def _compute_3d(input_, predictor, f, save_path, lazy_loading, pbar_init, pbar_u
             features = _create_dataset_without_data(f, "features", shape=shape, chunks=chunks, dtype="float32")
 
     # We create the 'inference_state' object which keeps all important components in memory.
+    # Pass the predictor's device so encoder inputs match the model when it is not the default device.
     inference_state = predictor.init_state(
         volume=input_,
         volume_embeddings=None,  # NOTE: It's a mandatory argument, but with the argument below, passing 'None' doesn't matter.  # noqa
+        device=predictor.device,
         ignore_caching_features=True
     )
 


### PR DESCRIPTION
Somehow there was a weird in-memory embeddings forwarding issue which created patchy NaN masks -- which is the segmentation artefact @Marei33 reported!

This happens due to async transfer across CPU and MPS while recasting inputs around like a swing (because several `pytorch`-related stuff is not compiled in `mps`). I just offload the lightweight components to CPU and works fine in MPS since it's unified memory!

Will merge this once the tests pass!