### PR TITLE
Fix MPS OOM for 3d automatic segmentation by lifting memory watermarks

### DIFF
--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -131,11 +131,14 @@ def _configure_mps_memory(device: Union[str, torch.device]) -> None:
     """Disable the MPS memory watermark so 3d automatic segmentation does not hit a premature OOM.
 
     MPS's default watermark rejects allocations that would still fit in unified memory; '0.0' disables
-    it. ``setdefault`` keeps a user-set value, and it must run before the first MPS allocation to apply.
+    it. We set it only when unset (so a user-provided value is kept) and it must run before the first
+    MPS allocation to apply.
     """
     device_type = device if isinstance(device, str) else getattr(device, "type", "")
-    if isinstance(device_type, str) and device_type.lower() == "mps":
-        os.environ.setdefault("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.0")
+    is_mps = isinstance(device_type, str) and device_type.lower() == "mps"
+    if is_mps and "PYTORCH_MPS_HIGH_WATERMARK_RATIO" not in os.environ:
+        os.environ["PYTORCH_MPS_HIGH_WATERMARK_RATIO"] = "0.0"
+        print("Lifting the MPS memory limit for large 3d segmentation; this may use swap on low-memory Macs.")
 
 
 def get_device(device: Optional[Union[str, torch.device]] = None) -> Union[str, torch.device]:

--- a/micro_sam/util.py
+++ b/micro_sam/util.py
@@ -127,6 +127,17 @@ def _get_default_device():
     return device
 
 
+def _configure_mps_memory(device: Union[str, torch.device]) -> None:
+    """Disable the MPS memory watermark so 3d automatic segmentation does not hit a premature OOM.
+
+    MPS's default watermark rejects allocations that would still fit in unified memory; '0.0' disables
+    it. ``setdefault`` keeps a user-set value, and it must run before the first MPS allocation to apply.
+    """
+    device_type = device if isinstance(device, str) else getattr(device, "type", "")
+    if isinstance(device_type, str) and device_type.lower() == "mps":
+        os.environ.setdefault("PYTORCH_MPS_HIGH_WATERMARK_RATIO", "0.0")
+
+
 def get_device(device: Optional[Union[str, torch.device]] = None) -> Union[str, torch.device]:
     """Get the torch device.
 
@@ -154,6 +165,7 @@ def get_device(device: Optional[Union[str, torch.device]] = None) -> Union[str, 
         else:
             raise RuntimeError(f"Unsupported device: '{device}'. Please choose from 'cpu', 'cuda', or 'mps'.")
 
+    _configure_mps_memory(device)
     return device
 
 

--- a/micro_sam/v2/util.py
+++ b/micro_sam/v2/util.py
@@ -11,6 +11,7 @@ import torch
 
 from micro_sam.util import (
     get_device, get_cache_directory, microsam_cachedir, _open_embeddings, _create_dataset_without_data,
+    _configure_mps_memory,
 )
 from micro_sam.v2.models._video_predictor import _build_sam2_video_predictor
 from micro_sam.v2.normalization import RAW_NORMALIZATION, to_image
@@ -185,6 +186,8 @@ def _download_finetuned_sam2_model(model_type, progress_bar_factory=None):
 def _get_device(device=None):
     if device is None or device == "auto":
         device = get_device()
+    else:
+        _configure_mps_memory(device)
 
     if device == "cuda":
         # NOTE: Adapt global variables to work with flash attentions.

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -421,6 +421,33 @@ class TestUtil(unittest.TestCase):
         self.assertTrue(isinstance(device, torch.device))
         self.assertEqual(device.type, "cpu")
 
+    def test_configure_mps_memory(self):
+        from micro_sam.util import _configure_mps_memory
+
+        key = "PYTORCH_MPS_HIGH_WATERMARK_RATIO"
+        original = os.environ.get(key)
+        try:
+            # non-mps devices must not touch the watermark
+            os.environ.pop(key, None)
+            _configure_mps_memory("cpu")
+            self.assertNotIn(key, os.environ)
+            _configure_mps_memory(torch.device("cpu"))
+            self.assertNotIn(key, os.environ)
+
+            # mps disables the watermark when it is unset
+            _configure_mps_memory("mps")
+            self.assertEqual(os.environ.get(key), "0.0")
+
+            # an explicit user-provided value is kept
+            os.environ[key] = "1.9"
+            _configure_mps_memory("mps")
+            self.assertEqual(os.environ[key], "1.9")
+        finally:
+            if original is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = original
+
 
 try:
     import sam2  # noqa


### PR DESCRIPTION
This should also help other MPS OOM cases for Macbook, since it bypasses MPS's artificial allocation cap and let's the PyTorch processes use all the unified memory (also overflowing to swap if needed) -- kind of allowing MPS to make use of resources as dedicated VRAM.

I'll go ahead and merge this once the tests pass!