### PR TITLE
Fix pixel and object classification geometry for SAM2 embeddings

### DIFF
--- a/examples/object_classifier.py
+++ b/examples/object_classifier.py
@@ -303,8 +303,8 @@ def main():
     # wholeslide_annotator()
     # lucchi_annotator()
     # tiled_3d_annotator()
-    sam2_object_classifier()
-    # histopathology_annotator()
+    # sam2_object_classifier()
+    histopathology_annotator()
     # batch_prediction()
 
     # annotator_devel()

--- a/examples/object_classifier.py
+++ b/examples/object_classifier.py
@@ -271,6 +271,17 @@ def dino_annotator():
     object_classifier(image, segmentation, model_type="vit_b_dinov2")
 
 
+def sam2_object_classifier():
+    from micro_sam.sam_annotator.object_classifier import object_classifier
+
+    example_data = fetch_livecell_example_data(DATA_CACHE)
+    image = imageio.imread(example_data)
+    segmentation = imageio.imread(os.path.join(DATA_CACHE, "livecell-2d-segmentation.tif"))
+
+    embedding_path = os.path.join(EMBEDDING_CACHE, "embeddings-livecell-hvit_t_cells.zarr")
+    object_classifier(image, segmentation, embedding_path=embedding_path, model_type="hvit_t_cells")
+
+
 def sam3_object_classifier():
     from micro_sam.sam_annotator.object_classifier import object_classifier
 
@@ -292,7 +303,8 @@ def main():
     # wholeslide_annotator()
     # lucchi_annotator()
     # tiled_3d_annotator()
-    histopathology_annotator()
+    sam2_object_classifier()
+    # histopathology_annotator()
     # batch_prediction()
 
     # annotator_devel()

--- a/micro_sam/object_classification.py
+++ b/micro_sam/object_classification.py
@@ -19,11 +19,10 @@ from .import util
 from .v1.util import precompute_image_embeddings
 
 
-def _anyup_object_resize(embeds_chw, image_region, target_hw, upsampler, is_sam2=False):
+def _anyup_object_resize(embeds_chw, image_region, target_hw, upsampler):
     # Upsample a (C, h, w) embedding to (target_h, target_w, C) with AnyUp, using the image region
-    # as guidance. SAM1 padded the image to a square, so we square-pad the image here to match how
-    # the segmentation is padded; SAM2 stretched the image to a square, so we pass it as-is (AnyUp
-    # pools it to the embedding grid, matching the stretched features).
+    # as guidance. The encoders pad the image to a square, so we square-pad the image here to match
+    # how the segmentation is padded.
     import torch
     import torch.nn.functional as F
     from .pixel_classification import _to_anyup_image
@@ -37,9 +36,8 @@ def _anyup_object_resize(embeds_chw, image_region, target_hw, upsampler, is_sam2
 
     device = next(upsampler.parameters()).device
     image_tensor = _to_anyup_image(image_region, device)  # (1, 3, H, W)
-    if not is_sam2:
-        h, w = image_tensor.shape[-2:]
-        image_tensor = F.pad(image_tensor, (0, max(h - w, 0), 0, max(w - h, 0)))
+    h, w = image_tensor.shape[-2:]
+    image_tensor = F.pad(image_tensor, (0, max(h - w, 0), 0, max(w - h, 0)))
     feature_tensor = torch.from_numpy(np.ascontiguousarray(embeds_chw)).to(device).float().unsqueeze(0)
     from .pixel_classification import ANYUP_Q_CHUNK_SIZE
     with torch.no_grad():
@@ -50,22 +48,15 @@ def _anyup_object_resize(embeds_chw, image_region, target_hw, upsampler, is_sam2
 
 
 def _compute_object_features_impl(
-    embeddings, segmentation, resize_embedding_shape, image_region=None, upsampler=None, is_sam2=False,
-    pbar_update=None,
+    embeddings, segmentation, resize_embedding_shape, image_region=None, upsampler=None, pbar_update=None,
 ):
     # Keep the raw (C, h, w) embedding for AnyUp, which needs the channel axis first.
     embeddings_chw = embeddings
 
-    # Bring the segmentation to a square shape matching the (square) embedding. SAM1 pads the image
-    # to a square (so we zero-pad the segmentation to match); SAM2 stretches the image to a square
-    # (so we resize the segmentation to a square to match the stretched embedding).
+    # Bring the segmentation to a square shape matching the (square) embedding. The encoders pad the
+    # image to a square, so we zero-pad the segmentation to match.
     shape = segmentation.shape
-    if is_sam2:
-        side = max(shape)
-        segmentation_rescaled = resize(
-            segmentation, (side, side), order=0, anti_aliasing=False, preserve_range=True
-        ).astype(segmentation.dtype)
-    elif shape[0] == shape[1]:
+    if shape[0] == shape[1]:
         segmentation_rescaled = segmentation
     elif shape[0] > shape[1]:
         segmentation_rescaled = np.pad(segmentation, ((0, 0), (0, shape[0] - shape[1])))
@@ -83,7 +74,7 @@ def _compute_object_features_impl(
     resize_hw = tuple(min(rsh, sh) for rsh, sh in zip(resize_embedding_shape, shape))
     if upsampler is not None:
         # AnyUp upsamples the embedding using the image region instead of plain interpolation.
-        embeddings = _anyup_object_resize(embeddings_chw, image_region, resize_hw, upsampler, is_sam2)
+        embeddings = _anyup_object_resize(embeddings_chw, image_region, resize_hw, upsampler)
     else:
         embeddings = embeddings_chw.transpose(1, 2, 0)  # put the channel axis last
         embeddings = resize(
@@ -191,9 +182,6 @@ def compute_object_features(
 
     is_tiled = image_embeddings["input_size"] is None
     is_3d = segmentation.ndim == 3
-    # SAM2 embeddings carry the high-resolution decoder features; SAM1 embeddings never do. SAM2
-    # stretches the image to a square (no padding), which changes how the embedding aligns spatially.
-    is_sam2 = "high_res_feats" in image_embeddings
 
     # If we have simple embeddings, i.e. 2d without tiling, then we can directly compute the features.
     if not is_tiled and not is_3d:
@@ -205,7 +193,7 @@ def compute_object_features(
         )
         result = _compute_object_features_impl(
             embeddings, segmentation, resize_embedding_shape, image_region=image, upsampler=upsampler,
-            is_sam2=is_sam2, pbar_update=anyup_pbar.update if upsampler is not None else None,
+            pbar_update=anyup_pbar.update if upsampler is not None else None,
         )
         anyup_pbar.close()
         return result
@@ -237,7 +225,7 @@ def compute_object_features(
     ):
         # Compute this seg ids and features.
         this_seg_ids, this_features = _compute_object_features_impl(
-            embeds, seg, resize_embedding_shape, image_region=image_region, upsampler=upsampler, is_sam2=is_sam2
+            embeds, seg, resize_embedding_shape, image_region=image_region, upsampler=upsampler
         )
         this_seg_ids = this_seg_ids.tolist()
 

--- a/micro_sam/pixel_classification.py
+++ b/micro_sam/pixel_classification.py
@@ -144,15 +144,14 @@ def _resize_to_grid(embeddings: np.ndarray, target_hw: Tuple[int, int]) -> np.nd
     return resize(feature_image, resize_shape, preserve_range=True).astype("float32")
 
 
-def _block_to_grid(embeddings, block_hw, target_hw, image_region=None, upsampler=None, is_sam2=False, pbar_update=None):
+def _block_to_grid(embeddings, block_hw, target_hw, image_region=None, upsampler=None, pbar_update=None):
     """Crop a block embedding to its aspect ratio and map it to the target grid shape.
 
-    SAM1 pads the image to a square before encoding, so the square embedding has content in a
-    sub-rectangle that we crop out. SAM2 stretches the image to a square, so the full embedding
-    already corresponds to the whole image and must not be cropped. With `upsampler`, AnyUp
-    upsamples the embedding using `image_region` as guidance; otherwise it is plainly interpolated.
+    The encoders pad the image to a square, so the square embedding has content in a sub-rectangle
+    that we crop out. With `upsampler`, AnyUp upsamples the embedding using `image_region` as
+    guidance; otherwise it is plainly interpolated.
     """
-    block = embeddings if is_sam2 else _aspect_crop(embeddings, block_hw)
+    block = _aspect_crop(embeddings, block_hw)
     if upsampler is not None:
         result = _anyup_to_grid(block, image_region, target_hw, upsampler)
         if pbar_update is not None:
@@ -162,7 +161,7 @@ def _block_to_grid(embeddings, block_hw, target_hw, image_region=None, upsampler
 
 
 def _compute_tiled_feature_image(
-    features, image_hw, max_grid_size, z=None, image=None, upsampler=None, is_sam2=False, pbar_update=None
+    features, image_hw, max_grid_size, z=None, image=None, upsampler=None, pbar_update=None
 ):
     """Assemble a downsampled (GH, GW, C) feature image for a single 2d (tiled) plane.
 
@@ -184,9 +183,8 @@ def _compute_tiled_feature_image(
         outer, inner_local = block.outer_block, block.inner_block_local
         outer_hw = (outer.end[0] - outer.begin[0], outer.end[1] - outer.begin[1])
 
-        # SAM1 pads the tile to a square (crop to the outer block aspect); SAM2 stretches it (no crop).
-        if not is_sam2:
-            embeds = _aspect_crop(embeds, outer_hw)
+        # The tile is padded to a square, so crop to the outer block aspect.
+        embeds = _aspect_crop(embeds, outer_hw)
         tile_scale = (embeds.shape[-2] / outer_hw[0], embeds.shape[-1] / outer_hw[1])
         iy0, iy1 = int(round(inner_local.begin[0] * tile_scale[0])), int(round(inner_local.end[0] * tile_scale[0]))
         ix0, ix1 = int(round(inner_local.begin[1] * tile_scale[1])), int(round(inner_local.end[1] * tile_scale[1]))
@@ -248,9 +246,6 @@ def compute_pixel_features(
 
     is_tiled = image_embeddings["input_size"] is None
     is_3d = len(image_shape) == 3
-    # SAM2 embeddings carry the high-resolution decoder features; SAM1 embeddings never do. SAM2
-    # stretches the image to a square (no padding), so its embedding must not be aspect-cropped.
-    is_sam2 = "high_res_feats" in image_embeddings
     features = image_embeddings["features"]
 
     # AnyUp is the slow part, so when it is used we show a dedicated progress bar (which also drives
@@ -274,15 +269,14 @@ def compute_pixel_features(
         for z in tqdm(range(depth), total=depth, disable=slice_disable, desc="Compute pixel features"):
             if is_tiled:
                 plane, grid = _compute_tiled_feature_image(
-                    features, image_hw, max_grid_size, z=z, image=image, upsampler=upsampler,
-                    is_sam2=is_sam2, pbar_update=pbar_update,
+                    features, image_hw, max_grid_size, z=z, image=image, upsampler=upsampler, pbar_update=pbar_update
                 )
             else:
                 embeds = np.asarray(features[z]).squeeze()
                 grid, _ = _grid_shape(image_hw, grid_size)
                 plane = _block_to_grid(
                     embeds, image_hw, grid, image_region=None if image is None else image[z],
-                    upsampler=upsampler, is_sam2=is_sam2, pbar_update=pbar_update,
+                    upsampler=upsampler, pbar_update=pbar_update,
                 )
             planes.append(plane)
         feature_image = np.stack(planes)
@@ -291,15 +285,13 @@ def compute_pixel_features(
         image_hw = (image_shape[0], image_shape[1])
         if is_tiled:
             feature_image, grid = _compute_tiled_feature_image(
-                features, image_hw, max_grid_size, image=image, upsampler=upsampler,
-                is_sam2=is_sam2, pbar_update=pbar_update,
+                features, image_hw, max_grid_size, image=image, upsampler=upsampler, pbar_update=pbar_update
             )
         else:
             embeds = np.asarray(features).squeeze()
             grid, _ = _grid_shape(image_hw, grid_size)
             feature_image = _block_to_grid(
-                embeds, image_hw, grid, image_region=image, upsampler=upsampler,
-                is_sam2=is_sam2, pbar_update=pbar_update,
+                embeds, image_hw, grid, image_region=image, upsampler=upsampler, pbar_update=pbar_update,
             )
         grid_shape = grid
 

--- a/test/test_classification_geometry.py
+++ b/test/test_classification_geometry.py
@@ -1,0 +1,52 @@
+"""Geometry tests for the classification feature extraction.
+
+The image encoders (SAM1, SAM2 and the VFM encoders) all resize the longest side and zero-pad the
+bottom/right, so a non-square image has its content in the top-left sub-rectangle of the square
+embedding. These tests pin that the padded region is discarded instead of being treated as image
+content, which silently misplaces every feature for non-square inputs.
+"""
+
+import numpy as np
+
+from micro_sam.object_classification import compute_object_features
+from micro_sam.pixel_classification import compute_pixel_features
+
+IMAGE_SHAPE = (48, 64)  # Non-square, so a quarter of the square embedding is padding.
+EMBEDDING_SIZE = 16
+N_CHANNELS = 8
+
+
+def _padded_embeddings():
+    """A (1, C, 16, 16) embedding that is 1.0 in the content region and 0.0 in the padded region."""
+    content_rows = int(round(EMBEDDING_SIZE * IMAGE_SHAPE[0] / max(IMAGE_SHAPE)))
+    features = np.zeros((1, N_CHANNELS, EMBEDDING_SIZE, EMBEDDING_SIZE), dtype="float32")
+    features[:, :, :content_rows] = 1.0
+    return {
+        "features": features,
+        "high_res_feats": [],  # Marks the embeddings as SAM2, which pads exactly like SAM1.
+        "input_size": 1024,
+        "original_size": IMAGE_SHAPE,
+    }
+
+
+def test_pixel_features_exclude_padding():
+    features, grid_shape = compute_pixel_features(_padded_embeddings(), IMAGE_SHAPE, verbose=False)
+
+    # The grid keeps the image aspect ratio and every feature comes from the content region.
+    assert np.isclose(grid_shape[0] / grid_shape[1], IMAGE_SHAPE[0] / IMAGE_SHAPE[1], atol=0.01)
+    assert features.shape == (grid_shape[0] * grid_shape[1], N_CHANNELS)
+    assert np.allclose(features, 1.0), f"padded region leaked into the features: min {features.min()}"
+
+
+def test_object_features_exclude_padding():
+    # An object low in the image, which lands in the padded region if the geometry is wrong.
+    # It is inset from the last rows so that interpolation at the content/padding border does not
+    # bleed into it, which would blur the distinction this test draws.
+    segmentation = np.zeros(IMAGE_SHAPE, dtype="uint32")
+    segmentation[-16:-6, -12:] = 1
+
+    seg_ids, features = compute_object_features(_padded_embeddings(), segmentation, verbose=False)
+
+    assert seg_ids.tolist() == [1]
+    # Feature layout is [area, per-channel mean], so the embedding means follow the area column.
+    assert np.allclose(features[0, 1:], 1.0), f"padded region leaked into the object features: {features[0, 1:]}"


### PR DESCRIPTION
Yeah I broke this while my unification attempt for segmentation and tracking annotators. Should be working now! ;)

I'll make a few final tests with models besides SAM2 for classification, and merge this!