### PR TITLE
Add disk-backed lazy embeddings for eager annotation workflow

### DIFF
--- a/micro_sam/sam_annotator/_state.py
+++ b/micro_sam/sam_annotator/_state.py
@@ -90,6 +90,9 @@ class AnnotatorState(metaclass=Singleton):
     ndim: Optional[int] = None
     image_name: Optional[str] = None
     embedding_path: Optional[str] = None
+    # Path to an ephemeral on-disk embedding cache created when no save path is given (SAM2 volumes /
+    # tiled images), so embeddings stream from disk instead of filling RAM. Removed on reset / exit.
+    embedding_tmpdir: Optional[str] = None
     data_signature: Optional[str] = None
     skip_recomputing_embeddings: Optional[bool] = None
 
@@ -233,6 +236,17 @@ class AnnotatorState(metaclass=Singleton):
         else:  # Otherwise, compute the image embeddings.
             _comp_embed_fn = util.get_embedding_function(model_type)
 
+            # When no save path is given for a SAM2 volume or a tiled image, cache the embeddings to
+            # an ephemeral on-disk zarr instead of holding the whole volume in RAM. Materialising all
+            # slices costs ~200 MB/slice and OOMs on large volumes; the disk cache lets the consumers
+            # stream slices/tiles one at a time. It is removed on 'reset_state' and at process exit.
+            # Small non-tiled 2d stays in memory (a single image is cheap).
+            needs_disk_cache = self.is_sam2 and (ndim == 3 or tile_shape is not None)
+            if needs_disk_cache and not isinstance(save_path, str):
+                self._cleanup_embedding_tmpdir()
+                save_path = util.make_temp_embedding_path()
+                self.embedding_tmpdir = save_path
+
             # For SAM2 volumes, load the embeddings lazily from the zarr so the high-resolution
             # per-slice features stay on disk and are streamed one slice at a time during tracking.
             # This keeps memory bounded for large volumes (materialising all slices costs
@@ -369,8 +383,16 @@ class AnnotatorState(metaclass=Singleton):
             miss_vars = ", ".join(miss_vars)
             raise RuntimeError(f"Invalid state: the variables {miss_vars} have to be initialized for tracking.")
 
+    def _cleanup_embedding_tmpdir(self):
+        """Remove the ephemeral on-disk embedding cache, if one was created for this image."""
+        if self.embedding_tmpdir is not None:
+            import shutil
+            shutil.rmtree(self.embedding_tmpdir, ignore_errors=True)
+            self.embedding_tmpdir = None
+
     def reset_state(self):
         """Reset state, clear all attributes."""
+        self._cleanup_embedding_tmpdir()
         self.image_embeddings = None
         self.predictor = None
         self.image_shape = None

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -3,7 +3,10 @@
 
 import os
 import json
+import uuid
 import pooch
+import shutil
+import atexit
 import xxhash
 import pickle
 import hashlib
@@ -70,6 +73,22 @@ def get_cache_directory() -> None:
     default_cache_directory = os.path.expanduser(pooch.os_cache("micro_sam"))
     cache_directory = Path(os.environ.get("MICROSAM_CACHEDIR", default_cache_directory))
     return cache_directory
+
+
+def make_temp_embedding_path() -> str:
+    """Create a fresh ephemeral on-disk zarr path for streaming image embeddings.
+
+    Used when no explicit embedding save path is given: caching to disk (under the micro-sam cache
+    directory, honoring MICROSAM_CACHEDIR) instead of holding the whole volume in RAM keeps memory
+    bounded on large volumes / tiled images. The cache is disk-backed rather than in /tmp, which is
+    tmpfs (RAM) on many systems. The caller owns eager cleanup; the returned path is also removed on
+    process exit.
+    """
+    parent = get_cache_directory() / "tmp_embeddings"
+    parent.mkdir(parents=True, exist_ok=True)
+    path = str(parent / f"{uuid.uuid4().hex}.zarr")
+    atexit.register(shutil.rmtree, path, ignore_errors=True)
+    return path
 
 
 #

--- a/micro_sam/v2/automatic_segmentation.py
+++ b/micro_sam/v2/automatic_segmentation.py
@@ -447,17 +447,19 @@ def run_unisam2_decoder_on_3d_embeddings(
     z_block = DEFAULT_TILE_Z if z_block is None else int(z_block)
     z_halo = DEFAULT_HALO_Z if z_halo is None else int(z_halo)
 
-    features = np.asarray(image_embeddings["features"])
-    # Per-slice features are (Z, C, h, w); the tiled / save-path layout keeps a singleton batch axis
-    # (Z, 1, C, h, w) - squeeze it so the stub returns a (1, C, h, w) feature per slice.
-    if features.ndim == 5 and features.shape[1] == 1:
-        features = features[:, 0]
-    if features.ndim != 4:
+    # Keep 'features' as the (possibly lazy, on-disk) handle and read only the current z block inside
+    # the loop, so peak memory is one z block instead of the whole feature volume. Use 'len(shape)' as
+    # zarr / z5py datasets and numpy arrays all expose 'shape' (but not always 'ndim').
+    features = image_embeddings["features"]
+    n_dims = len(features.shape)
+    if n_dims not in (4, 5):
         raise ValueError(
-            f"Decoder-from-embeddings (3d) requires 3d embeddings (features with ndim 4 or 5), got {features.ndim}."
+            f"Decoder-from-embeddings (3d) requires 3d embeddings (features with ndim 4 or 5), got {n_dims}."
         )
+    # Per-slice features are (Z, C, h, w); the tiled / save-path layout keeps a singleton batch axis
+    # (Z, 1, C, h, w) - squeeze it per block so the stub returns a (1, C, h, w) feature per slice.
+    squeeze_batch = n_dims == 5 and features.shape[1] == 1
     n_slices = features.shape[0]
-    feature = torch.as_tensor(features, device=device).float()
     original_size = tuple(int(s) for s in np.array(image_embeddings["original_size"]).reshape(-1)[:2])
 
     # Decode in z blocks with a halo and stitch the inner range, bounding peak memory. The whole stack
@@ -471,7 +473,11 @@ def run_unisam2_decoder_on_3d_embeddings(
     for z0 in z_starts:
         z1 = min(z0 + z_block, n_slices)
         c0, c1 = max(0, z0 - z_halo), min(n_slices, z1 + z_halo)
-        pred = _decode_3d_feature_block(model, feature[c0:c1], original_size, device)  # (4, c1-c0, H, W)
+        block = np.asarray(features[c0:c1])
+        if squeeze_batch:
+            block = block[:, 0]
+        feature_block = torch.as_tensor(block, device=device).float()
+        pred = _decode_3d_feature_block(model, feature_block, original_size, device)  # (4, c1-c0, H, W)
         inner = z0 - c0
         output[:, z0:z1] = pred[:, inner:inner + (z1 - z0)]
         if pbar_update is not None:
@@ -614,8 +620,10 @@ def run_unisam2_decoder_on_tiled_3d_embeddings(
 
     output = np.zeros((4, *shape), dtype="float32")
     for tile_id in range(tiling.number_of_blocks):
+        # Keep the tile-column features lazy; 'run_unisam2_decoder_on_3d_embeddings' reads them one z
+        # block at a time from disk rather than materialising the whole column.
         tile_features = feats_group[str(tile_id)]  # (Z, C, h, w)
-        tile_embeddings = {"features": np.asarray(tile_features), "original_size": tile_features.attrs["original_size"]}
+        tile_embeddings = {"features": tile_features, "original_size": tile_features.attrs["original_size"]}
         tile_prediction = run_unisam2_decoder_on_3d_embeddings(
             model, tile_embeddings, device=device, z_block=z_block, z_halo=z_halo, pbar_update=pbar_update,
         )  # (4, Z, ty, tx)
@@ -975,9 +983,11 @@ def automatic_instance_segmentation(
             model_type=model_type, ndim=ndim, device=device, checkpoint_path=checkpoint,
             decoder_path=None, use_cli=True,
         )
+        # Stream 3d embeddings from the cache instead of materialising the whole volume; the 3d
+        # decoder reads them one z block at a time. 'lazy_loading' is a no-op for 2d / tiled.
         image_embeddings = precompute_image_embeddings(
             predictor, raw, save_path=embedding_path, ndim=ndim,
-            tile_shape=tile_shape, halo=halo, verbose=verbose,
+            tile_shape=tile_shape, halo=halo, verbose=verbose, lazy_loading=(ndim == 3),
         )
 
     segmenter.initialize(

--- a/micro_sam/v2/instance_segmentation.py
+++ b/micro_sam/v2/instance_segmentation.py
@@ -382,8 +382,10 @@ class TiledAutomaticMaskGenerationSegmenter(AutomaticMaskGenerationSegmenter):
         self._masks = []
         for tile_id in range(self._tiling.number_of_blocks):
             block = self._tiling.get_block_with_halo(tile_id, list(self._halo)).outer_block
-            fpn_tile = _load_list_datasets(image_embeddings["fpn"], str(tile_id), lazy_loading=False)
-            pos_tile = _load_list_datasets(image_embeddings["pos_enc"], str(tile_id), lazy_loading=False)
+            # Keep the per-tile datasets lazy so '_set_image_predictor_from_backbone' reads only slice
+            # 'i' from disk, instead of pulling the tile's whole z-stack into RAM on every slice.
+            fpn_tile = _load_list_datasets(image_embeddings["fpn"], str(tile_id), lazy_loading=True)
+            pos_tile = _load_list_datasets(image_embeddings["pos_enc"], str(tile_id), lazy_loading=True)
             original_size = feats[str(tile_id)].attrs["original_size"]
             _set_image_predictor_from_backbone(predictor, fpn_tile, pos_tile, original_size, i)
             tile_size = tuple(end - begin for begin, end in zip(block.begin, block.end))

--- a/micro_sam/v2/models/_video_predictor.py
+++ b/micro_sam/v2/models/_video_predictor.py
@@ -53,6 +53,34 @@ def _load_img_as_tensor(img_path, image_size):
     return img, video_height, video_width
 
 
+class _LazyVideoFrames:
+    """Produce per-slice frame tensors from a numpy volume on demand, without stacking the whole volume.
+
+    'inference_state["images"]' is only ever integer-indexed and passed to 'len', so a sequence that
+    resizes + normalises one slice at access time is a drop-in for the eager
+    '(num_frames, 3, image_size, image_size)' tensor. This avoids holding every slice at 'image_size^2'
+    (~12 MB/slice), which otherwise grows unbounded with depth and, after the embeddings were moved to
+    disk, is the dominant per-volume RAM cost. Frames are returned on CPU (the consumer moves the
+    current frame to the device); the upstream <=MAX_CACHED_FRAMES feature cache already retains the
+    frames in active use, so nothing is cached here.
+    """
+
+    def __init__(self, volume, image_size, img_mean, img_std):
+        self._volume = volume
+        self._image_size = image_size
+        self._img_mean = img_mean
+        self._img_std = img_std
+        h, w = volume.shape[1], volume.shape[2]
+        self.video_height = self.video_width = max(h, w)
+
+    def __len__(self):
+        return len(self._volume)
+
+    def __getitem__(self, index):
+        img, _, _ = _load_img_as_tensor(self._volume[index], self._image_size)
+        return (img - self._img_mean) / self._img_std
+
+
 def _load_video_frames_from_images(
     video_path,
     volume,
@@ -78,16 +106,14 @@ def _load_video_frames_from_images(
 
     if video_path is None:
         # Coerce lazy inputs (e.g. dask / zarr / h5py arrays handed over by a napari layer) to a numpy
-        # array; the non-tiled path stacks every slice into a single device tensor anyway.
+        # array (cheap at native resolution; the expensive image_size^2 copy is what we avoid stacking).
         volume = np.asarray(volume)
         if volume.ndim != 3:
             raise ValueError(f"Expected a 3D volume of shape (Z, Y, X), got an array of shape {volume.shape}.")
-        # Iterate over each slice.
-        images = []
-        for i, curr_slice in enumerate(volume):
-            curr_image, video_height, video_width = _load_img_as_tensor(curr_slice, image_size)
-            images.append(curr_image)
-        images = torch.stack(images)  # Stack the inputs in expected format.
+        # Stream slices lazily (resize + normalise on access) instead of stacking the whole volume at
+        # image_size^2, so RAM stays bounded regardless of depth.
+        lazy_images = _LazyVideoFrames(volume, image_size, img_mean, img_std)
+        return lazy_images, lazy_images.video_height, lazy_images.video_width
     else:
         if isinstance(video_path, str) and os.path.isdir(video_path):
             frames_folder = video_path

--- a/micro_sam/v2/models/_video_predictor.py
+++ b/micro_sam/v2/models/_video_predictor.py
@@ -94,12 +94,16 @@ def _load_video_frames_from_images(
 ):
     """Based on 'load_video_frames_from_jpg_images'.
 
-    Load the video frames from a directory of image files (eg. "<frame_index>.jpg" format).
+    Returns the frame sequence (resized to image_size x image_size and ImageNet-normalised) plus the
+    effective video height / width, for two input kinds:
 
-    The frames are resized to image_size x image_size and are loaded to GPU if
-    `offload_video_to_cpu` is `False` and to CPU if `offload_video_to_cpu` is `True`.
-
-    You can load a frame asynchronously by setting `async_loading_frames` to `True`.
+    - `volume` (a numpy (Z, Y, X) array, the micro-sam path): returns a lazy `_LazyVideoFrames` that
+      resizes + normalises one slice on demand on CPU, so the whole volume is never stacked at
+      image_size^2 in memory. `offload_video_to_cpu` does not apply here (the consumer moves the
+      current frame to the device per access).
+    - `video_path` (a directory of "<frame_index>.jpg" files): stacks the frames into a single tensor,
+      on the GPU if `offload_video_to_cpu` is `False` else on CPU. Set `async_loading_frames` to `True`
+      to load these frames asynchronously.
     """
     img_mean = torch.tensor(img_mean, dtype=torch.float32)[:, None, None]
     img_std = torch.tensor(img_std, dtype=torch.float32)[:, None, None]

--- a/micro_sam/v2/prompt_based_segmentation.py
+++ b/micro_sam/v2/prompt_based_segmentation.py
@@ -963,10 +963,12 @@ class TiledPromptableSegmentation3D:
 
             feats = self.volume_embeddings["features"]
             tile_dataset = feats[str(tile_id)]
+            # Keep the per-tile datasets lazy so the video predictor streams this tile-column one
+            # frame at a time from disk, instead of materialising the whole column (~124 MB/slice).
             tile_embeddings = {
-                "features": np.asarray(tile_dataset),
-                "pos_enc": _load_list_datasets(self.volume_embeddings["pos_enc"], str(tile_id), lazy_loading=False),
-                "fpn": _load_list_datasets(self.volume_embeddings["fpn"], str(tile_id), lazy_loading=False),
+                "features": tile_dataset,
+                "pos_enc": _load_list_datasets(self.volume_embeddings["pos_enc"], str(tile_id), lazy_loading=True),
+                "fpn": _load_list_datasets(self.volume_embeddings["fpn"], str(tile_id), lazy_loading=True),
                 "input_size": tile_dataset.attrs["input_size"],
                 "original_size": tile_dataset.attrs["original_size"],
             }

--- a/micro_sam/v2/prompt_based_segmentation.py
+++ b/micro_sam/v2/prompt_based_segmentation.py
@@ -27,7 +27,7 @@ def _trim_cpu_heap():
         pass
 
 
-def _free_device_memory(device=None):
+def _free_device_memory():
     """Return freed tensor memory to the allocator / OS after clearing cached embeddings.
 
     Covers GPU (empty the CUDA / MPS caching allocator) and native CPU systems (trim the glibc heap
@@ -509,7 +509,7 @@ class PromptableSegmentation3D:
         # this cache. The embeddings are disk-backed, so the next prompt re-reads the needed frame
         # lazily via '_get_image_feature' - the cache stays empty until then.
         self.inference_state["cached_features"] = {}
-        _free_device_memory(self.device)
+        _free_device_memory()
 
     def get_progress_total(self, z_range=None):
         """Return the number of slice propagation steps for the requested z range."""
@@ -976,7 +976,7 @@ class TiledPromptableSegmentation3D:
         for segmenter in self._segmenters.values():
             segmenter.reset_predictor()
         self._segmenters = {}
-        _free_device_memory(self.device)
+        _free_device_memory()
 
     def get_progress_total(self, z_range=None):
         """Return tile-slice propagation steps for the currently active tiles."""

--- a/micro_sam/v2/prompt_based_segmentation.py
+++ b/micro_sam/v2/prompt_based_segmentation.py
@@ -1,3 +1,7 @@
+import gc
+import ctypes
+import platform
+
 from typing import Optional, Union, List
 
 import numpy as np
@@ -5,6 +9,36 @@ import torch
 
 from micro_sam.v1.prompt_based_segmentation import _process_box, _compute_logits_from_mask
 from micro_sam.v2.transforms.resize import resize_longest_side_and_pad_spatial_numpy, ResizeLongestSideTransforms
+
+
+def _trim_cpu_heap():
+    """Return freed CPU heap to the OS on glibc/Linux; no-op elsewhere.
+
+    'gc.collect' drops the Python references and frees the tensors, but glibc keeps the freed pages
+    in its arenas rather than returning them to the OS, so RSS stays high on native CPU systems (the
+    low-RAM target). 'malloc_trim' releases that free heap, so clearing the embedding cache actually
+    lowers RSS.
+    """
+    if platform.system() != "Linux":
+        return
+    try:
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except (OSError, AttributeError):
+        pass
+
+
+def _free_device_memory(device=None):
+    """Return freed tensor memory to the allocator / OS after clearing cached embeddings.
+
+    Covers GPU (empty the CUDA / MPS caching allocator) and native CPU systems (trim the glibc heap
+    so RSS actually drops, not just the Python-level references).
+    """
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    elif getattr(torch.backends, "mps", None) is not None and torch.backends.mps.is_available():
+        torch.mps.empty_cache()
+    _trim_cpu_heap()
 
 
 def _crop_to_original_shape(mask, shape):
@@ -470,6 +504,12 @@ class PromptableSegmentation3D:
         self._pushed_points = {}
         self._pushed_boxes = {}
         self._pushed_masks = {}
+        # Drop the per-frame embedding cache (up to MAX_CACHED_FRAMES slices of high-res features) so
+        # committing / clearing frees its RAM. SAM2's 'reset_state' clears the tracking outputs but not
+        # this cache. The embeddings are disk-backed, so the next prompt re-reads the needed frame
+        # lazily via '_get_image_feature' - the cache stays empty until then.
+        self.inference_state["cached_features"] = {}
+        _free_device_memory(self.device)
 
     def get_progress_total(self, z_range=None):
         """Return the number of slice propagation steps for the requested z range."""
@@ -931,9 +971,12 @@ class TiledPromptableSegmentation3D:
         pass
 
     def reset_predictor(self):
+        # Drop the per-tile segmenters (each with its own inference state + embedding cache) so
+        # committing / clearing frees their RAM; they are rebuilt lazily for the next prompt.
         for segmenter in self._segmenters.values():
             segmenter.reset_predictor()
         self._segmenters = {}
+        _free_device_memory(self.device)
 
     def get_progress_total(self, z_range=None):
         """Return tile-slice propagation steps for the currently active tiles."""

--- a/micro_sam/v2/util.py
+++ b/micro_sam/v2/util.py
@@ -475,15 +475,19 @@ def _compute_tiled_3d(input_, predictor, tile_shape, halo, f, save_path, pbar_in
         tile_pos = [torch.stack([p[level] for p in pos_encs]).detach().cpu().numpy() for level in range(depth)]
         tile_fpn = [torch.stack([p[level] for p in fpns]).detach().cpu().numpy() for level in range(depth)]
 
-        ds = _create_dataset_with_data(features, str(tile_id), data=tile_features)
+        # Chunk per slice (chunks=(1, ...)), as '_compute_3d' does: a whole tile-column stacked into a
+        # single chunk exceeds Blosc's ~2.1 GB per-chunk limit for deep volumes (e.g. pos_enc level 0
+        # is ~67 MB/slice, so 50 slices is ~3.35 GB) and fails to compress.
+        feat_chunks = (1,) + tile_features.shape[1:]
+        ds = _create_dataset_with_data(features, str(tile_id), data=tile_features, chunks=feat_chunks)
         ds.attrs["input_size"] = input_sizes[-1]
         ds.attrs["original_size"] = list(original_sizes[-1])
         tile_pos_group = pos_enc_group.require_group(str(tile_id))
         for level, level_feat in enumerate(tile_pos):
-            _create_dataset_with_data(tile_pos_group, str(level), data=level_feat)
+            _create_dataset_with_data(tile_pos_group, str(level), data=level_feat, chunks=(1,) + level_feat.shape[1:])
         tile_fpn_group = fpn_group.require_group(str(tile_id))
         for level, level_feat in enumerate(tile_fpn):
-            _create_dataset_with_data(tile_fpn_group, str(level), data=level_feat)
+            _create_dataset_with_data(tile_fpn_group, str(level), data=level_feat, chunks=(1,) + level_feat.shape[1:])
 
     if save_path is not None:
         _write_embedding_signature(

--- a/micro_sam/v2/util.py
+++ b/micro_sam/v2/util.py
@@ -428,7 +428,7 @@ def _compute_tiled_2d(input_, predictor, tile_shape, halo, f, save_path, pbar_in
 
 
 def _compute_tiled_3d(input_, predictor, tile_shape, halo, f, save_path, pbar_init, pbar_update):
-    from micro_sam.util import _to_image, _create_dataset_with_data, _write_embedding_signature
+    from micro_sam.util import _to_image, _create_dataset_without_data, _write_embedding_signature
     from bioimage_cpp.utils import Blocking
 
     features = f.require_group("features")
@@ -463,31 +463,53 @@ def _compute_tiled_3d(input_, predictor, tile_shape, halo, f, save_path, pbar_in
         inference_state = predictor.init_state(
             volume=sub_volume, volume_embeddings=None, device=predictor.device, ignore_caching_features=True,
         )
-        batched_images = [_to_image(sub_volume[z]) for z in range(n_slices)]
-        vision_feats, pos_encs, fpns, original_sizes, input_sizes = _compute_embeddings_batched_3d(
-            inference_state, predictor, list(range(n_slices)), batched_images, pbar_update=pbar_update,
-        )
 
-        # Stack the per-slice outputs along z, matching the (n_slices, ...) layout '_compute_3d' saves.
-        stacked = [feat.unsqueeze(0) if feat.ndim == 3 else feat for feat in vision_feats]
-        tile_features = torch.stack(stacked, dim=0).detach().cpu().numpy()
-        depth = len(pos_encs[0])
-        tile_pos = [torch.stack([p[level] for p in pos_encs]).detach().cpu().numpy() for level in range(depth)]
-        tile_fpn = [torch.stack([p[level] for p in fpns]).detach().cpu().numpy() for level in range(depth)]
-
-        # Chunk per slice (chunks=(1, ...)), as '_compute_3d' does: a whole tile-column stacked into a
-        # single chunk exceeds Blosc's ~2.1 GB per-chunk limit for deep volumes (e.g. pos_enc level 0
-        # is ~67 MB/slice, so 50 slices is ~3.35 GB) and fails to compress.
-        feat_chunks = (1,) + tile_features.shape[1:]
-        ds = _create_dataset_with_data(features, str(tile_id), data=tile_features, chunks=feat_chunks)
-        ds.attrs["input_size"] = input_sizes[-1]
-        ds.attrs["original_size"] = list(original_sizes[-1])
+        # Stream one slice at a time into per-tile datasets, moving each slice's features off-device
+        # right away, so peak memory is a single slice rather than the whole tile-column. Buffering all
+        # slices (and then stacking them) held ~200 MB/slice of high-res features on-device and OOMed on
+        # deep volumes even when saving to disk. Datasets are created lazily from the first slice's
+        # shapes with per-slice '(1, ...)' chunking, matching '_compute_3d' and the on-disk layout the
+        # lazy tiled consumer expects (features/<tile>, pos_enc/<tile>/<level>, fpn/<tile>/<level>).
+        feature_ds, pos_enc_dsets, fpn_dsets = None, None, None
         tile_pos_group = pos_enc_group.require_group(str(tile_id))
-        for level, level_feat in enumerate(tile_pos):
-            _create_dataset_with_data(tile_pos_group, str(level), data=level_feat, chunks=(1,) + level_feat.shape[1:])
         tile_fpn_group = fpn_group.require_group(str(tile_id))
-        for level, level_feat in enumerate(tile_fpn):
-            _create_dataset_with_data(tile_fpn_group, str(level), data=level_feat, chunks=(1,) + level_feat.shape[1:])
+        input_size, original_size = None, None
+        for z in range(n_slices):
+            vision_feats, pos_encs, fpns, original_sizes, input_sizes = _compute_embeddings_batched_3d(
+                inference_state, predictor, [z], [_to_image(sub_volume[z])], pbar_update=pbar_update,
+            )
+            curr_feat = vision_feats[0]
+            if curr_feat.ndim == 3:
+                curr_feat = curr_feat.unsqueeze(0)
+            curr_pos, curr_fpn = pos_encs[0], fpns[0]
+
+            if feature_ds is None:
+                feature_ds = _create_dataset_without_data(
+                    features, str(tile_id), shape=(n_slices,) + tuple(curr_feat.shape),
+                    dtype="float32", chunks=(1,) + tuple(curr_feat.shape),
+                )
+                pos_enc_dsets = [
+                    _create_dataset_without_data(
+                        tile_pos_group, str(level), shape=(n_slices,) + tuple(t.shape),
+                        dtype="float32", chunks=(1,) + tuple(t.shape),
+                    ) for level, t in enumerate(curr_pos)
+                ]
+                fpn_dsets = [
+                    _create_dataset_without_data(
+                        tile_fpn_group, str(level), shape=(n_slices,) + tuple(t.shape),
+                        dtype="float32", chunks=(1,) + tuple(t.shape),
+                    ) for level, t in enumerate(curr_fpn)
+                ]
+
+            feature_ds[z] = curr_feat.detach().cpu().numpy()
+            for level, t in enumerate(curr_pos):
+                pos_enc_dsets[level][z] = t.detach().cpu().numpy()
+            for level, t in enumerate(curr_fpn):
+                fpn_dsets[level][z] = t.detach().cpu().numpy()
+            input_size, original_size = input_sizes[-1], original_sizes[-1]
+
+        feature_ds.attrs["input_size"] = input_size
+        feature_ds.attrs["original_size"] = list(original_size)
 
     if save_path is not None:
         _write_embedding_signature(


### PR DESCRIPTION
Okay this is an ambitious attempt. I'll pair this with two use-cases: 1) one with @lufre1's, and 2) on my Macbook on larger volumes!

The eager loading of embeddings should work fairly well (tried and it seems to do the trick for me).

I'll leave this as a draft for now!