### PR TITLE
Treat cleared checkpoint path as None in annotator widgets

### DIFF
--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -85,10 +85,10 @@ class _WidgetBase(QtWidgets.QWidget):
             label.setToolTip(tooltip)
         layout.addWidget(label)
         param = QtWidgets.QLineEdit()
-        param.setText(value)
+        param.setText("" if value is None else str(value))
         if placeholder is not None:
             param.setPlaceholderText(placeholder)
-        param.textChanged.connect(lambda val: setattr(self, name, val))
+        param.textChanged.connect(lambda val: setattr(self, name, val if val else None))
         if tooltip:
             param.setToolTip(tooltip)
         layout.addWidget(param)
@@ -184,10 +184,10 @@ class _WidgetBase(QtWidgets.QWidget):
         layout.addWidget(label)
 
         path_textbox = QtWidgets.QLineEdit()
-        path_textbox.setText(str(value))
+        path_textbox.setText("" if value is None else str(value))
         if placeholder is not None:
             path_textbox.setPlaceholderText(placeholder)
-        path_textbox.textChanged.connect(lambda val: setattr(self, name, val))
+        path_textbox.textChanged.connect(lambda val: setattr(self, name, val if val else None))
         if tooltip:
             path_textbox.setToolTip(tooltip)
 
@@ -1441,7 +1441,7 @@ class EmbeddingWidget(_WidgetBase):
 
         # Process tile_shape and halo, set other data.
         tile_shape, halo = _process_tiling_inputs(self.tile_x, self.tile_y, self.halo_x, self.halo_y)
-        save_path = None if self.embeddings_save_path == "" else self.embeddings_save_path
+        save_path = self.embeddings_save_path
         image_data = image.data
 
         # Set up progress bar and signals for using it within a threadworker.

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -88,7 +88,7 @@ class _WidgetBase(QtWidgets.QWidget):
         param.setText("" if value is None else str(value))
         if placeholder is not None:
             param.setPlaceholderText(placeholder)
-        param.textChanged.connect(lambda val: setattr(self, name, val if val else None))
+        param.textChanged.connect(lambda val: setattr(self, name, val))
         if tooltip:
             param.setToolTip(tooltip)
         layout.addWidget(param)
@@ -1441,7 +1441,7 @@ class EmbeddingWidget(_WidgetBase):
 
         # Process tile_shape and halo, set other data.
         tile_shape, halo = _process_tiling_inputs(self.tile_x, self.tile_y, self.halo_x, self.halo_y)
-        save_path = self.embeddings_save_path
+        save_path = None if self.embeddings_save_path == "" else self.embeddings_save_path
         image_data = image.data
 
         # Set up progress bar and signals for using it within a threadworker.

--- a/micro_sam/sam_annotator/image_series_annotator.py
+++ b/micro_sam/sam_annotator/image_series_annotator.py
@@ -483,7 +483,7 @@ class ImageSeriesAnnotator(widgets._WidgetBase):
         return settings
 
     def _validate_inputs(self):
-        missing_data = self.folder is None or len(glob(os.path.join(self.folder, self.pattern))) == 0
+        missing_data = self.folder is None or len(glob(os.path.join(self.folder, self.pattern or "*"))) == 0
         missing_output = self.output_folder is None
         if missing_data or missing_output:
             msg = ""
@@ -504,7 +504,7 @@ class ImageSeriesAnnotator(widgets._WidgetBase):
         image_folder_annotator(
             input_folder=self.folder,
             output_folder=self.output_folder,
-            pattern=self.pattern,
+            pattern=self.pattern or "*",
             model_type=self.model_type,
             embedding_path=self.embeddings_save_path,
             tile_shape=tile_shape, halo=halo, checkpoint_path=self.custom_weights,

--- a/micro_sam/sam_annotator/training_ui.py
+++ b/micro_sam/sam_annotator/training_ui.py
@@ -222,7 +222,7 @@ class TrainingWidget(widgets._WidgetBase):
         pbar, pbar_signals = widgets._create_pbar_for_threadworker()
 
         self._get_model_type()
-        if self.custom_weights is None:
+        if not self.custom_weights:
             model_registry = util.models()
             checkpoint_path = model_registry.fetch(self.model_type)
         else:

--- a/test/test_sam_annotator/test_widgets.py
+++ b/test/test_sam_annotator/test_widgets.py
@@ -17,8 +17,26 @@ import torch
 import zarr
 
 from micro_sam.sam_annotator._state import AnnotatorState
-from micro_sam.sam_annotator._widgets import EmbeddingWidget
+from micro_sam.sam_annotator._widgets import _WidgetBase, EmbeddingWidget
 from micro_sam.util import _compute_data_signature
+
+
+@pytest.mark.skipif(platform.system() == "Windows", reason="GUI test does not work on Windows.")
+def test_string_and_path_param_empty_value_semantics(qtbot):
+    widget = _WidgetBase()
+    qtbot.addWidget(widget)
+
+    widget.name = "sam_model"
+    name_param, layout = widget._add_string_param("name", widget.name)
+    widget.layout().addLayout(layout)
+    name_param.setText("")
+    assert widget.name == ""
+
+    widget.checkpoint_path = "/path/to/checkpoint.pt"
+    path_param, layout = widget._add_path_param("checkpoint_path", widget.checkpoint_path, "file")
+    widget.layout().addLayout(layout)
+    path_param.setText("")
+    assert widget.checkpoint_path is None
 
 
 # make_napari_viewer is a pytest fixture that returns a napari viewer object


### PR DESCRIPTION
Reported by @ericvillard-paris at https://github.com/computational-cell-analytics/micro-sam/commit/7a77b410303683bcf9faa6a483a3d614c9889982#commitcomment-193484308 (thanks for spotting 😁)

TL&DR on the core issue: when a provided custom weights path is cleared, it then registers it as `""` instead of `None`, so `get_sam_model` goes crazy about it and tries to load an empty checkpoint path and crashes (instead of falling back to the default model). I went ahead and made it modular!

PS. I'll also add @ericvillard-paris as a co-author to my commit in this PR (since you diagnosed and found this issue -- thanks once again 🥳)

I'll merge this once the tests pass, and probably bump the version in a follow-up PR!
