### PR TITLE
Add existing Labels layers as SAM mask inputs

### DIFF
--- a/doc/annotation_tools.md
+++ b/doc/annotation_tools.md
@@ -56,6 +56,23 @@ When `commit_path` is given the results will automatically be saved there.
 
 Point prompts and box prompts can be combined. When you're using point prompts you can only segment one object at a time, unless the `batched` mode is activated. With box prompts you can segment several objects at once, both in the normal and `batched` mode.
 
+### Using existing segmentations
+
+The `Existing Segmentation Inputs` section accepts any compatible napari Labels layer, including segmentations created by Cellpose or another napari plugin.
+Use the checkboxes or the `Select all` and `Unselect all` buttons to choose inputs.
+All nonzero label IDs are treated as objects: equal IDs from multiple selected layers are unioned, while overlapping different IDs must be resolved in napari before continuing.
+The selected layers must have the same spatial shape and data-to-world transform as the selected image; micro-sam does not resample them.
+
+`Refine with SAM` processes every selected object independently and writes the merged result to `current_object`.
+If point or shape corrections are present and the inputs contain several objects, choose the single object ID they apply to.
+The normal `Commit` action then replaces those IDs in `committed_objects` without renumbering them.
+SAM converts each 2D mask prompt to its 256 by 256 low-resolution mask representation, so fine structures may be lost during refinement.
+The source Labels layers are never changed.
+
+`Commit input masks unchanged` bypasses SAM and the embedding computation.
+Use it when an input mask is already satisfactory.
+It preserves the input IDs and atomically unions equal IDs into `committed_objects`; a collision with a different committed ID is rejected.
+
 Check out [the video tutorial](https://youtu.be/9xjJBg_Bfuc) for an in-depth explanation on how to use this tool.
 
 
@@ -81,6 +98,12 @@ Most elements are the same as in [the 2d annotator](#annotator-2d):
 8. The menu for clearing the current annotations. If `all slices` is set all annotations will be cleared, otherwise they are only cleared for the current slice.
 
 You can only segment one object at a time using the interactive segmentation functionality with this tool.
+
+Existing 3D Labels layers can be refined in two ways.
+`Refine all occupied slices` runs 2D mask refinement on each slice where an object exists and preserves the input z-extent.
+`Propagate from seed slices` chooses each object's largest cross-section as its seed (the lowest z wins ties), refines the seed, and propagates it through the selected z-range.
+For SAM-v1 this uses slice-to-slice mask projection; for SAM2 it conditions the video predictor with the already refined seed.
+A 3D point or shape correction is routed to the chosen object ID; in occupied-slice mode it must lie on an occupied slice, while propagation mode can use a positive cue on an empty slice as another anchor.
 
 Check out [the video tutorial](https://youtu.be/nqpyNQSyu74) for an in-depth explanation on how to use this tool.
 

--- a/doc/annotation_tools.md
+++ b/doc/annotation_tools.md
@@ -65,14 +65,18 @@ All nonzero label IDs are treated as objects: equal IDs from multiple selected l
 The selected layers must have the same data-to-world transform as the selected image.
 An input that is exactly one trailing pixel larger on one or more axes is cropped to the image extent, which accommodates new Labels layers created by napari; other shape mismatches are rejected and micro-sam does not resample them.
 
-When mask inputs are selected, `Segment Object` (or `S`) processes every selected object independently and writes the merged result to `current_object`.
+When mask inputs are selected, `Segment Object` (or `S`) uses every nonzero ID as a separate SAM mask prompt and writes the merged result to `current_object`.
 When no mask input is selected, the same action uses the normal point and shape prompt workflow.
-If point or shape corrections are present and the inputs contain several objects, choose the single object ID they apply to.
+Point, scribble and shape corrections carry their own target object ID, so several input objects can receive different corrections in one operation.
+Select prompts in napari and use `Target object ID` to assign them; with no prompt selected, the control sets the target for new corrections.
+Every correction must target one of the IDs in the selected input layers.
+The `Prompt type` control sets selected or new points and scribbles to `Positive (include)` or `Negative (exclude)`.
+Rectangles, ellipses and polygons are always positive because SAM box and dense shape prompts do not have negative semantics.
 The normal `Commit` action then replaces those IDs in `committed_objects` without renumbering them.
 SAM converts each 2D mask prompt to its 256 by 256 low-resolution mask representation, so fine structures may be lost during refinement.
 The source Labels layers are never changed.
 
-`Commit input masks unchanged` bypasses SAM and the embedding computation.
+`Commit selected masks unchanged` bypasses SAM and the embedding computation.
 Use it when an input mask is already satisfactory.
 It preserves the input IDs and atomically unions equal IDs into `committed_objects`; a collision with a different committed ID is rejected.
 
@@ -106,7 +110,7 @@ Existing 3D Labels layers can be refined in two ways.
 `Refine all occupied slices` runs 2D mask refinement on each slice where an object exists and preserves the input z-extent.
 `Propagate from seed slices` chooses each object's largest cross-section as its seed (the lowest z wins ties), refines the seed, and propagates it through the selected z-range.
 For SAM-v1 this uses slice-to-slice mask projection; for SAM2 it conditions the video predictor with the already refined seed.
-A 3D point or shape correction is routed to the chosen object ID; in occupied-slice mode it must lie on an occupied slice, while propagation mode can use a positive cue on an empty slice as another anchor.
+A 3D point or shape correction is routed to its assigned object ID; in occupied-slice mode it must lie on a slice occupied by that object, while propagation mode can use a positive cue on an empty slice as another anchor.
 
 Check out [the video tutorial](https://youtu.be/nqpyNQSyu74) for an in-depth explanation on how to use this tool.
 

--- a/doc/annotation_tools.md
+++ b/doc/annotation_tools.md
@@ -79,6 +79,8 @@ The source Labels layers are never changed.
 `Commit selected masks unchanged` bypasses SAM and the embedding computation.
 Use it when an input mask is already satisfactory.
 It preserves the input IDs and atomically unions equal IDs into `committed_objects`; a collision with a different committed ID is rejected.
+For 3D data, this copies the complete Labels volume without changing its slices.
+See [Using existing 3D segmentations](#using-existing-3d-segmentations) for the refinement choices available for a z-stack.
 
 Check out [the video tutorial](https://youtu.be/9xjJBg_Bfuc) for an in-depth explanation on how to use this tool.
 
@@ -104,13 +106,51 @@ Most elements are the same as in [the 2d annotator](#annotator-2d):
 7. The menu for committing the current object.
 8. The menu for clearing the current annotations. If `all slices` is set all annotations will be cleared, otherwise they are only cleared for the current slice.
 
-You can only segment one object at a time using the interactive segmentation functionality with this tool.
+In the normal prompt-only workflow, interactive 3D segmentation handles one object at a time.
+Existing segmentation inputs are different: `Segment Object` processes every nonzero Labels ID independently and merges the results while preserving the IDs.
 
-Existing 3D Labels layers can be refined in two ways.
-`Refine all occupied slices` runs 2D mask refinement on each slice where an object exists and preserves the input z-extent.
-`Propagate from seed slices` chooses each object's largest cross-section as its seed (the lowest z wins ties), refines the seed, and propagates it through the selected z-range.
-For SAM-v1 this uses slice-to-slice mask projection; for SAM2 it conditions the video predictor with the already refined seed.
-A 3D point or shape correction is routed to its assigned object ID; in occupied-slice mode it must lie on a slice occupied by that object, while propagation mode can use a positive cue on an empty slice as another anchor.
+### Using existing 3D segmentations
+
+A selected 3D Labels layer is a full `(z, y, x)` volume aligned with the selected image.
+IDs are interpreted across the complete volume, so every voxel with label `7`, for example, belongs to object ID 7 even when the object has gaps along z.
+Prepare and relabel the data in napari before selecting it if this is not the intended meaning.
+
+SAM does not receive this volume as one native 3D mask prompt.
+The plugin splits each object into 2D masks and handles the z-axis as a sequence: SAM-v1 refines or projects masks one slice at a time, while SAM2 treats z like video frames.
+Neither method understands physical depth or voxel spacing as a 3D model would.
+
+If the input is already correct, use `Commit selected masks unchanged`.
+This copies the complete volume without running SAM, computing embeddings or converting masks to SAM's 256 by 256 prompt representation.
+It is both faster and lossless compared with refinement.
+
+If the masks need correction, choose one of the following `3D behavior` options and press `Segment Object` or `S`.
+While Labels inputs are selected, this choice controls how the volume is processed; `Batched` and `Apply to Volume` do not affect mask refinement.
+`Apply to Volume` still controls whether `Clear Annotations` clears the current slice or the complete volume.
+
+#### Refine existing slices only
+
+This option refines every slice where each object ID already has pixels.
+It does not create the object on empty slices, so the input z-extent and any gaps are preserved.
+Corrections for an object must be placed on a slice where that object ID is already present.
+Choose this for a complete 3D segmentation whose slice coverage is correct but whose 2D boundaries need adjustment.
+
+#### Refine and extend through z
+
+This option is intended for a sparse or incomplete 3D segmentation.
+For each object ID, the plugin chooses the slice with the largest mask area as the initial seed; if several slices tie, it chooses the lowest z-index.
+Slices with corrections assigned to that ID are also refined and used as anchors.
+Other occupied input slices are not used as anchors, which keeps the behavior deterministic and easy to understand.
+The object is then extended independently through the selected z-range, so this mode can fill missing slices or expand beyond the original z-extent.
+Because every object is propagated independently, results may drift or overlap and should be reviewed before committing.
+
+SAM-v1 extends the result with slice-to-slice mask projection and may stop when overlap between adjacent slices becomes too small.
+SAM2 conditions its video predictor with the refined anchor masks and propagates them as frames.
+The propagation z-range is an inclusive hard limit for both model families.
+`Stop after empty slices` is used only by SAM2 and is ignored by SAM-v1.
+
+As a practical rule, commit a correct input unchanged, use `Refine existing slices only` when only boundaries need work, and use `Refine and extend through z` when slices are missing.
+In both refinement modes, every 2D input mask is converted to SAM's 256 by 256 low-resolution mask representation, so very thin or fine structures may be lost.
+The source Labels layers are never modified; the refined result is written to `current_object` for review.
 
 Check out [the video tutorial](https://youtu.be/nqpyNQSyu74) for an in-depth explanation on how to use this tool.
 

--- a/doc/annotation_tools.md
+++ b/doc/annotation_tools.md
@@ -58,12 +58,15 @@ Point prompts and box prompts can be combined. When you're using point prompts y
 
 ### Using existing segmentations
 
-The `Existing Segmentation Inputs` section accepts any compatible napari Labels layer, including segmentations created by Cellpose or another napari plugin.
+The `Existing Segmentation Inputs` section accepts compatible napari Labels layers, including segmentations created by Cellpose or another napari plugin.
+The internal `current_object`, `auto_segmentation` and `committed_objects` output layers are not listed; duplicate one in napari first if you intentionally want to reuse it as an input.
 Use the checkboxes or the `Select all` and `Unselect all` buttons to choose inputs.
 All nonzero label IDs are treated as objects: equal IDs from multiple selected layers are unioned, while overlapping different IDs must be resolved in napari before continuing.
-The selected layers must have the same spatial shape and data-to-world transform as the selected image; micro-sam does not resample them.
+The selected layers must have the same data-to-world transform as the selected image.
+An input that is exactly one trailing pixel larger on one or more axes is cropped to the image extent, which accommodates new Labels layers created by napari; other shape mismatches are rejected and micro-sam does not resample them.
 
-`Refine with SAM` processes every selected object independently and writes the merged result to `current_object`.
+When mask inputs are selected, `Segment Object` (or `S`) processes every selected object independently and writes the merged result to `current_object`.
+When no mask input is selected, the same action uses the normal point and shape prompt workflow.
 If point or shape corrections are present and the inputs contain several objects, choose the single object ID they apply to.
 The normal `Commit` action then replaces those IDs in `committed_objects` without renumbering them.
 SAM converts each 2D mask prompt to its 256 by 256 low-resolution mask representation, so fine structures may be lost during refinement.

--- a/micro_sam/sam_annotator/_annotator.py
+++ b/micro_sam/sam_annotator/_annotator.py
@@ -154,8 +154,15 @@ class _AnnotatorBase(QtWidgets.QScrollArea):
         shape_prompt_layer = self._viewer.layers["prompts"]
         linked_layers = [shape_prompt_layer] if "label" in shape_prompt_layer.current_properties else None
         self._prompt_widget = widgets.create_prompt_menu(
-            self._point_prompt_layer, self._point_labels, linked_layers=linked_layers,
+            self._point_prompt_layer,
+            self._point_labels,
+            menu_name="Prompt type",
+            linked_layers=linked_layers,
             viewer=self._viewer,
+            choice_labels={
+                "positive": "Positive (include)",
+                "negative": "Negative (exclude)",
+            },
         )
 
         # Create the dictionary for the widgets and get the widgets of the child plugin.
@@ -328,8 +335,15 @@ class _AnnotatorBase(QtWidgets.QScrollArea):
         shape_prompt_layer = self._viewer.layers["prompts"]
         linked_layers = [shape_prompt_layer] if "label" in shape_prompt_layer.current_properties else None
         self._prompt_widget = widgets.create_prompt_menu(
-            self._point_prompt_layer, self._point_labels, linked_layers=linked_layers,
+            self._point_prompt_layer,
+            self._point_labels,
+            menu_name="Prompt type",
+            linked_layers=linked_layers,
             viewer=self._viewer,
+            choice_labels={
+                "positive": "Positive (include)",
+                "negative": "Negative (exclude)",
+            },
         )
 
         # Rebuild the dimension-specific widgets, keeping the shared embedding widget.

--- a/micro_sam/sam_annotator/_tooltips.py
+++ b/micro_sam/sam_annotator/_tooltips.py
@@ -25,13 +25,13 @@ tooltips = {
     "segmentnd": {
         "box_extension": "Enter the factor by which the box size grows when it projects to adjacent slices. Larger factors help if object sizes change between slices.",  # noqa
         "iou_threshold": "Enter the minimal overlap between objects in adjacent slices to continue segmentation.",
-        "early_stop_patience": "SAM2 volume mode: stop propagation once the object is absent for this many slices in a row. Lower values stop sooner (faster). A value of 0 disables early stopping and propagates through the whole volume.",  # noqa
-        "use_full_z_range": "SAM2 volume mode: propagate through all slices along z. Uncheck to restrict propagation to a chosen slice range with the slider below (faster, and a hard guardrail against leaking into neighbouring structures).",  # noqa
-        "z_range": "SAM2 volume mode: the inclusive range of slices (along z) that propagation is allowed to cover. Only used when 'Propagate through full volume' is unchecked.",  # noqa
+        "early_stop_patience": "SAM2 only: stop propagation once the object is absent for this many slices in a row. Lower values stop sooner. A value of 0 disables this automatic stopping. SAM-v1 mask propagation does not use this setting.",  # noqa
+        "use_full_z_range": "Propagate through every z-slice. Uncheck to restrict propagation to the inclusive range selected below. A restricted range is faster and helps prevent propagation into unrelated structures.",  # noqa
+        "z_range": "The inclusive range of z-slices that propagation may cover. This is used by both SAM-v1 and SAM2 when 'Propagate through all slices' is unchecked. Every seed and correction anchor must be inside the range.",  # noqa
         "motion_smoothing": "Enter the motion smoothing factor. It helps to follow objects that have a directed movement. Higher values help for fast objects.",  # noqa
         "projection_dropdown": "Choose the projection mode. It determines which prompts are derived from the masks projected to adjacent frames to rerun SAM.",  # noqa
         "batched": "Enable to segment multiple objects with separate point prompts. The tool tracks each positive point as a separate object. Only available for SAM2 models.",  # noqa
-        "settings": "Settings controlling how a 2d segmentation is propagated through the volume (projection mode, IoU threshold, early stopping and the z-range).",  # noqa
+        "settings": "Settings controlling how 2d masks are propagated through a z-stack. The z-range applies to SAM-v1 and SAM2; stopping after empty slices applies only to SAM2.",  # noqa
     },
     "unified_segment": {
         "apply_to_volume": "Choose whether to segment only the current slice or frame, or the full volume or all frames.",  # noqa
@@ -83,6 +83,14 @@ tooltips = {
     },
     "prompt_menu": {
         "labels": "Choose positive point/scribble prompts to include regions or negative ones to exclude regions. Toggle between the settings by pressing [t]. In 3d, a scribble belongs to the z-slice where it was drawn and can seed or correct volume propagation.",  # noqa
+    },
+    "mask_inputs": {
+        "layer_list": "Select one or more compatible Labels layers. For a 3d image, each selected layer must be a full (z, y, x) volume aligned with the image.",  # noqa
+        "commit_unchanged": "Copy the complete selected Labels data directly into committed objects. This does not run SAM, compute embeddings or downsample the masks, so it is the safest choice when the input segmentation is already correct.",  # noqa
+        "target_object": "Assign selected point or shape corrections to one object ID from the checked Labels layers. With no correction selected, this chooses the ID for new points and shapes.",  # noqa
+        "3d_behavior": "Choose whether Segment Object refines only the z-slices where each ID already exists, or starts from selected seed slices and extends the objects through z. SAM processes 2d slices; it does not receive a native 3d mask prompt.",  # noqa
+        "batched_ignored": "Batched point-prompt segmentation is not used while Labels mask inputs are selected. Each Labels object ID is already processed independently.",  # noqa
+        "apply_to_volume_ignored": "Labels mask inputs always use the selected 3d behavior. Apply to Volume does not change mask refinement; it still controls whether Clear Annotations clears one slice or the whole volume.",  # noqa
     },
     "annotator_tracking": {
         "track_id": "Select the id of the track you are currently annotating.",

--- a/micro_sam/sam_annotator/_tooltips.py
+++ b/micro_sam/sam_annotator/_tooltips.py
@@ -37,7 +37,10 @@ tooltips = {
         "apply_to_volume": "Choose whether to segment only the current slice or frame, or the full volume or all frames.",  # noqa
         "batched": "Enable to segment multiple objects at once: each positive point and each box defines a separate object. Only available for SAM2 models.",  # noqa
         "batched_scribble_disabled": "Batched segmentation is unavailable while scribble prompts are present. Remove all path, polyline and line prompts to re-enable it.",  # noqa
-        "segment_button": "Run Segment Anything 2 on the current point/box prompts to segment the object. Shortcut: S.",  # noqa
+        "segment_button": (
+            "Run Segment Anything on the selected existing-segmentation inputs, or on the current "
+            "point/shape prompts when no mask input is selected. Shortcut: S."
+        ),
         "clear_button": "Clear the current prompts and the current-object segmentation (whole volume or current slice per 'Apply to Volume' for 3d data). Shortcut: Shift + C.",  # noqa
         "settings": "Settings for interactive segmentation across slices (projection mode and propagation parameters).",  # noqa
     },

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -1267,12 +1267,16 @@ def export_track(
 
 def create_prompt_menu(
     points_layer, labels, menu_name="prompt", label_name="label", linked_layers=None, viewer=None,
+    choice_labels=None,
 ):
     """Create a menu that keeps point and optional shape prompt labels synchronized."""
     prompt_layers = [points_layer] + ([] if linked_layers is None else list(linked_layers))
+    choices = labels if choice_labels is None else [
+        (choice_labels.get(label, str(label)), label) for label in labels
+    ]
     label_menu = ComboBox(
         label=menu_name,
-        choices=labels,
+        choices=choices,
         tooltip=get_tooltip("prompt_menu", "labels"),
     )
     label_widget = Container(widgets=[label_menu])
@@ -3599,19 +3603,32 @@ class InteractiveSegmentationWidget(_WidgetBase):
         self._mask_layer_items = {}
         self._connected_mask_layers = set()
         self._connected_mask_images = set()
+        self._updating_prompt_targets = False
+        self._last_prompt_target_id = None
         self._excluded_mask_layer_ids = {
             id(self._viewer.layers[name])
             for name in ("current_object", "auto_segmentation", "committed_objects")
             if name in self._viewer.layers
         }
+        for layer_name in ("point_prompts", "prompts"):
+            vutil.ensure_prompt_object_ids(self._viewer.layers[layer_name])
         self._create_widget()
 
     def _create_widget(self):
-        # Prompt label menu.
-        self.layout().addWidget(self._prompt_widget.native)
-
         self._mask_input_widget = self._create_mask_input_widget()
         self.layout().addWidget(self._mask_input_widget)
+
+        prompt_properties = QtWidgets.QGroupBox("Point and scribble prompts")
+        prompt_properties.setLayout(QtWidgets.QVBoxLayout())
+        prompt_info = QtWidgets.QLabel(
+            "Set selected points or scribbles to foreground or background. With no prompt "
+            "selected, this controls how new points and scribbles are added. Rectangles, "
+            "ellipses and polygons are always positive."
+        )
+        prompt_info.setWordWrap(True)
+        prompt_properties.layout().addWidget(prompt_info)
+        prompt_properties.layout().addWidget(self._prompt_widget.native)
+        self.layout().addWidget(prompt_properties)
 
         self.clear_button = QtWidgets.QPushButton("Clear Annotations [Shift + C]")
         self.clear_button.setToolTip(get_tooltip("unified_segment", "clear_button"))
@@ -3685,6 +3702,18 @@ class InteractiveSegmentationWidget(_WidgetBase):
         self._viewer.layers["prompts"].events.data.connect(self._update_batched_visibility)
         self._viewer.layers["prompts"].events.data.connect(self._update_mask_input_controls)
         self._viewer.layers["point_prompts"].events.data.connect(self._update_mask_input_controls)
+        self._viewer.layers["prompts"].events.current_properties.connect(
+            self._sync_correction_target_from_prompts
+        )
+        self._viewer.layers["point_prompts"].events.current_properties.connect(
+            self._sync_correction_target_from_prompts
+        )
+        self._viewer.layers["prompts"].selected_data.events.items_changed.connect(
+            self._on_prompt_selection_changed
+        )
+        self._viewer.layers["point_prompts"].selected_data.events.items_changed.connect(
+            self._on_prompt_selection_changed
+        )
         for event_name in ("inserted", "removed", "reordered"):
             event = getattr(self._viewer.layers.events, event_name, None)
             if event is not None:
@@ -3700,8 +3729,8 @@ class InteractiveSegmentationWidget(_WidgetBase):
         container.setLayout(QtWidgets.QVBoxLayout())
 
         intro = QtWidgets.QLabel(
-            "Select one or more Labels layers, then use Segment Object [S] to refine them with SAM. "
-            "Equal IDs are unioned; overlapping different IDs are rejected."
+            "Select one or more Labels layers. Segment Object [S] uses every nonzero ID as a "
+            "separate SAM mask prompt. Equal IDs are unioned; overlapping different IDs are rejected."
         )
         intro.setWordWrap(True)
         container.layout().addWidget(intro)
@@ -3724,12 +3753,26 @@ class InteractiveSegmentationWidget(_WidgetBase):
         self.mask_input_summary.setWordWrap(True)
         container.layout().addWidget(self.mask_input_summary)
 
+        self.commit_masks_button = QtWidgets.QPushButton("Commit selected masks unchanged")
+        self.commit_masks_button.clicked.connect(self._commit_selected_masks_unchanged)
+        container.layout().addWidget(self.commit_masks_button)
+
+        self.correction_target_help = QtWidgets.QLabel(
+            "Corrections are assigned per object. Select points or shapes, then assign them to an "
+            "input object ID. With no prompt selected, this ID is used for new corrections."
+        )
+        self.correction_target_help.setWordWrap(True)
+        self.correction_target_help.setVisible(False)
+        container.layout().addWidget(self.correction_target_help)
+
         self.correction_target_row = QtWidgets.QWidget()
         correction_layout = QtWidgets.QHBoxLayout()
         correction_layout.setContentsMargins(0, 0, 0, 0)
         self.correction_target_row.setLayout(correction_layout)
-        correction_layout.addWidget(QtWidgets.QLabel("Corrections apply to object ID"))
+        correction_layout.addWidget(QtWidgets.QLabel("Target object ID"))
         self.correction_target = QtWidgets.QComboBox()
+        self.correction_target.setPlaceholderText("Choose object ID")
+        self.correction_target.currentIndexChanged.connect(self._on_correction_target_changed)
         correction_layout.addWidget(self.correction_target)
         self.correction_target_row.setVisible(False)
         container.layout().addWidget(self.correction_target_row)
@@ -3742,10 +3785,6 @@ class InteractiveSegmentationWidget(_WidgetBase):
             self.mask_3d_strategy.currentTextChanged.connect(self._update_propagation_visibility)
             strategy_row.addWidget(self.mask_3d_strategy)
             container.layout().addLayout(strategy_row)
-
-        self.commit_masks_button = QtWidgets.QPushButton("Commit input masks unchanged")
-        self.commit_masks_button.clicked.connect(self._commit_selected_masks_unchanged)
-        container.layout().addWidget(self.commit_masks_button)
 
         return _make_collapsible(
             container,
@@ -3765,6 +3804,11 @@ class InteractiveSegmentationWidget(_WidgetBase):
 
     def _refresh_mask_layer_list(self, event=None):
         """Refresh the checklist while preserving checks by layer identity."""
+        self._excluded_mask_layer_ids.update(
+            id(self._viewer.layers[name])
+            for name in ("current_object", "auto_segmentation", "committed_objects")
+            if name in self._viewer.layers
+        )
         checked = {
             layer_id
             for layer_id, (_, item) in self._mask_layer_items.items()
@@ -3782,6 +3826,9 @@ class InteractiveSegmentationWidget(_WidgetBase):
             self._connected_mask_images.add(id(image_layer))
         for layer in self._viewer.layers:
             if not isinstance(layer, napari.layers.Labels):
+                continue
+            if layer.name in ("current_object", "auto_segmentation", "committed_objects"):
+                self._excluded_mask_layer_ids.add(id(layer))
                 continue
             if id(layer) in self._excluded_mask_layer_ids:
                 continue
@@ -3850,6 +3897,103 @@ class InteractiveSegmentationWidget(_WidgetBase):
             or len(self._viewer.layers["prompts"].data)
         )
 
+    def _set_only_prompt_target(self, object_id):
+        """Assign every existing and future correction to the only available object."""
+        object_id_string = str(int(object_id))
+        was_updating = self._updating_prompt_targets
+        self._updating_prompt_targets = True
+        try:
+            for layer_name in ("point_prompts", "prompts"):
+                layer = self._viewer.layers[layer_name]
+                vutil.ensure_prompt_object_ids(layer)
+                current_properties = dict(layer.current_properties)
+                properties = dict(layer.properties)
+                properties["object_id"] = np.full(len(layer.data), object_id_string, dtype=object)
+                layer.properties = properties
+                current_properties["object_id"] = np.array([object_id_string])
+                selected_data = set(layer.selected_data)
+                if selected_data:
+                    layer.selected_data = set()
+                layer.current_properties = current_properties
+                if selected_data:
+                    layer.selected_data = selected_data
+        finally:
+            self._updating_prompt_targets = was_updating
+
+    def _on_correction_target_changed(self, index):
+        if self._updating_prompt_targets:
+            return
+        object_id = self.correction_target.itemData(index) if index >= 0 else None
+        if object_id is None:
+            return
+        self._last_prompt_target_id = int(object_id)
+        self._updating_prompt_targets = True
+        try:
+            for layer_name in ("point_prompts", "prompts"):
+                layer = self._viewer.layers[layer_name]
+                vutil.set_prompt_object_id(
+                    layer, object_id, relabel_selected=bool(layer.selected_data),
+                )
+        finally:
+            self._updating_prompt_targets = False
+
+    def _on_prompt_selection_changed(self, *args):
+        self._sync_correction_target_from_prompts()
+
+    def _sync_correction_target_from_prompts(self, event=None):
+        """Reflect selected prompt target IDs in the target object combo box."""
+        if self._updating_prompt_targets or self.correction_target_row.isHidden():
+            return
+
+        selected_ids = []
+        for layer_name in ("point_prompts", "prompts"):
+            layer = self._viewer.layers[layer_name]
+            properties = layer.properties.get("object_id", [])
+            selected_ids.extend(
+                int(properties[index])
+                for index in layer.selected_data
+                if 0 <= index < len(properties)
+            )
+
+        if selected_ids:
+            target_ids = set(selected_ids)
+        elif event is not None and hasattr(event, "source"):
+            current = event.source.current_properties.get(
+                "object_id", np.array([vutil.UNASSIGNED_OBJECT_ID]),
+            )
+            target_ids = {int(current[0])}
+        else:
+            object_id = self.correction_target.currentData()
+            if object_id is None:
+                object_id = self._last_prompt_target_id
+            target_ids = set() if object_id is None else {int(object_id)}
+
+        self.correction_target.blockSignals(True)
+        if len(target_ids) == 1:
+            object_id = next(iter(target_ids))
+            index = self.correction_target.findData(object_id)
+            self.correction_target.setPlaceholderText("Choose object ID")
+            self.correction_target.setCurrentIndex(index)
+            if index >= 0:
+                self._last_prompt_target_id = object_id
+        else:
+            self.correction_target.setPlaceholderText(
+                "Multiple target IDs" if target_ids else "Choose object ID"
+            )
+            self.correction_target.setCurrentIndex(-1)
+        self.correction_target.blockSignals(False)
+
+        if len(target_ids) == 1 and self.correction_target.currentIndex() >= 0:
+            object_id = next(iter(target_ids))
+            self._updating_prompt_targets = True
+            try:
+                for layer_name in ("point_prompts", "prompts"):
+                    layer = self._viewer.layers[layer_name]
+                    if not layer.selected_data:
+                        vutil.set_prompt_object_id(layer, object_id, relabel_selected=False)
+            finally:
+                self._updating_prompt_targets = False
+
     def _update_mask_input_controls(self, event=None):
         """Show live selection validity and correction-target routing."""
         try:
@@ -3869,45 +4013,57 @@ class InteractiveSegmentationWidget(_WidgetBase):
                 )
             self.mask_input_summary.setText(summary)
 
-        have_corrections = self._have_correction_prompts()
-        self.correction_target_row.setVisible(have_corrections)
+        valid = mask_inputs is not None
+        self.correction_target_help.setVisible(valid)
+        self.correction_target_row.setVisible(valid)
         previous = self.correction_target.currentData()
         self.correction_target.blockSignals(True)
         self.correction_target.clear()
         if mask_inputs is not None:
-            if len(mask_inputs.object_ids) > 1:
-                self.correction_target.addItem("Choose object ID", None)
             for object_id in mask_inputs.object_ids:
                 self.correction_target.addItem(str(object_id), object_id)
             if len(mask_inputs.object_ids) == 1:
+                self._set_only_prompt_target(mask_inputs.object_ids[0])
+                self._last_prompt_target_id = mask_inputs.object_ids[0]
                 self.correction_target.setCurrentIndex(0)
                 self.correction_target.setEnabled(False)
             else:
                 index = self.correction_target.findData(previous)
-                self.correction_target.setCurrentIndex(max(index, 0))
+                if index < 0:
+                    index = self.correction_target.findData(self._last_prompt_target_id)
+                self.correction_target.setCurrentIndex(index)
                 self.correction_target.setEnabled(True)
         self.correction_target.blockSignals(False)
 
-        valid = mask_inputs is not None
         self.commit_masks_button.setEnabled(valid)
 
-    def _correction_object_id(self, mask_inputs):
-        if not self._have_correction_prompts():
-            return None
-        if len(mask_inputs.object_ids) == 1:
-            return mask_inputs.object_ids[0]
-        object_id = self.correction_target.currentData()
-        if object_id is None:
-            raise ValueError("Choose the object ID that the current point and shape corrections apply to.")
-        return int(object_id)
+    def _validate_prompt_target_ids(self, mask_inputs):
+        """Require every correction prompt to target one of the selected mask IDs."""
+        valid_ids = set(mask_inputs.object_ids)
+        invalid = []
+        for layer_name in ("point_prompts", "prompts"):
+            layer = self._viewer.layers[layer_name]
+            vutil.ensure_prompt_object_ids(layer)
+            object_ids = list(map(int, layer.properties["object_id"]))
+            invalid.extend(
+                f"{layer_name}[{index}]={object_id}"
+                for index, object_id in enumerate(object_ids)
+                if object_id not in valid_ids
+            )
+        if invalid:
+            raise ValueError(
+                "Assign every correction prompt to one of the selected input object IDs. "
+                "Invalid or unassigned targets: " + ", ".join(invalid)
+            )
 
-    def _collect_mask_prompts(self, base_mask, z=None):
-        """Combine one external mask with all corrections for its selected object and frame."""
+    def _collect_mask_prompts(self, base_mask, object_id, z=None):
+        """Combine one external mask with corrections assigned to its object and frame."""
         prompts = vutil.collect_frame_prompts(
             self._viewer.layers["point_prompts"],
             self._viewer.layers["prompts"],
             tuple(base_mask.shape),
             i=z,
+            object_id=object_id,
             with_stop_annotation=False,
         )
         dense = np.asarray(base_mask, dtype=bool).copy()
@@ -3931,20 +4087,10 @@ class InteractiveSegmentationWidget(_WidgetBase):
             ])
         return dense, box, prompts
 
-    def _refine_mask_slice(self, base_mask, z=None, with_corrections=False):
+    def _refine_mask_slice(self, base_mask, object_id, z=None):
         """Refine one logical mask through the active SAM implementation."""
-        if with_corrections:
-            dense, box, prompts = self._collect_mask_prompts(base_mask, z=z)
-            points, labels = prompts.points, prompts.labels
-        else:
-            dense = np.asarray(base_mask, dtype=bool)
-            coordinates = np.argwhere(dense)
-            if not len(coordinates):
-                return None
-            lower, upper = coordinates.min(axis=0), coordinates.max(axis=0)
-            box = np.array([lower[0], lower[1], upper[0], upper[1]], dtype="float64")
-            points = np.empty((0, 2), dtype="float64")
-            labels = np.empty((0,), dtype="int64")
+        dense, box, prompts = self._collect_mask_prompts(base_mask, object_id=object_id, z=z)
+        points, labels = prompts.points, prompts.labels
 
         state = AnnotatorState()
         if box is None:
@@ -4028,15 +4174,22 @@ class InteractiveSegmentationWidget(_WidgetBase):
                 )
         return None if seg is None else np.asarray(seg).squeeze().astype(bool)
 
-    def _correction_slices(self):
+    def _correction_slices(self, object_id):
         if self._ndim != 3:
             return set()
         slices = set()
-        point_data = np.asarray(self._viewer.layers["point_prompts"].data)
+        point_layer = self._viewer.layers["point_prompts"]
+        point_data = np.asarray(point_layer.data)
         if point_data.size:
-            slices.update(np.round(point_data[:, 0]).astype(int).tolist())
-        for shape in self._viewer.layers["prompts"].data:
-            slices.add(int(round(float(np.asarray(shape)[0, 0]))))
+            point_ids = np.asarray(list(map(int, point_layer.properties["object_id"])))
+            slices.update(
+                np.round(point_data[point_ids == object_id, 0]).astype(int).tolist()
+            )
+        shape_layer = self._viewer.layers["prompts"]
+        shape_ids = list(map(int, shape_layer.properties["object_id"]))
+        for shape, shape_id in zip(shape_layer.data, shape_ids):
+            if shape_id == object_id:
+                slices.add(int(round(float(np.asarray(shape)[0, 0]))))
         return slices
 
     def _seed_slice(self, mask_inputs, object_id):
@@ -4047,53 +4200,46 @@ class InteractiveSegmentationWidget(_WidgetBase):
         }
         return min(slices, key=lambda z: (-areas[z], z))
 
-    def _refine_masks_occupied(self, mask_inputs, correction_id):
+    def _refine_masks_occupied(self, mask_inputs):
         candidates = {
             object_id: np.zeros(mask_inputs.labels.shape, dtype=bool)
             for object_id in mask_inputs.object_ids
         }
-        correction_slices = self._correction_slices()
-        if correction_id is not None:
-            absent = correction_slices.difference(mask_inputs.occupied_slices[correction_id])
+        correction_slices = {
+            object_id: self._correction_slices(object_id)
+            for object_id in mask_inputs.object_ids
+        }
+        for object_id in mask_inputs.object_ids:
+            absent = correction_slices[object_id].difference(mask_inputs.occupied_slices[object_id])
             if absent:
                 raise ValueError(
                     "In 'Refine all occupied slices' mode, corrections must be on a slice occupied "
-                    f"by object ID {correction_id}. Invalid slices: {sorted(absent)}."
+                    f"by object ID {object_id}. Invalid slices: {sorted(absent)}."
                 )
 
         for object_id, z, mask in vutil.iter_mask_input_masks(mask_inputs):
-            refined = self._refine_mask_slice(
-                mask,
-                z=z,
-                with_corrections=(object_id == correction_id and z in correction_slices),
-            )
+            refined = self._refine_mask_slice(mask, object_id=object_id, z=z)
             if refined is None:
                 raise ValueError(f"SAM did not return a mask for object ID {object_id} on slice {z}.")
             candidates[object_id][z] = refined
         return candidates
 
-    def _refine_masks_propagated(self, mask_inputs, correction_id):
+    def _refine_masks_propagated(self, mask_inputs):
         """Refine deterministic seeds, then propagate each object independently."""
         state = AnnotatorState()
-        correction_slices = self._correction_slices()
         candidates = {}
 
         for object_id in mask_inputs.object_ids:
             seed = self._seed_slice(mask_inputs, object_id)
             anchor_slices = {seed}
-            if object_id == correction_id:
-                anchor_slices.update(correction_slices)
+            anchor_slices.update(self._correction_slices(object_id))
 
             seed_volume = np.zeros(mask_inputs.labels.shape, dtype="uint32")
             valid_anchors = []
             stop_slices = set()
             for z in sorted(anchor_slices):
                 base = mask_inputs.labels[z] == object_id
-                refined = self._refine_mask_slice(
-                    base,
-                    z=z,
-                    with_corrections=(object_id == correction_id and z in correction_slices),
-                )
+                refined = self._refine_mask_slice(base, object_id=object_id, z=z)
                 if refined is None:
                     stop_slices.add(z)
                     continue
@@ -4190,24 +4336,22 @@ class InteractiveSegmentationWidget(_WidgetBase):
         )
         try:
             mask_inputs = self._collect_mask_inputs()
-            correction_id = self._correction_object_id(mask_inputs)
+            self._validate_prompt_target_ids(mask_inputs)
             if _validate_embeddings(self._viewer):
                 return
 
             if self._ndim == 2:
                 candidates = {}
                 for object_id, _, mask in vutil.iter_mask_input_masks(mask_inputs):
-                    refined = self._refine_mask_slice(
-                        mask, with_corrections=(object_id == correction_id),
-                    )
+                    refined = self._refine_mask_slice(mask, object_id=object_id)
                     if refined is None:
                         raise ValueError(f"SAM did not return a mask for object ID {object_id}.")
                     candidates[object_id] = refined
             elif self.mask_3d_strategy.currentText() == "Propagate from seed slices":
                 self._sync_propagation_settings()
-                candidates = self._refine_masks_propagated(mask_inputs, correction_id)
+                candidates = self._refine_masks_propagated(mask_inputs)
             else:
-                candidates = self._refine_masks_occupied(mask_inputs, correction_id)
+                candidates = self._refine_masks_occupied(mask_inputs)
 
             refined_labels = vutil.merge_refined_mask_candidates(mask_inputs.labels, candidates)
             refined_ids = tuple(int(value) for value in np.unique(refined_labels) if value != 0)

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -754,6 +754,23 @@ def _commit_impl(viewer, layer, preserve_mode, preservation_threshold):
     # Check whether all layers exist as expected or create new ones automatically.
     state.annotator._require_layers(layer_choices=[layer, "committed_objects"])
 
+    # Refined mask inputs are authoritative replacements for their source IDs. They deliberately
+    # bypass the ordinary id-offset and preservation modes so Cellpose (or other external) IDs stay
+    # stable across the refine/commit round-trip.
+    source = viewer.layers[layer]
+    provenance = source.metadata.get("micro_sam_mask_refinement")
+    if layer == "current_object" and provenance is not None:
+        destination = viewer.layers["committed_objects"]
+        merged = vutil.merge_labels_for_refined_commit(
+            destination.data, source.data, provenance["object_ids"],
+        )
+        destination.data = merged
+        destination.refresh()
+        mask = np.asarray(source.data) != 0
+        if state.interactive_segmenter is not None:
+            state.interactive_segmenter.reset_predictor()
+        return 0, np.asarray(source.data), mask, np.s_[:]
+
     # Check if we have a z_range. If yes, use it to set a bounding box.
     if state.z_range is None:
         bb = np.s_[:]
@@ -1098,10 +1115,16 @@ def commit(
             "Saving committed results to 'commit_path' is not supported yet and will be added in a future release."
         )
 
-    # Commit the segmentation layer.
-    _commit_impl(viewer, layer, preserve_mode, preservation_threshold)
+    # Commit the segmentation layer. Refined-mask conflicts are reported without clearing the
+    # result or prompts, so the user can resolve the conflicting committed object and retry.
+    try:
+        _commit_impl(viewer, layer, preserve_mode, preservation_threshold)
+    except ValueError as error:
+        _generate_message("error", str(error))
+        return
 
     if layer == "current_object":
+        viewer.layers["current_object"].metadata.pop("micro_sam_mask_refinement", None)
         vutil.clear_annotations(viewer)
     else:
         viewer.layers["auto_segmentation"].data = np.zeros(
@@ -1627,8 +1650,10 @@ def _segment_object_2d(viewer, batched=False):
         )
         return
 
-    viewer.layers["current_object"].data = seg
-    viewer.layers["current_object"].refresh()
+    current_object = viewer.layers["current_object"]
+    current_object.metadata.pop("micro_sam_mask_refinement", None)
+    current_object.data = seg
+    current_object.refresh()
 
 
 @magic_factory(call_button="Segment Object [S]")
@@ -3030,8 +3055,10 @@ class UnifiedSegmentWidget(_WidgetBase):
             )
             return
 
-        self._viewer.layers["current_object"].data[z] = seg
-        self._viewer.layers["current_object"].refresh()
+        current_object = self._viewer.layers["current_object"]
+        current_object.metadata.pop("micro_sam_mask_refinement", None)
+        current_object.data[z] = seg
+        current_object.refresh()
 
     def _segment_slice_batched(self, z, points, labels, boxes, masks, shape):
         """Batched multi-object segmentation for a single slice with SAM2.
@@ -3279,8 +3306,10 @@ class UnifiedSegmentWidget(_WidgetBase):
         seg = volumetric_segmentation_impl()
         if seg is None:
             return None
-        self._viewer.layers["current_object"].data = seg
-        self._viewer.layers["current_object"].refresh()
+        current_object = self._viewer.layers["current_object"]
+        current_object.metadata.pop("micro_sam_mask_refinement", None)
+        current_object.data = seg
+        current_object.refresh()
         # worker = volumetric_segmentation_impl()
         # worker.returned.connect(update_segmentation)
         # worker.start()
@@ -3567,11 +3596,17 @@ class InteractiveSegmentationWidget(_WidgetBase):
         self.apply_to_volume = False
         self._segment_widget = None
         self._propagation_settings = None
+        self._mask_layer_items = {}
+        self._connected_mask_layers = set()
+        self._connected_mask_images = set()
         self._create_widget()
 
     def _create_widget(self):
         # Prompt label menu.
         self.layout().addWidget(self._prompt_widget.native)
+
+        self._mask_input_widget = self._create_mask_input_widget()
+        self.layout().addWidget(self._mask_input_widget)
 
         self.clear_button = QtWidgets.QPushButton("Clear Annotations [Shift + C]")
         self.clear_button.setToolTip(get_tooltip("unified_segment", "clear_button"))
@@ -3643,9 +3678,594 @@ class InteractiveSegmentationWidget(_WidgetBase):
         # separate objects in batched mode. Keep the control in sync as scribbles are added or
         # removed from the shared prompt layer.
         self._viewer.layers["prompts"].events.data.connect(self._update_batched_visibility)
+        self._viewer.layers["prompts"].events.data.connect(self._update_mask_input_controls)
+        self._viewer.layers["point_prompts"].events.data.connect(self._update_mask_input_controls)
+        for event_name in ("inserted", "removed", "reordered"):
+            event = getattr(self._viewer.layers.events, event_name, None)
+            if event is not None:
+                event.connect(self._refresh_mask_layer_list)
 
         # Hide the batched control if the (already loaded) embeddings are tiled.
         self._update_batched_visibility()
+        self._refresh_mask_layer_list()
+
+    def _create_mask_input_widget(self):
+        """Build the existing-segmentation input controls."""
+        container = QtWidgets.QWidget()
+        container.setLayout(QtWidgets.QVBoxLayout())
+
+        intro = QtWidgets.QLabel(
+            "Select one or more Labels layers. Equal IDs are unioned; overlapping different IDs are rejected."
+        )
+        intro.setWordWrap(True)
+        container.layout().addWidget(intro)
+
+        self.mask_layer_list = QtWidgets.QListWidget()
+        self.mask_layer_list.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
+        self.mask_layer_list.itemChanged.connect(self._update_mask_input_controls)
+        container.layout().addWidget(self.mask_layer_list)
+
+        select_row = QtWidgets.QHBoxLayout()
+        select_all = QtWidgets.QPushButton("Select all")
+        select_all.clicked.connect(lambda: self._set_all_mask_layers_checked(True))
+        unselect_all = QtWidgets.QPushButton("Unselect all")
+        unselect_all.clicked.connect(lambda: self._set_all_mask_layers_checked(False))
+        select_row.addWidget(select_all)
+        select_row.addWidget(unselect_all)
+        container.layout().addLayout(select_row)
+
+        self.mask_input_summary = QtWidgets.QLabel("No mask input selected.")
+        self.mask_input_summary.setWordWrap(True)
+        container.layout().addWidget(self.mask_input_summary)
+
+        self.correction_target_row = QtWidgets.QWidget()
+        correction_layout = QtWidgets.QHBoxLayout()
+        correction_layout.setContentsMargins(0, 0, 0, 0)
+        self.correction_target_row.setLayout(correction_layout)
+        correction_layout.addWidget(QtWidgets.QLabel("Corrections apply to object ID"))
+        self.correction_target = QtWidgets.QComboBox()
+        correction_layout.addWidget(self.correction_target)
+        self.correction_target_row.setVisible(False)
+        container.layout().addWidget(self.correction_target_row)
+
+        if self._ndim == 3:
+            strategy_row = QtWidgets.QHBoxLayout()
+            strategy_row.addWidget(QtWidgets.QLabel("3D behavior"))
+            self.mask_3d_strategy = QtWidgets.QComboBox()
+            self.mask_3d_strategy.addItems(["Refine all occupied slices", "Propagate from seed slices"])
+            self.mask_3d_strategy.currentTextChanged.connect(self._update_propagation_visibility)
+            strategy_row.addWidget(self.mask_3d_strategy)
+            container.layout().addLayout(strategy_row)
+
+        self.mask_downsampling_warning = QtWidgets.QLabel(
+            "Refinement warning: every 2D mask prompt is converted to SAM's 256 × 256 low-resolution "
+            "mask representation. Fine structures may be lost. The selected input layers are never modified."
+        )
+        self.mask_downsampling_warning.setWordWrap(True)
+        self.mask_downsampling_warning.setVisible(False)
+        container.layout().addWidget(self.mask_downsampling_warning)
+
+        action_row = QtWidgets.QHBoxLayout()
+        self.refine_masks_button = QtWidgets.QPushButton("Refine with SAM")
+        self.refine_masks_button.clicked.connect(self._refine_selected_masks)
+        self.commit_masks_button = QtWidgets.QPushButton("Commit input masks unchanged")
+        self.commit_masks_button.clicked.connect(self._commit_selected_masks_unchanged)
+        action_row.addWidget(self.refine_masks_button)
+        action_row.addWidget(self.commit_masks_button)
+        container.layout().addLayout(action_row)
+
+        return _make_collapsible(
+            container,
+            title="Existing Segmentation Inputs",
+            tooltip=(
+                "Use compatible napari Labels layers as dense SAM prompts, or commit them directly "
+                "when no refinement is needed."
+            ),
+        )
+
+    def _selected_image_layer(self):
+        state = AnnotatorState()
+        embedding_widget = state.widgets.get("embeddings") if state.widgets is not None else None
+        if embedding_widget is None:
+            return None
+        return embedding_widget.image_selection.get_value()
+
+    def _refresh_mask_layer_list(self, event=None):
+        """Refresh the checklist while preserving checks by layer identity."""
+        checked = {
+            layer_id
+            for layer_id, (_, item) in self._mask_layer_items.items()
+            if item.checkState() == Qt.Checked
+        }
+        self.mask_layer_list.blockSignals(True)
+        self.mask_layer_list.clear()
+        self._mask_layer_items = {}
+        image_layer = self._selected_image_layer()
+        if image_layer is not None and id(image_layer) not in self._connected_mask_images:
+            for event_name in ("data", "scale", "translate", "rotate", "shear", "affine"):
+                image_event = getattr(image_layer.events, event_name, None)
+                if image_event is not None:
+                    image_event.connect(self._refresh_mask_layer_list)
+            self._connected_mask_images.add(id(image_layer))
+        for layer in self._viewer.layers:
+            if not isinstance(layer, napari.layers.Labels):
+                continue
+            layer_id = id(layer)
+            compatibility_error = None
+            if image_layer is None:
+                compatibility_error = "select an image first"
+            else:
+                try:
+                    vutil.collect_mask_inputs([layer], image_layer)
+                except ValueError as error:
+                    # An empty Labels layer is geometrically compatible; it may become a valid
+                    # source as soon as the user paints or pastes an object into it.
+                    if "do not contain any nonzero label IDs" not in str(error):
+                        compatibility_error = str(error)
+            internal_suffix = (
+                " (micro-sam output)"
+                if layer.name in {"current_object", "auto_segmentation", "committed_objects"}
+                else ""
+            )
+            text = f"{layer.name}{internal_suffix}"
+            if compatibility_error is not None:
+                text += " — incompatible"
+            item = QtWidgets.QListWidgetItem(text)
+            item.setFlags(item.flags() | Qt.ItemIsUserCheckable)
+            if compatibility_error is not None:
+                item.setFlags(item.flags() & ~Qt.ItemIsEnabled)
+                item.setToolTip(compatibility_error)
+            item.setCheckState(
+                Qt.Checked if compatibility_error is None and layer_id in checked else Qt.Unchecked
+            )
+            item.setData(Qt.UserRole, layer_id)
+            self.mask_layer_list.addItem(item)
+            self._mask_layer_items[layer_id] = (layer, item)
+            if layer_id not in self._connected_mask_layers:
+                layer.events.data.connect(self._refresh_mask_layer_list)
+                layer.events.name.connect(self._refresh_mask_layer_list)
+                for event_name in ("scale", "translate", "rotate", "shear", "affine"):
+                    transform_event = getattr(layer.events, event_name, None)
+                    if transform_event is not None:
+                        transform_event.connect(self._refresh_mask_layer_list)
+                self._connected_mask_layers.add(layer_id)
+        self.mask_layer_list.blockSignals(False)
+        self._update_mask_input_controls()
+
+    def _set_all_mask_layers_checked(self, checked):
+        value = Qt.Checked if checked else Qt.Unchecked
+        self.mask_layer_list.blockSignals(True)
+        for _, item in self._mask_layer_items.values():
+            if item.flags() & Qt.ItemIsEnabled:
+                item.setCheckState(value)
+        self.mask_layer_list.blockSignals(False)
+        self._update_mask_input_controls()
+
+    def _checked_mask_layers(self):
+        return [
+            layer
+            for layer, item in self._mask_layer_items.values()
+            if item.checkState() == Qt.Checked
+        ]
+
+    def _collect_mask_inputs(self):
+        image_layer = self._selected_image_layer()
+        if image_layer is None:
+            raise ValueError("Select an image layer before using existing segmentations.")
+        return vutil.collect_mask_inputs(self._checked_mask_layers(), image_layer)
+
+    def _have_correction_prompts(self):
+        return bool(
+            len(self._viewer.layers["point_prompts"].data)
+            or len(self._viewer.layers["prompts"].data)
+        )
+
+    def _update_mask_input_controls(self, event=None):
+        """Show live selection validity and correction-target routing."""
+        try:
+            mask_inputs = self._collect_mask_inputs()
+        except ValueError as error:
+            mask_inputs = None
+            self.mask_input_summary.setText(str(error))
+        else:
+            self.mask_input_summary.setText(
+                f"{len(mask_inputs.source_layers)} layer(s), {len(mask_inputs.object_ids)} object(s): "
+                + ", ".join(str(object_id) for object_id in mask_inputs.object_ids)
+            )
+
+        have_corrections = self._have_correction_prompts()
+        self.correction_target_row.setVisible(have_corrections)
+        previous = self.correction_target.currentData()
+        self.correction_target.blockSignals(True)
+        self.correction_target.clear()
+        if mask_inputs is not None:
+            if len(mask_inputs.object_ids) > 1:
+                self.correction_target.addItem("Choose object ID", None)
+            for object_id in mask_inputs.object_ids:
+                self.correction_target.addItem(str(object_id), object_id)
+            if len(mask_inputs.object_ids) == 1:
+                self.correction_target.setCurrentIndex(0)
+                self.correction_target.setEnabled(False)
+            else:
+                index = self.correction_target.findData(previous)
+                self.correction_target.setCurrentIndex(max(index, 0))
+                self.correction_target.setEnabled(True)
+        self.correction_target.blockSignals(False)
+
+        valid = mask_inputs is not None
+        self.refine_masks_button.setEnabled(valid)
+        self.commit_masks_button.setEnabled(valid)
+
+    def _correction_object_id(self, mask_inputs):
+        if not self._have_correction_prompts():
+            return None
+        if len(mask_inputs.object_ids) == 1:
+            return mask_inputs.object_ids[0]
+        object_id = self.correction_target.currentData()
+        if object_id is None:
+            raise ValueError("Choose the object ID that the current point and shape corrections apply to.")
+        return int(object_id)
+
+    def _collect_mask_prompts(self, base_mask, z=None):
+        """Combine one external mask with all corrections for its selected object and frame."""
+        prompts = vutil.collect_frame_prompts(
+            self._viewer.layers["point_prompts"],
+            self._viewer.layers["prompts"],
+            tuple(base_mask.shape),
+            i=z,
+            with_stop_annotation=False,
+        )
+        dense = np.asarray(base_mask, dtype=bool).copy()
+        for shape_mask in prompts.masks:
+            if shape_mask is not None:
+                dense |= np.asarray(shape_mask, dtype=bool)
+
+        coordinates = np.argwhere(dense)
+        bounds = []
+        if len(coordinates):
+            lower = coordinates.min(axis=0)
+            upper = coordinates.max(axis=0)
+            bounds.append(np.array([lower[0], lower[1], upper[0], upper[1]], dtype="float64"))
+        bounds.extend(np.asarray(box, dtype="float64") for box in prompts.boxes)
+        box = None
+        if bounds:
+            stacked = np.stack(bounds)
+            box = np.array([
+                stacked[:, 0].min(), stacked[:, 1].min(),
+                stacked[:, 2].max(), stacked[:, 3].max(),
+            ])
+        return dense, box, prompts
+
+    def _refine_mask_slice(self, base_mask, z=None, with_corrections=False):
+        """Refine one logical mask through the active SAM implementation."""
+        if with_corrections:
+            dense, box, prompts = self._collect_mask_prompts(base_mask, z=z)
+            points, labels = prompts.points, prompts.labels
+        else:
+            dense = np.asarray(base_mask, dtype=bool)
+            coordinates = np.argwhere(dense)
+            if not len(coordinates):
+                return None
+            lower, upper = coordinates.min(axis=0), coordinates.max(axis=0)
+            box = np.array([lower[0], lower[1], upper[0], upper[1]], dtype="float64")
+            points = np.empty((0, 2), dtype="float64")
+            labels = np.empty((0,), dtype="int64")
+
+        state = AnnotatorState()
+        if box is None:
+            # In propagation mode a positive point on an empty source slice is an additional anchor.
+            # A lone negative point is instead a stop annotation and does not create a mask.
+            if not np.any(labels == 1):
+                return None
+            if state.is_sam2:
+                seg = state.interactive_segmenter.segment_slice(
+                    frame_idx=int(z),
+                    points=points[:, ::-1].copy(),
+                    labels=labels,
+                )
+            else:
+                seg = vutil.prompt_segmentation(
+                    state.predictor,
+                    points,
+                    labels,
+                    [],
+                    [],
+                    tuple(base_mask.shape),
+                    image_embeddings=state.image_embeddings,
+                    multiple_box_prompts=False,
+                    batched=False,
+                    i=z,
+                )
+            return None if seg is None else np.asarray(seg).squeeze().astype(bool)
+
+        if state.is_sam2:
+            if self._ndim == 3:
+                seg = state.interactive_segmenter.segment_slice(
+                    frame_idx=int(z),
+                    points=points[:, ::-1].copy() if len(points) else None,
+                    labels=labels if len(labels) else None,
+                    boxes=[box[[1, 0, 3, 2]]],
+                    masks=[dense],
+                )
+            elif state.image_embeddings is not None and state.image_embeddings.get("input_size") is None:
+                from micro_sam.v2.prompt_based_segmentation import tiled_promptable_segmentation_2d
+                seg = tiled_promptable_segmentation_2d(
+                    predictor=state.predictor,
+                    image_embeddings=state.image_embeddings,
+                    points=points,
+                    labels=labels,
+                    boxes=[box],
+                    masks=[dense],
+                    batched=False,
+                    devices=state.inference_devices,
+                )
+            else:
+                from micro_sam.v2.prompt_based_segmentation import promptable_segmentation_2d
+                seg = promptable_segmentation_2d(
+                    predictor=state.predictor,
+                    points=points,
+                    labels=labels,
+                    boxes=[box],
+                    masks=[dense],
+                    batched=False,
+                )
+        else:
+            from micro_sam.v1.prompt_based_segmentation import segment_from_mask, segment_from_mask_tiled
+            if state.image_embeddings.get("input_size") is None:
+                seg = segment_from_mask_tiled(
+                    state.predictor,
+                    dense,
+                    state.image_embeddings,
+                    i=z,
+                    box=box,
+                    points=points,
+                    labels=labels,
+                )
+            else:
+                seg = segment_from_mask(
+                    state.predictor,
+                    dense,
+                    image_embeddings=state.image_embeddings,
+                    i=z,
+                    box=box,
+                    points=points[:, ::-1].copy() if len(points) else None,
+                    labels=labels if len(labels) else None,
+                )
+        return None if seg is None else np.asarray(seg).squeeze().astype(bool)
+
+    def _correction_slices(self):
+        if self._ndim != 3:
+            return set()
+        slices = set()
+        point_data = np.asarray(self._viewer.layers["point_prompts"].data)
+        if point_data.size:
+            slices.update(np.round(point_data[:, 0]).astype(int).tolist())
+        for shape in self._viewer.layers["prompts"].data:
+            slices.add(int(round(float(np.asarray(shape)[0, 0]))))
+        return slices
+
+    def _seed_slice(self, mask_inputs, object_id):
+        slices = mask_inputs.occupied_slices[object_id]
+        areas = {
+            z: int(np.count_nonzero(mask_inputs.labels[z] == object_id))
+            for z in slices
+        }
+        return min(slices, key=lambda z: (-areas[z], z))
+
+    def _refine_masks_occupied(self, mask_inputs, correction_id):
+        candidates = {
+            object_id: np.zeros(mask_inputs.labels.shape, dtype=bool)
+            for object_id in mask_inputs.object_ids
+        }
+        correction_slices = self._correction_slices()
+        if correction_id is not None:
+            absent = correction_slices.difference(mask_inputs.occupied_slices[correction_id])
+            if absent:
+                raise ValueError(
+                    "In 'Refine all occupied slices' mode, corrections must be on a slice occupied "
+                    f"by object ID {correction_id}. Invalid slices: {sorted(absent)}."
+                )
+
+        for object_id, z, mask in vutil.iter_mask_input_masks(mask_inputs):
+            refined = self._refine_mask_slice(
+                mask,
+                z=z,
+                with_corrections=(object_id == correction_id and z in correction_slices),
+            )
+            if refined is None:
+                raise ValueError(f"SAM did not return a mask for object ID {object_id} on slice {z}.")
+            candidates[object_id][z] = refined
+        return candidates
+
+    def _refine_masks_propagated(self, mask_inputs, correction_id):
+        """Refine deterministic seeds, then propagate each object independently."""
+        state = AnnotatorState()
+        correction_slices = self._correction_slices()
+        candidates = {}
+
+        for object_id in mask_inputs.object_ids:
+            seed = self._seed_slice(mask_inputs, object_id)
+            anchor_slices = {seed}
+            if object_id == correction_id:
+                anchor_slices.update(correction_slices)
+
+            seed_volume = np.zeros(mask_inputs.labels.shape, dtype="uint32")
+            valid_anchors = []
+            stop_slices = set()
+            for z in sorted(anchor_slices):
+                base = mask_inputs.labels[z] == object_id
+                refined = self._refine_mask_slice(
+                    base,
+                    z=z,
+                    with_corrections=(object_id == correction_id and z in correction_slices),
+                )
+                if refined is None:
+                    stop_slices.add(z)
+                    continue
+                seed_volume[z][refined] = 1
+                valid_anchors.append(z)
+
+            if not valid_anchors:
+                raise ValueError(f"No positive seed remains for object ID {object_id}.")
+
+            lower_stops = [z for z in stop_slices if z < min(valid_anchors)]
+            upper_stops = [z for z in stop_slices if z > max(valid_anchors)]
+            z_range = (
+                max(lower_stops) + 1 if lower_stops else 0,
+                min(upper_stops) - 1 if upper_stops else mask_inputs.labels.shape[0] - 1,
+            )
+            if self._segment_widget.z_range is not None:
+                z_range = (
+                    max(z_range[0], self._segment_widget.z_range[0]),
+                    min(z_range[1], self._segment_widget.z_range[1]),
+                )
+            if z_range[0] > z_range[1] or not all(z_range[0] <= z <= z_range[1] for z in valid_anchors):
+                raise ValueError(
+                    f"The propagation z-range must include every seed for object ID {object_id}: "
+                    f"{sorted(valid_anchors)}."
+                )
+
+            if state.is_sam2:
+                try:
+                    state.interactive_segmenter.add_pre_refined_masks(
+                        frame_ids=valid_anchors,
+                        masks=[seed_volume[z].astype(bool) for z in valid_anchors],
+                        object_id=object_id,
+                    )
+                    early_stop_patience = (
+                        self._segment_widget.early_stop_patience
+                        if self._segment_widget.early_stop_patience > 0
+                        else None
+                    )
+                    propagated = state.interactive_segmenter.predict(
+                        z_range=z_range,
+                        early_stop_patience=early_stop_patience,
+                    )
+                finally:
+                    state.interactive_segmenter.reset_predictor()
+                candidates[object_id] = np.asarray(propagated) == object_id
+                continue
+
+            if state.image_embeddings.get("input_size") is None:
+                from micro_sam.v1.prompt_based_segmentation import segment_from_mask_tiled
+
+                propagated = seed_volume.astype(bool)
+                lower, upper = z_range
+                first, last = min(valid_anchors), max(valid_anchors)
+                for z in range(first - 1, lower - 1, -1):
+                    propagated[z] = np.asarray(segment_from_mask_tiled(
+                        state.predictor, propagated[z + 1], state.image_embeddings, i=z,
+                    )).squeeze().astype(bool)
+                for z in range(last + 1, upper + 1):
+                    propagated[z] = np.asarray(segment_from_mask_tiled(
+                        state.predictor, propagated[z - 1], state.image_embeddings, i=z,
+                    )).squeeze().astype(bool)
+                for left, right in zip(valid_anchors[:-1], valid_anchors[1:]):
+                    midpoint = (left + right) // 2
+                    for z in range(left + 1, midpoint + 1):
+                        propagated[z] = np.asarray(segment_from_mask_tiled(
+                            state.predictor, propagated[z - 1], state.image_embeddings, i=z,
+                        )).squeeze().astype(bool)
+                    for z in range(right - 1, midpoint, -1):
+                        propagated[z] = np.asarray(segment_from_mask_tiled(
+                            state.predictor, propagated[z + 1], state.image_embeddings, i=z,
+                        )).squeeze().astype(bool)
+                candidates[object_id] = propagated
+            else:
+                propagated, _ = segment_mask_in_volume(
+                    seed_volume,
+                    state.predictor,
+                    state.image_embeddings,
+                    np.asarray(valid_anchors),
+                    stop_lower=bool(lower_stops),
+                    stop_upper=bool(upper_stops),
+                    iou_threshold=self._segment_widget.iou_threshold,
+                    projection=self._segment_widget.projection,
+                    box_extension=self._segment_widget.box_extension,
+                )
+                candidates[object_id] = np.asarray(propagated) != 0
+
+        return candidates
+
+    def _refine_selected_masks(self):
+        """Refine all checked Labels objects atomically into ``current_object``."""
+        show_info(
+            "Mask refinement converts every 2D mask prompt to SAM's 256 × 256 low-resolution "
+            "representation, so fine structures may be lost. Input Labels layers are not modified."
+        )
+        try:
+            mask_inputs = self._collect_mask_inputs()
+            correction_id = self._correction_object_id(mask_inputs)
+            if _validate_embeddings(self._viewer):
+                return
+
+            if self._ndim == 2:
+                candidates = {}
+                for object_id, _, mask in vutil.iter_mask_input_masks(mask_inputs):
+                    refined = self._refine_mask_slice(
+                        mask, with_corrections=(object_id == correction_id),
+                    )
+                    if refined is None:
+                        raise ValueError(f"SAM did not return a mask for object ID {object_id}.")
+                    candidates[object_id] = refined
+            elif self.mask_3d_strategy.currentText() == "Propagate from seed slices":
+                self._sync_propagation_settings()
+                candidates = self._refine_masks_propagated(mask_inputs, correction_id)
+            else:
+                candidates = self._refine_masks_occupied(mask_inputs, correction_id)
+
+            refined_labels = vutil.merge_refined_mask_candidates(mask_inputs.labels, candidates)
+            refined_ids = tuple(int(value) for value in np.unique(refined_labels) if value != 0)
+            if refined_ids != mask_inputs.object_ids:
+                missing = sorted(set(mask_inputs.object_ids).difference(refined_ids))
+                raise ValueError(
+                    f"SAM returned an empty result for input object ID(s) {missing}; "
+                    "the existing current result was left unchanged."
+                )
+        except (ValueError, RuntimeError) as error:
+            _generate_message("error", str(error))
+            return
+
+        current_object = self._viewer.layers["current_object"]
+        current_object.data = refined_labels
+        image_layer = self._selected_image_layer()
+        for transform_name in ("scale", "translate", "rotate", "shear", "affine"):
+            if hasattr(image_layer, transform_name):
+                setattr(current_object, transform_name, getattr(image_layer, transform_name))
+        current_object.metadata["micro_sam_mask_refinement"] = {
+            "object_ids": tuple(mask_inputs.object_ids),
+            "source_layers": tuple(mask_inputs.source_names),
+        }
+        current_object.refresh()
+
+    def _commit_selected_masks_unchanged(self):
+        """Atomically union selected external labels into committed objects without running SAM."""
+        try:
+            mask_inputs = self._collect_mask_inputs()
+            committed = self._viewer.layers["committed_objects"]
+            destination = np.asarray(committed.data)
+            if destination.shape != mask_inputs.labels.shape:
+                if np.any(destination):
+                    raise ValueError(
+                        f"The committed layer has shape {destination.shape}, but mask inputs have "
+                        f"shape {mask_inputs.labels.shape}."
+                    )
+                destination = np.zeros(mask_inputs.labels.shape, dtype="uint32")
+            merged = vutil.merge_labels_for_direct_commit(destination, mask_inputs.labels)
+        except ValueError as error:
+            _generate_message("error", str(error))
+            return
+
+        committed.data = merged
+        image_layer = self._selected_image_layer()
+        for transform_name in ("scale", "translate", "rotate", "shear", "affine"):
+            if hasattr(image_layer, transform_name):
+                setattr(committed, transform_name, getattr(image_layer, transform_name))
+        committed.metadata["micro_sam_direct_mask_commit"] = {
+            "image_layer_id": id(image_layer),
+            "shape": tuple(mask_inputs.labels.shape),
+        }
+        committed.refresh()
 
     def _update_batched_visibility(self, event=None):
         """Disable batched segmentation while one or more scribble prompts are present."""
@@ -3746,15 +4366,23 @@ class InteractiveSegmentationWidget(_WidgetBase):
         self.apply_to_volume = bool(state)
         self._segment_widget.apply_to_volume = self.apply_to_volume
 
-        # Show the propagation controls only in volume mode with a SAM2 model, and size the slider.
-        if self._propagation_settings is not None:
-            annotator_state = AnnotatorState()
-            is_sam2 = bool(annotator_state.is_sam2) if annotator_state.is_sam2 is not None else False
-            show = self.apply_to_volume and is_sam2
-            self._propagation_settings.setVisible(show)
-            if show:
-                self._update_z_range_slider()
-                self._sync_propagation_settings()
+        self._update_propagation_visibility()
+
+    def _update_propagation_visibility(self, *args):
+        """Expose propagation controls for prompt-volume or mask-seed propagation."""
+        if self._propagation_settings is None:
+            return
+        annotator_state = AnnotatorState()
+        is_sam2 = bool(annotator_state.is_sam2) if annotator_state.is_sam2 is not None else False
+        mask_propagation = (
+            hasattr(self, "mask_3d_strategy")
+            and self.mask_3d_strategy.currentText() == "Propagate from seed slices"
+        )
+        show = mask_propagation or (self.apply_to_volume and is_sam2)
+        self._propagation_settings.setVisible(show)
+        if show:
+            self._update_z_range_slider()
+            self._sync_propagation_settings()
 
     def _on_batched_changed(self, state):
         """Sync the batched mode to the segmentation engine."""
@@ -3771,6 +4399,7 @@ class InteractiveSegmentationWidget(_WidgetBase):
 
     def clear(self, viewer=None):
         """Clear the current annotations."""
+        self._viewer.layers["current_object"].metadata.pop("micro_sam_mask_refinement", None)
         if self._ndim == 2 or self.apply_to_volume:
             vutil.clear_annotations(self._viewer)
         else:

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -3599,6 +3599,11 @@ class InteractiveSegmentationWidget(_WidgetBase):
         self._mask_layer_items = {}
         self._connected_mask_layers = set()
         self._connected_mask_images = set()
+        self._excluded_mask_layer_ids = {
+            id(self._viewer.layers[name])
+            for name in ("current_object", "auto_segmentation", "committed_objects")
+            if name in self._viewer.layers
+        }
         self._create_widget()
 
     def _create_widget(self):
@@ -3695,7 +3700,8 @@ class InteractiveSegmentationWidget(_WidgetBase):
         container.setLayout(QtWidgets.QVBoxLayout())
 
         intro = QtWidgets.QLabel(
-            "Select one or more Labels layers. Equal IDs are unioned; overlapping different IDs are rejected."
+            "Select one or more Labels layers, then use Segment Object [S] to refine them with SAM. "
+            "Equal IDs are unioned; overlapping different IDs are rejected."
         )
         intro.setWordWrap(True)
         container.layout().addWidget(intro)
@@ -3737,22 +3743,9 @@ class InteractiveSegmentationWidget(_WidgetBase):
             strategy_row.addWidget(self.mask_3d_strategy)
             container.layout().addLayout(strategy_row)
 
-        self.mask_downsampling_warning = QtWidgets.QLabel(
-            "Refinement warning: every 2D mask prompt is converted to SAM's 256 × 256 low-resolution "
-            "mask representation. Fine structures may be lost. The selected input layers are never modified."
-        )
-        self.mask_downsampling_warning.setWordWrap(True)
-        self.mask_downsampling_warning.setVisible(False)
-        container.layout().addWidget(self.mask_downsampling_warning)
-
-        action_row = QtWidgets.QHBoxLayout()
-        self.refine_masks_button = QtWidgets.QPushButton("Refine with SAM")
-        self.refine_masks_button.clicked.connect(self._refine_selected_masks)
         self.commit_masks_button = QtWidgets.QPushButton("Commit input masks unchanged")
         self.commit_masks_button.clicked.connect(self._commit_selected_masks_unchanged)
-        action_row.addWidget(self.refine_masks_button)
-        action_row.addWidget(self.commit_masks_button)
-        container.layout().addLayout(action_row)
+        container.layout().addWidget(self.commit_masks_button)
 
         return _make_collapsible(
             container,
@@ -3790,6 +3783,8 @@ class InteractiveSegmentationWidget(_WidgetBase):
         for layer in self._viewer.layers:
             if not isinstance(layer, napari.layers.Labels):
                 continue
+            if id(layer) in self._excluded_mask_layer_ids:
+                continue
             layer_id = id(layer)
             compatibility_error = None
             if image_layer is None:
@@ -3802,12 +3797,7 @@ class InteractiveSegmentationWidget(_WidgetBase):
                     # source as soon as the user paints or pastes an object into it.
                     if "do not contain any nonzero label IDs" not in str(error):
                         compatibility_error = str(error)
-            internal_suffix = (
-                " (micro-sam output)"
-                if layer.name in {"current_object", "auto_segmentation", "committed_objects"}
-                else ""
-            )
-            text = f"{layer.name}{internal_suffix}"
+            text = layer.name
             if compatibility_error is not None:
                 text += " — incompatible"
             item = QtWidgets.QListWidgetItem(text)
@@ -3868,10 +3858,16 @@ class InteractiveSegmentationWidget(_WidgetBase):
             mask_inputs = None
             self.mask_input_summary.setText(str(error))
         else:
-            self.mask_input_summary.setText(
+            summary = (
                 f"{len(mask_inputs.source_layers)} layer(s), {len(mask_inputs.object_ids)} object(s): "
                 + ", ".join(str(object_id) for object_id in mask_inputs.object_ids)
             )
+            if mask_inputs.cropped_source_names:
+                summary += (
+                    ". Cropped one trailing pixel on one or more axes to match the image for: "
+                    + ", ".join(mask_inputs.cropped_source_names)
+                )
+            self.mask_input_summary.setText(summary)
 
         have_corrections = self._have_correction_prompts()
         self.correction_target_row.setVisible(have_corrections)
@@ -3893,7 +3889,6 @@ class InteractiveSegmentationWidget(_WidgetBase):
         self.correction_target.blockSignals(False)
 
         valid = mask_inputs is not None
-        self.refine_masks_button.setEnabled(valid)
         self.commit_masks_button.setEnabled(valid)
 
     def _correction_object_id(self, mask_inputs):
@@ -4390,7 +4385,10 @@ class InteractiveSegmentationWidget(_WidgetBase):
         self._segment_widget.batched = self.batched
 
     def segment(self, viewer=None):
-        """Run interactive segmentation for the current prompts."""
+        """Refine selected mask inputs, or run interactive point/shape segmentation."""
+        if self._checked_mask_layers():
+            self._refine_selected_masks()
+            return
         if self._ndim == 2:
             _segment_object_2d(self._viewer, batched=bool(self.batched))
         else:

--- a/micro_sam/sam_annotator/_widgets.py
+++ b/micro_sam/sam_annotator/_widgets.py
@@ -3576,6 +3576,10 @@ def _instance_segmentation_impl(
     return seg
 
 
+MASK_3D_REFINE_EXISTING = "Refine existing slices only"
+MASK_3D_REFINE_AND_EXTEND = "Refine and extend through z"
+
+
 class InteractiveSegmentationWidget(_WidgetBase):
     """Interactive segmentation widget combining the prompt menu, segmentation and clearing.
 
@@ -3684,8 +3688,8 @@ class InteractiveSegmentationWidget(_WidgetBase):
             checkbox_row.addWidget(self.apply_to_volume_checkbox)
             self.layout().addLayout(checkbox_row)
 
-            # SAM2 volume-mode propagation controls (early stopping + z-range). Hidden until the
-            # user enables 'Apply to Volume' with a SAM2 model. The controls drive the engine.
+            # Volume-propagation controls. These are shown for mask extension with either model
+            # family, or for prompt-volume propagation with SAM2. The controls drive the engine.
             self._propagation_settings = self._create_propagation_settings()
             self._propagation_settings.setVisible(False)
             self.layout().addWidget(self._propagation_settings)
@@ -3737,6 +3741,7 @@ class InteractiveSegmentationWidget(_WidgetBase):
 
         self.mask_layer_list = QtWidgets.QListWidget()
         self.mask_layer_list.setSelectionMode(QtWidgets.QAbstractItemView.NoSelection)
+        self.mask_layer_list.setToolTip(get_tooltip("mask_inputs", "layer_list"))
         self.mask_layer_list.itemChanged.connect(self._update_mask_input_controls)
         container.layout().addWidget(self.mask_layer_list)
 
@@ -3749,13 +3754,14 @@ class InteractiveSegmentationWidget(_WidgetBase):
         select_row.addWidget(unselect_all)
         container.layout().addLayout(select_row)
 
+        self.commit_masks_button = QtWidgets.QPushButton("Commit selected masks unchanged")
+        self.commit_masks_button.setToolTip(get_tooltip("mask_inputs", "commit_unchanged"))
+        self.commit_masks_button.clicked.connect(self._commit_selected_masks_unchanged)
+        container.layout().addWidget(self.commit_masks_button)
+
         self.mask_input_summary = QtWidgets.QLabel("No mask input selected.")
         self.mask_input_summary.setWordWrap(True)
         container.layout().addWidget(self.mask_input_summary)
-
-        self.commit_masks_button = QtWidgets.QPushButton("Commit selected masks unchanged")
-        self.commit_masks_button.clicked.connect(self._commit_selected_masks_unchanged)
-        container.layout().addWidget(self.commit_masks_button)
 
         self.correction_target_help = QtWidgets.QLabel(
             "Corrections are assigned per object. Select points or shapes, then assign them to an "
@@ -3772,19 +3778,38 @@ class InteractiveSegmentationWidget(_WidgetBase):
         correction_layout.addWidget(QtWidgets.QLabel("Target object ID"))
         self.correction_target = QtWidgets.QComboBox()
         self.correction_target.setPlaceholderText("Choose object ID")
+        self.correction_target.setToolTip(get_tooltip("mask_inputs", "target_object"))
         self.correction_target.currentIndexChanged.connect(self._on_correction_target_changed)
         correction_layout.addWidget(self.correction_target)
         self.correction_target_row.setVisible(False)
         container.layout().addWidget(self.correction_target_row)
 
         if self._ndim == 3:
+            mask_3d_intro = QtWidgets.QLabel(
+                "A 3D Labels layer is handled as a stack of 2D masks. Refinement is 2D; when "
+                "extending through z, SAM-v1 projects between slices and SAM2 treats z like video "
+                "frames. Neither model treats the data as physical 3D space."
+            )
+            mask_3d_intro.setWordWrap(True)
+            mask_3d_intro.setToolTip(get_tooltip("mask_inputs", "3d_behavior"))
+            container.layout().addWidget(mask_3d_intro)
+
             strategy_row = QtWidgets.QHBoxLayout()
-            strategy_row.addWidget(QtWidgets.QLabel("3D behavior"))
+            strategy_label = QtWidgets.QLabel("3D behavior")
+            strategy_label.setToolTip(get_tooltip("mask_inputs", "3d_behavior"))
+            strategy_row.addWidget(strategy_label)
             self.mask_3d_strategy = QtWidgets.QComboBox()
-            self.mask_3d_strategy.addItems(["Refine all occupied slices", "Propagate from seed slices"])
+            self.mask_3d_strategy.addItems([MASK_3D_REFINE_EXISTING, MASK_3D_REFINE_AND_EXTEND])
+            self.mask_3d_strategy.setToolTip(get_tooltip("mask_inputs", "3d_behavior"))
             self.mask_3d_strategy.currentTextChanged.connect(self._update_propagation_visibility)
+            self.mask_3d_strategy.currentTextChanged.connect(self._update_mask_3d_help)
             strategy_row.addWidget(self.mask_3d_strategy)
             container.layout().addLayout(strategy_row)
+
+            self.mask_3d_help = QtWidgets.QLabel()
+            self.mask_3d_help.setWordWrap(True)
+            container.layout().addWidget(self.mask_3d_help)
+            self._update_mask_3d_help()
 
         return _make_collapsible(
             container,
@@ -4036,6 +4061,33 @@ class InteractiveSegmentationWidget(_WidgetBase):
         self.correction_target.blockSignals(False)
 
         self.commit_masks_button.setEnabled(valid)
+        self._update_batched_visibility()
+        if self._ndim == 3:
+            have_mask_inputs = bool(self._checked_mask_layers())
+            tooltip_key = "apply_to_volume_ignored" if have_mask_inputs else "apply_to_volume"
+            tooltip_group = "mask_inputs" if have_mask_inputs else "unified_segment"
+            self.apply_to_volume_checkbox.setToolTip(get_tooltip(tooltip_group, tooltip_key))
+
+    def _update_mask_3d_help(self, *args):
+        """Explain the selected 3D mask-input behavior in beginner-facing terms."""
+        if self.mask_3d_strategy.currentText() == MASK_3D_REFINE_AND_EXTEND:
+            text = (
+                "For each object ID, SAM first refines its largest cross-section (the lowest z "
+                "wins a tie) and any slices carrying corrections, then extends the object through "
+                "z. Other occupied input slices are not used as anchors. This can fill gaps or "
+                "extend an incomplete object, but the result can drift."
+            )
+        else:
+            text = (
+                "SAM refines every slice where each object ID already exists. Empty slices stay "
+                "empty, so the object's z-extent is preserved. Corrections must be placed on a "
+                "slice occupied by their target object."
+            )
+        text += (
+            " With mask inputs selected, this choice controls Segment Object; Batched and Apply "
+            "to Volume do not change mask refinement."
+        )
+        self.mask_3d_help.setText(text)
 
     def _validate_prompt_target_ids(self, mask_inputs):
         """Require every correction prompt to target one of the selected mask IDs."""
@@ -4213,7 +4265,7 @@ class InteractiveSegmentationWidget(_WidgetBase):
             absent = correction_slices[object_id].difference(mask_inputs.occupied_slices[object_id])
             if absent:
                 raise ValueError(
-                    "In 'Refine all occupied slices' mode, corrections must be on a slice occupied "
+                    f"In '{MASK_3D_REFINE_EXISTING}' mode, corrections must be on a slice occupied "
                     f"by object ID {object_id}. Invalid slices: {sorted(absent)}."
                 )
 
@@ -4313,18 +4365,25 @@ class InteractiveSegmentationWidget(_WidgetBase):
                         )).squeeze().astype(bool)
                 candidates[object_id] = propagated
             else:
-                propagated, _ = segment_mask_in_volume(
-                    seed_volume,
+                lower, upper = z_range
+                cropped_embeddings = dict(state.image_embeddings)
+                cropped_embeddings["features"] = state.image_embeddings["features"][
+                    lower:upper + 1
+                ]
+                cropped, _ = segment_mask_in_volume(
+                    seed_volume[lower:upper + 1].copy(),
                     state.predictor,
-                    state.image_embeddings,
-                    np.asarray(valid_anchors),
+                    cropped_embeddings,
+                    np.asarray(valid_anchors) - lower,
                     stop_lower=bool(lower_stops),
                     stop_upper=bool(upper_stops),
                     iou_threshold=self._segment_widget.iou_threshold,
                     projection=self._segment_widget.projection,
                     box_extension=self._segment_widget.box_extension,
                 )
-                candidates[object_id] = np.asarray(propagated) != 0
+                propagated = np.zeros_like(seed_volume, dtype=bool)
+                propagated[lower:upper + 1] = np.asarray(cropped) != 0
+                candidates[object_id] = propagated
 
         return candidates
 
@@ -4347,7 +4406,7 @@ class InteractiveSegmentationWidget(_WidgetBase):
                     if refined is None:
                         raise ValueError(f"SAM did not return a mask for object ID {object_id}.")
                     candidates[object_id] = refined
-            elif self.mask_3d_strategy.currentText() == "Propagate from seed slices":
+            elif self.mask_3d_strategy.currentText() == MASK_3D_REFINE_AND_EXTEND:
                 self._sync_propagation_settings()
                 candidates = self._refine_masks_propagated(mask_inputs)
             else:
@@ -4407,28 +4466,44 @@ class InteractiveSegmentationWidget(_WidgetBase):
         committed.refresh()
 
     def _update_batched_visibility(self, event=None):
-        """Disable batched segmentation while one or more scribble prompts are present."""
+        """Disable batched segmentation when prompts or mask inputs make it inapplicable."""
         super()._update_batched_visibility()
 
+        # napari emits layer-removal events while closing the viewer. At that point the prompt
+        # layer may already be gone, so there are no controls left to synchronize.
+        if "prompts" not in self._viewer.layers:
+            return
         prompt_layer = self._viewer.layers["prompts"]
         have_scribbles = any(
             shape_type in vutil.SCRIBBLE_SHAPE_TYPES for shape_type in prompt_layer.shape_type
         )
-        if have_scribbles and self.batched_checkbox.isChecked():
+        have_mask_inputs = bool(self._checked_mask_layers())
+        if (have_scribbles or have_mask_inputs) and self.batched_checkbox.isChecked():
             self.batched_checkbox.setChecked(False)
 
-        self.batched_checkbox.setEnabled(not have_scribbles)
-        tooltip_key = "batched_scribble_disabled" if have_scribbles else "batched"
-        self.batched_checkbox.setToolTip(get_tooltip("unified_segment", tooltip_key))
+        self.batched_checkbox.setEnabled(not have_scribbles and not have_mask_inputs)
+        if have_mask_inputs:
+            self.batched_checkbox.setToolTip(get_tooltip("mask_inputs", "batched_ignored"))
+        else:
+            tooltip_key = "batched_scribble_disabled" if have_scribbles else "batched"
+            self.batched_checkbox.setToolTip(get_tooltip("unified_segment", tooltip_key))
 
     def _create_propagation_settings(self):
-        """Build the SAM2 volume-mode propagation controls (early stopping + z-range slider).
+        """Build the volume-propagation controls (early stopping + z-range slider).
 
         The controls live on the visible interactive widget and write their values into the hidden
         'UnifiedSegmentWidget' engine, which reads 'early_stop_patience' and 'z_range' at run time.
         """
         container = QtWidgets.QWidget()
         container.setLayout(QtWidgets.QVBoxLayout())
+
+        propagation_info = QtWidgets.QLabel(
+            "The propagation z-range applies to SAM-v1 and SAM2. Stop after empty slices applies "
+            "only to SAM2; SAM-v1 ignores that setting."
+        )
+        propagation_info.setWordWrap(True)
+        propagation_info.setToolTip(get_tooltip("segmentnd", "settings"))
+        container.layout().addWidget(propagation_info)
 
         # Stop after this many consecutive empty slices (0 disables early stopping).
         self.early_stop_patience = 2
@@ -4515,7 +4590,7 @@ class InteractiveSegmentationWidget(_WidgetBase):
         is_sam2 = bool(annotator_state.is_sam2) if annotator_state.is_sam2 is not None else False
         mask_propagation = (
             hasattr(self, "mask_3d_strategy")
-            and self.mask_3d_strategy.currentText() == "Propagate from seed slices"
+            and self.mask_3d_strategy.currentText() == MASK_3D_REFINE_AND_EXTEND
         )
         show = mask_propagation or (self.apply_to_volume and is_sam2)
         self._propagation_settings.setVisible(show)

--- a/micro_sam/sam_annotator/annotator.py
+++ b/micro_sam/sam_annotator/annotator.py
@@ -251,6 +251,10 @@ class Annotator(_AnnotatorBase):
         if ndim != self._ndim:
             self._rebuild_for_ndim(ndim)
 
+        interactive = self._widgets.get("interactive")
+        if interactive is not None:
+            interactive._refresh_mask_layer_list()
+
     def _on_ndim_mode_changed(self, *args):
         """Re-interpret the current image when the 'image dimensions' override changes.
 
@@ -295,7 +299,29 @@ class Annotator(_AnnotatorBase):
 
     def _update_image(self, segmentation_result=None):
         """Update the image and load AMG state for 3D."""
+        # Direct mask commits are allowed before embeddings exist. Preserve them when embedding
+        # initialization updates the helper layers for the same selected image. A real image-layer
+        # change rebuilds the layers first, so this marker cannot leak to another image.
+        preserved_direct_commit = False
+        image_layer = self._embedding_widget.image_selection.get_value()
+        if segmentation_result is None and "committed_objects" in self._viewer.layers:
+            committed = self._viewer.layers["committed_objects"]
+            direct_commit = committed.metadata.get("micro_sam_direct_mask_commit")
+            if (
+                direct_commit is not None
+                and image_layer is not None
+                and direct_commit.get("image_layer_id") == id(image_layer)
+                and tuple(committed.data.shape) == tuple(AnnotatorState().image_shape or ())
+            ):
+                segmentation_result = np.asarray(committed.data).copy()
+                preserved_direct_commit = True
         super()._update_image(segmentation_result=segmentation_result)
+
+        if preserved_direct_commit:
+            committed = self._viewer.layers["committed_objects"]
+            for transform_name in ("scale", "translate", "rotate", "shear", "affine"):
+                if hasattr(image_layer, transform_name):
+                    setattr(committed, transform_name, getattr(image_layer, transform_name))
 
         # Load the AMG state from the embedding path (3D only)
         if self._ndim == 3:

--- a/micro_sam/sam_annotator/util.py
+++ b/micro_sam/sam_annotator/util.py
@@ -327,6 +327,8 @@ class MaskInputData:
         object_ids: The sorted nonzero IDs in ``labels``.
         source_layers: The source Labels layer objects, retained for UI provenance.
         source_names: The source layer names at collection time.
+        cropped_source_names: Source layers that had one trailing pixel cropped on at least one
+            axis to match the image extent.
         occupied_slices: For 3D inputs, the sorted z-slices occupied by each object ID. This is
             empty for 2D inputs.
     """
@@ -335,6 +337,7 @@ class MaskInputData:
     object_ids: Tuple[int, ...]
     source_layers: Tuple[object, ...]
     source_names: Tuple[str, ...]
+    cropped_source_names: Tuple[str, ...]
     occupied_slices: Dict[int, Tuple[int, ...]]
 
 
@@ -375,14 +378,29 @@ def _transform_signature(layer, ndim: int) -> np.ndarray:
     return points * scale + translate
 
 
-def _validated_label_array(data, name: str, expected_shape: Tuple[int, ...]) -> np.ndarray:
+def _validated_label_array(
+    data,
+    name: str,
+    expected_shape: Tuple[int, ...],
+    allow_trailing_crop: bool = False,
+) -> np.ndarray:
     """Validate one label array and convert it losslessly to uint32."""
     labels = np.asarray(data)
     if labels.shape != expected_shape:
-        raise ValueError(
-            f"Mask layer '{name}' has shape {labels.shape}, but the selected image has spatial shape "
-            f"{expected_shape}. Mask inputs are not resampled."
+        deltas = (
+            tuple(actual - expected for actual, expected in zip(labels.shape, expected_shape))
+            if labels.ndim == len(expected_shape)
+            else ()
         )
+        can_crop = allow_trailing_crop and deltas and all(delta in (0, 1) for delta in deltas)
+        if can_crop:
+            labels = labels[tuple(slice(0, size) for size in expected_shape)]
+        else:
+            raise ValueError(
+                f"Mask layer '{name}' has shape {labels.shape}, but the selected image has spatial shape "
+                f"{expected_shape}. Only one trailing pixel per axis can be cropped automatically; "
+                "mask inputs are otherwise not resampled."
+            )
     if labels.dtype == np.bool_:
         return labels.astype("uint32", copy=False)
     if not np.issubdtype(labels.dtype, np.integer):
@@ -404,8 +422,9 @@ def collect_mask_inputs(layers: Sequence[object], image_layer) -> MaskInputData:
     """Validate and merge selected Labels layers against the selected image.
 
     Equal IDs are unioned across layers. Unequal nonzero IDs at the same pixel are rejected rather
-    than resolved implicitly. Shape and data-to-world transform must match exactly (within floating
-    point tolerance); no resampling is performed.
+    than resolved implicitly. Data-to-world transforms must match (within floating point tolerance).
+    A single surplus pixel at the trailing edge of any axis is cropped to accommodate napari's
+    create-new-Labels behavior; other shape mismatches are rejected and no resampling is performed.
     """
     layers = tuple(layers)
     if not layers:
@@ -416,9 +435,15 @@ def collect_mask_inputs(layers: Sequence[object], image_layer) -> MaskInputData:
     merged = np.zeros(image_shape, dtype="uint32")
     owner = np.full(image_shape, -1, dtype="int64")
     names = tuple(str(getattr(layer, "name", f"layer {index}")) for index, layer in enumerate(layers))
+    cropped_names = []
 
     for index, (layer, name) in enumerate(zip(layers, names)):
-        labels = _validated_label_array(layer.data, name, image_shape)
+        source_shape = tuple(np.shape(layer.data))
+        labels = _validated_label_array(
+            layer.data, name, image_shape, allow_trailing_crop=True,
+        )
+        if source_shape != image_shape:
+            cropped_names.append(name)
         layer_transform = _transform_signature(layer, len(image_shape))
         if not np.allclose(layer_transform, image_transform, rtol=1e-7, atol=1e-8):
             raise ValueError(
@@ -459,6 +484,7 @@ def collect_mask_inputs(layers: Sequence[object], image_layer) -> MaskInputData:
         object_ids=object_ids,
         source_layers=layers,
         source_names=names,
+        cropped_source_names=tuple(cropped_names),
         occupied_slices=occupied_slices,
     )
 

--- a/micro_sam/sam_annotator/util.py
+++ b/micro_sam/sam_annotator/util.py
@@ -28,6 +28,9 @@ SCRIBBLE_SHAPE_TYPES = ("path", "line")
 SCRIBBLE_DRAW_MODES = ("add_path", "add_polyline", "add_line")
 """Napari Shapes modes that create open scribble prompts."""
 
+UNASSIGNED_OBJECT_ID = "0"
+"""Sentinel stored on prompts that have not been assigned to an input mask object."""
+
 
 #
 # Misc helper functions
@@ -161,16 +164,21 @@ def set_prompt_label(layer, new_label, relabel_selected: bool = True):
         # and the user has moved to the other layer.
         layer.selected_data = set()
 
-    current_properties = layer.current_properties
+    selected_shapes = set(layer.selected_data) if is_shapes and relabel_selected else set()
+    if selected_shapes:
+        layer.selected_data = set()
+    current_properties = dict(layer.current_properties)
     current_properties["label"] = np.array([new_label])
     layer.current_properties = current_properties
+    if selected_shapes:
+        layer.selected_data = selected_shapes
 
-    if relabel_selected and is_shapes and layer.selected_data:
+    if selected_shapes:
         properties = dict(layer.properties)
         labels = np.asarray(properties.get("label", []), dtype=object).copy()
         shape_types = list(layer.shape_type)
         if len(labels) == len(shape_types):
-            for index in layer.selected_data:
+            for index in selected_shapes:
                 if shape_types[index] in SCRIBBLE_SHAPE_TYPES:
                     labels[index] = new_label
             properties["label"] = labels
@@ -178,9 +186,11 @@ def set_prompt_label(layer, new_label, relabel_selected: bool = True):
 
             # Keep the drawing default on the requested label. Updating the feature table above
             # may infer a current value from the edited selection.
-            current_properties = layer.current_properties
+            layer.selected_data = set()
+            current_properties = dict(layer.current_properties)
             current_properties["label"] = np.array([new_label])
             layer.current_properties = current_properties
+            layer.selected_data = selected_shapes
 
     layer.refresh()
     if isinstance(layer, napari.layers.Shapes):
@@ -192,6 +202,73 @@ def set_prompt_label(layer, new_label, relabel_selected: bool = True):
         if any(len(values) != n_shapes for values in layer.properties.values()):
             return
     layer.refresh_colors()
+
+
+def ensure_prompt_object_ids(layer) -> None:
+    """Add the per-prompt ``object_id`` property to an existing prompt layer.
+
+    The property is stored as a string, matching the tracking annotator's ID properties and
+    avoiding pandas categorical warnings in napari. ``0`` means that the prompt is unassigned.
+
+    Args:
+        layer: A napari Points or Shapes prompt layer.
+    """
+    current_properties = dict(layer.current_properties)
+    needs_current_object_id = "object_id" not in current_properties
+    if "object_id" not in layer.properties:
+        properties = dict(layer.properties)
+        properties["object_id"] = np.full(
+            len(layer.data), UNASSIGNED_OBJECT_ID, dtype=object,
+        )
+        layer.properties = properties
+
+    if needs_current_object_id:
+        current_properties["object_id"] = np.array([UNASSIGNED_OBJECT_ID])
+        selected_data = set(layer.selected_data)
+        if selected_data:
+            layer.selected_data = set()
+        layer.current_properties = current_properties
+        if selected_data:
+            layer.selected_data = selected_data
+
+
+def set_prompt_object_id(layer, object_id: int, relabel_selected: bool = True) -> None:
+    """Set the target object for selected and future prompts in a napari layer.
+
+    Args:
+        layer: A napari Points or Shapes prompt layer.
+        object_id: The positive input segmentation ID to assign.
+        relabel_selected: Whether selected prompts also take the new ID. When false, only the
+            drawing default is changed.
+    """
+    object_id = int(object_id)
+    if object_id <= 0:
+        raise ValueError("Prompt object IDs must be positive.")
+
+    ensure_prompt_object_ids(layer)
+    object_id_string = str(object_id)
+    valid_selection = {
+        index for index in layer.selected_data if 0 <= index < len(layer.data)
+    }
+    if valid_selection != layer.selected_data:
+        layer.selected_data = valid_selection
+
+    current_properties = dict(layer.current_properties)
+    if relabel_selected and valid_selection:
+        properties = dict(layer.properties)
+        object_ids = np.asarray(properties["object_id"], dtype=object).copy()
+        for index in valid_selection:
+            object_ids[index] = object_id_string
+        properties["object_id"] = object_ids
+        layer.properties = properties
+    current_properties["object_id"] = np.array([object_id_string])
+    selected_data = set(layer.selected_data)
+    if selected_data:
+        layer.selected_data = set()
+    layer.current_properties = current_properties
+    if selected_data:
+        layer.selected_data = selected_data
+    layer.refresh()
 
 
 def relabels_selection(layer, viewer) -> bool:
@@ -598,6 +675,7 @@ def merge_labels_for_refined_commit(
 
 def point_layer_to_prompts(
     layer: napari.layers.Points, i=None, track_id=None, with_stop_annotation=True, exclude_states=None,
+    object_id=None,
 ) -> Optional[Tuple[np.ndarray, np.ndarray]]:
     """Extract point prompts for SAM from a napari point layer.
 
@@ -609,6 +687,8 @@ def point_layer_to_prompts(
             as stop annotation or just returned as normal prompt.
         exclude_states: Track-states to drop (e.g. ('division',)); such points mark a lineage
             event rather than a segmentation prompt and must not be fed to the predictor.
+        object_id: Optional input mask object ID. When given, only points assigned to this ID are
+            returned.
 
     Returns:
         The point coordinates for the prompts.
@@ -623,6 +703,11 @@ def point_layer_to_prompts(
     keep = np.ones(len(points), dtype=bool)
     if exclude_states is not None and "state" in layer.properties:
         keep = ~np.isin(np.asarray(layer.properties["state"]), list(exclude_states))
+    if object_id is not None:
+        if "object_id" not in layer.properties:
+            raise ValueError("Point corrections do not have target object IDs.")
+        object_ids = np.asarray(list(map(int, layer.properties["object_id"])))
+        keep &= object_ids == int(object_id)
 
     if i is None:
         assert points.shape[1] == 2, f"{points.shape}"
@@ -832,6 +917,7 @@ def scribble_layer_to_prompts(
     max_points: int = 64,
     deduplication_distance: float = 4.0,
     track_id=None,
+    object_id=None,
 ) -> Tuple[np.ndarray, np.ndarray]:
     """Convert positive/negative open strokes into sparse SAM point prompts.
 
@@ -855,6 +941,8 @@ def scribble_layer_to_prompts(
             overlapping strokes with the same label are considered duplicates.
         track_id: Id of the current track. Required for tracking data. When given, the function
             converts only the strokes whose ``track_id`` property matches.
+        object_id: Optional input mask object ID. When given, only scribbles assigned to this ID
+            are converted.
 
     Returns:
         Sampled coordinates in ``(y, x)`` order and SAM labels (positive ``1``, negative ``0``).
@@ -881,11 +969,22 @@ def scribble_layer_to_prompts(
         if len(stroke_track_ids) != len(shape_data):
             raise AssertionError("Scribble shapes and track ids must have matching lengths.")
 
+    if object_id is None:
+        stroke_object_ids = [None] * len(shape_data)
+    else:
+        if "object_id" not in layer.properties:
+            raise ValueError("Shape corrections do not have target object IDs.")
+        stroke_object_ids = list(map(int, layer.properties["object_id"]))
+        if len(stroke_object_ids) != len(shape_data):
+            raise AssertionError("Scribble shapes and object ids must have matching lengths.")
+
     strokes = []
-    for vertices, shape_type, stroke_label, stroke_track_id in zip(
-        shape_data, shape_types, stroke_labels, stroke_track_ids
+    for vertices, shape_type, stroke_label, stroke_track_id, stroke_object_id in zip(
+        shape_data, shape_types, stroke_labels, stroke_track_ids, stroke_object_ids
     ):
         if track_id is not None and stroke_track_id != track_id:
+            continue
+        if object_id is not None and stroke_object_id != int(object_id):
             continue
         if shape_type in ("rectangle", "ellipse", "polygon"):
             continue
@@ -1037,6 +1136,7 @@ def collect_frame_prompts(
     shape: Tuple[int, int],
     i=None,
     track_id=None,
+    object_id=None,
     exclude_states=None,
     with_stop_annotation: bool = True,
 ) -> FramePrompts:
@@ -1054,6 +1154,7 @@ def collect_frame_prompts(
         shape: The image shape (in-plane, without the frame axis).
         i: Index for the data (required for 3d or timeseries data).
         track_id: Id of the current track (required for tracking data).
+        object_id: Optional input mask object ID used to filter correction prompts.
         exclude_states: Track-states to drop, e.g. ('division',). See `point_layer_to_prompts`.
         with_stop_annotation: Whether a lone negative point may be read as a stop annotation.
 
@@ -1061,14 +1162,17 @@ def collect_frame_prompts(
         The prompts of the frame.
     """
     scribble_points, scribble_labels = scribble_layer_to_prompts(
-        shape_layer, image_shape=shape, i=i, track_id=track_id
+        shape_layer, image_shape=shape, i=i, track_id=track_id, object_id=object_id
     )
     have_scribbles = len(scribble_points) > 0
-    boxes, masks = shape_layer_to_prompts(shape_layer, shape, i=i, track_id=track_id)
+    boxes, masks = shape_layer_to_prompts(
+        shape_layer, shape, i=i, track_id=track_id, object_id=object_id,
+    )
 
     prompts = point_layer_to_prompts(
         point_layer, i=i, track_id=track_id, exclude_states=exclude_states,
         with_stop_annotation=with_stop_annotation and not have_scribbles and not boxes,
+        object_id=object_id,
     )
     if prompts is None:
         return FramePrompts(
@@ -1084,7 +1188,7 @@ def collect_frame_prompts(
 
 
 def shape_layer_to_prompts(
-    layer: napari.layers.Shapes, shape: Tuple[int, int], i=None, track_id=None
+    layer: napari.layers.Shapes, shape: Tuple[int, int], i=None, track_id=None, object_id=None,
 ) -> Tuple[List[np.ndarray], List[Optional[np.ndarray]]]:
     """Extract prompts for SAM from a napari shape layer.
 
@@ -1096,6 +1200,8 @@ def shape_layer_to_prompts(
         shape: The image shape.
         i: Index for the data (required for 3d or timeseries data).
         track_id: Id of the current track (required for tracking data).
+        object_id: Optional input mask object ID. When given, only shapes assigned to this ID are
+            returned.
 
     Returns:
         The box prompts.
@@ -1145,18 +1251,29 @@ def shape_layer_to_prompts(
     if len(shape_data) == 0:
         return [], []
 
-    if i is not None:
-        if track_id is None:
-            prompt_selection = [j for j, data in enumerate(shape_data) if (data[:, 0] == i).all()]
-        else:
-            track_ids = np.array(list(map(int, layer.properties["track_id"])))
-            prompt_selection = [
-                j for j, (data, this_track_id) in enumerate(zip(shape_data, track_ids))
-                if ((data[:, 0] == i).all() and this_track_id == track_id)
-            ]
+    track_ids = None if track_id is None else np.asarray(list(map(int, layer.properties["track_id"])))
+    if object_id is None:
+        object_ids = None
+    else:
+        if "object_id" not in layer.properties:
+            raise ValueError("Shape corrections do not have target object IDs.")
+        object_ids = np.asarray(list(map(int, layer.properties["object_id"])))
 
+    prompt_selection = []
+    for j, data in enumerate(shape_data):
+        if i is not None and not (data[:, 0] == i).all():
+            continue
+        if track_ids is not None and track_ids[j] != track_id:
+            continue
+        if object_ids is not None and object_ids[j] != int(object_id):
+            continue
+        prompt_selection.append(j)
+
+    if i is not None:
         shape_data = [shape_data[j][:, 1:] for j in prompt_selection]
-        shape_types = [shape_types[j] for j in prompt_selection]
+    else:
+        shape_data = [shape_data[j] for j in prompt_selection]
+    shape_types = [shape_types[j] for j in prompt_selection]
 
     boxes, masks = _to_prompts(shape_data, shape_types)
     return boxes, masks

--- a/micro_sam/sam_annotator/util.py
+++ b/micro_sam/sam_annotator/util.py
@@ -4,7 +4,7 @@ import warnings
 from glob import glob
 from pathlib import Path
 from dataclasses import dataclass
-from typing import List, Optional, Tuple
+from typing import Dict, Iterator, List, Mapping, Optional, Sequence, Tuple
 
 import h5py
 import numpy as np
@@ -315,6 +315,259 @@ def clear_annotations_slice(viewer: napari.Viewer, i: int, clear_segmentations=T
 #
 # Helper functions to extract prompts from napari layers.
 #
+
+
+@dataclass
+class MaskInputData:
+    """Validated and merged Labels layers used as dense mask inputs.
+
+    Attributes:
+        labels: The merged 2D or 3D label image. Equal nonzero IDs from different source layers
+            are unioned and unequal IDs never overlap.
+        object_ids: The sorted nonzero IDs in ``labels``.
+        source_layers: The source Labels layer objects, retained for UI provenance.
+        source_names: The source layer names at collection time.
+        occupied_slices: For 3D inputs, the sorted z-slices occupied by each object ID. This is
+            empty for 2D inputs.
+    """
+
+    labels: np.ndarray
+    object_ids: Tuple[int, ...]
+    source_layers: Tuple[object, ...]
+    source_names: Tuple[str, ...]
+    occupied_slices: Dict[int, Tuple[int, ...]]
+
+
+def _spatial_image_shape(image_layer) -> Tuple[int, ...]:
+    """Return the spatial shape of a napari image, excluding an RGB channel axis."""
+    shape = tuple(np.shape(image_layer.data))
+    if bool(getattr(image_layer, "rgb", False)):
+        if len(shape) < 3:
+            raise ValueError(
+                f"RGB image layer '{getattr(image_layer, 'name', '<unnamed>')}' has invalid shape {shape}."
+            )
+        shape = shape[:-1]
+    if len(shape) not in (2, 3):
+        raise ValueError(f"Mask inputs require a 2D or 3D image, got spatial shape {shape}.")
+    return shape
+
+
+def _transform_signature(layer, ndim: int) -> np.ndarray:
+    """Sample a layer's data-to-world transform at the origin and basis vectors."""
+    points = np.concatenate([np.zeros((1, ndim)), np.eye(ndim)], axis=0)
+    if hasattr(layer, "data_to_world"):
+        try:
+            world = np.stack([np.asarray(layer.data_to_world(tuple(point)), dtype="float64") for point in points])
+            if world.shape == points.shape:
+                return world
+        except (AttributeError, TypeError, ValueError):
+            pass
+
+    # This fallback keeps the helper usable with lightweight layer-like objects and covers the
+    # common scale/translate case. Real napari layers take the public data_to_world path above,
+    # which also includes rotate, shear and affine.
+    scale = np.asarray(getattr(layer, "scale", np.ones(ndim)), dtype="float64")
+    translate = np.asarray(getattr(layer, "translate", np.zeros(ndim)), dtype="float64")
+    if scale.shape != (ndim,) or translate.shape != (ndim,):
+        raise ValueError(
+            f"Layer '{getattr(layer, 'name', '<unnamed>')}' has a transform with incompatible dimensionality."
+        )
+    return points * scale + translate
+
+
+def _validated_label_array(data, name: str, expected_shape: Tuple[int, ...]) -> np.ndarray:
+    """Validate one label array and convert it losslessly to uint32."""
+    labels = np.asarray(data)
+    if labels.shape != expected_shape:
+        raise ValueError(
+            f"Mask layer '{name}' has shape {labels.shape}, but the selected image has spatial shape "
+            f"{expected_shape}. Mask inputs are not resampled."
+        )
+    if labels.dtype == np.bool_:
+        return labels.astype("uint32", copy=False)
+    if not np.issubdtype(labels.dtype, np.integer):
+        raise ValueError(f"Mask layer '{name}' must contain boolean or integer labels, got dtype {labels.dtype}.")
+
+    if labels.size:
+        minimum, maximum = int(labels.min()), int(labels.max())
+        if minimum < 0:
+            raise ValueError(f"Mask layer '{name}' contains negative label ID {minimum}.")
+        if maximum > np.iinfo("uint32").max:
+            raise ValueError(
+                f"Mask layer '{name}' contains label ID {maximum}, which exceeds the uint32 limit "
+                f"{np.iinfo('uint32').max}."
+            )
+    return labels.astype("uint32", copy=False)
+
+
+def collect_mask_inputs(layers: Sequence[object], image_layer) -> MaskInputData:
+    """Validate and merge selected Labels layers against the selected image.
+
+    Equal IDs are unioned across layers. Unequal nonzero IDs at the same pixel are rejected rather
+    than resolved implicitly. Shape and data-to-world transform must match exactly (within floating
+    point tolerance); no resampling is performed.
+    """
+    layers = tuple(layers)
+    if not layers:
+        raise ValueError("Select at least one Labels layer as a mask input.")
+
+    image_shape = _spatial_image_shape(image_layer)
+    image_transform = _transform_signature(image_layer, len(image_shape))
+    merged = np.zeros(image_shape, dtype="uint32")
+    owner = np.full(image_shape, -1, dtype="int64")
+    names = tuple(str(getattr(layer, "name", f"layer {index}")) for index, layer in enumerate(layers))
+
+    for index, (layer, name) in enumerate(zip(layers, names)):
+        labels = _validated_label_array(layer.data, name, image_shape)
+        layer_transform = _transform_signature(layer, len(image_shape))
+        if not np.allclose(layer_transform, image_transform, rtol=1e-7, atol=1e-8):
+            raise ValueError(
+                f"Mask layer '{name}' is not aligned with image layer "
+                f"'{getattr(image_layer, 'name', '<unnamed>')}'. Their data-to-world transforms differ; "
+                "mask inputs are not resampled."
+            )
+
+        conflict = (merged != 0) & (labels != 0) & (merged != labels)
+        if np.any(conflict):
+            coordinates = np.argwhere(conflict)
+            first = tuple(int(value) for value in coordinates[0])
+            previous_index = int(owner[first])
+            raise ValueError(
+                f"Mask layers '{names[previous_index]}' (ID {int(merged[first])}) and '{name}' "
+                f"(ID {int(labels[first])}) overlap with different nonzero IDs on "
+                f"{len(coordinates)} pixels; first conflict at coordinate {first}. "
+                "Resolve the label IDs or overlap in napari before using these layers."
+            )
+
+        foreground = labels != 0
+        new_pixels = foreground & (merged == 0)
+        merged[new_pixels] = labels[new_pixels]
+        owner[new_pixels] = index
+
+    object_ids = tuple(int(value) for value in np.unique(merged) if value != 0)
+    if not object_ids:
+        raise ValueError("The selected mask input layers do not contain any nonzero label IDs.")
+
+    occupied_slices = {}
+    if merged.ndim == 3:
+        for object_id in object_ids:
+            occupied = np.flatnonzero(np.any(merged == object_id, axis=(1, 2)))
+            occupied_slices[object_id] = tuple(int(index) for index in occupied)
+
+    return MaskInputData(
+        labels=merged,
+        object_ids=object_ids,
+        source_layers=layers,
+        source_names=names,
+        occupied_slices=occupied_slices,
+    )
+
+
+def iter_mask_input_masks(mask_inputs: MaskInputData) -> Iterator[Tuple[int, Optional[int], np.ndarray]]:
+    """Yield ``(object_id, z, binary_mask)`` for every logical 2D mask prompt."""
+    if mask_inputs.labels.ndim == 2:
+        for object_id in mask_inputs.object_ids:
+            yield object_id, None, mask_inputs.labels == object_id
+        return
+
+    if mask_inputs.labels.ndim != 3:
+        raise ValueError(f"Mask inputs must be 2D or 3D, got shape {mask_inputs.labels.shape}.")
+    for object_id in mask_inputs.object_ids:
+        for z in mask_inputs.occupied_slices[object_id]:
+            yield object_id, z, mask_inputs.labels[z] == object_id
+
+
+def _validated_uint32_labels(labels, name: str, shape: Optional[Tuple[int, ...]] = None) -> np.ndarray:
+    """Validate an internal label image, optionally against a required shape."""
+    array = np.asarray(labels)
+    expected_shape = tuple(array.shape) if shape is None else shape
+    return _validated_label_array(array, name, expected_shape)
+
+
+def merge_refined_mask_candidates(
+    original_labels: np.ndarray, candidates: Mapping[int, np.ndarray]
+) -> np.ndarray:
+    """Merge overlapping refined binary masks deterministically.
+
+    At each pixel the original source owner wins when its candidate still covers that pixel.
+    Otherwise the smallest covering numeric ID wins. Candidate mapping order has no effect.
+    """
+    original = _validated_uint32_labels(original_labels, "original labels")
+    shape = tuple(original.shape)
+    normalized = {}
+    for raw_object_id, candidate in candidates.items():
+        object_id = int(raw_object_id)
+        if object_id <= 0 or object_id > np.iinfo("uint32").max:
+            raise ValueError(f"Candidate object ID {object_id} is outside the valid uint32 foreground range.")
+        candidate = np.asarray(candidate)
+        if candidate.shape != shape:
+            raise ValueError(
+                f"Candidate for object ID {object_id} has shape {candidate.shape}, expected {shape}."
+            )
+        normalized[object_id] = candidate.astype(bool, copy=False)
+
+    result = np.zeros(shape, dtype="uint32")
+    # Sorted assignment establishes the smallest-ID fallback without depending on mapping order.
+    for object_id in sorted(normalized):
+        mask = normalized[object_id]
+        result[mask & (result == 0)] = object_id
+    # Original ownership has higher priority than the fallback.
+    for object_id in sorted(normalized):
+        result[(original == object_id) & normalized[object_id]] = object_id
+    return result
+
+
+def merge_labels_for_direct_commit(destination: np.ndarray, incoming: np.ndarray) -> np.ndarray:
+    """Return a direct-commit merge without mutating either input label image."""
+    destination = _validated_uint32_labels(destination, "committed labels")
+    incoming = _validated_uint32_labels(incoming, "incoming labels", tuple(destination.shape))
+    conflict = (destination != 0) & (incoming != 0) & (destination != incoming)
+    if np.any(conflict):
+        coordinates = np.argwhere(conflict)
+        first = tuple(int(value) for value in coordinates[0])
+        raise ValueError(
+            f"Incoming ID {int(incoming[first])} overlaps committed ID {int(destination[first])} on "
+            f"{len(coordinates)} pixels; first conflict at coordinate {first}."
+        )
+
+    result = destination.copy()
+    foreground = (result == 0) & (incoming != 0)
+    result[foreground] = incoming[foreground]
+    return result
+
+
+def merge_labels_for_refined_commit(
+    destination: np.ndarray, refined: np.ndarray, object_ids: Sequence[int]
+) -> np.ndarray:
+    """Replace authoritative destination objects with refined masks, preserving their IDs."""
+    destination = _validated_uint32_labels(destination, "committed labels")
+    refined = _validated_uint32_labels(refined, "refined labels", tuple(destination.shape))
+    authoritative_ids = tuple(sorted({int(object_id) for object_id in object_ids}))
+    if any(object_id <= 0 or object_id > np.iinfo("uint32").max for object_id in authoritative_ids):
+        raise ValueError("Authoritative object IDs must be nonzero uint32 values.")
+
+    refined_ids = tuple(int(value) for value in np.unique(refined) if value != 0)
+    if refined_ids != authoritative_ids:
+        missing = sorted(set(authoritative_ids).difference(refined_ids))
+        unexpected = sorted(set(refined_ids).difference(authoritative_ids))
+        raise ValueError(
+            "The refined result IDs do not match its authoritative source IDs. "
+            f"Missing IDs: {missing}; unexpected IDs: {unexpected}."
+        )
+
+    result = destination.copy()
+    if authoritative_ids:
+        result[np.isin(result, authoritative_ids)] = 0
+    conflict = (result != 0) & (refined != 0)
+    if np.any(conflict):
+        coordinates = np.argwhere(conflict)
+        first = tuple(int(value) for value in coordinates[0])
+        raise ValueError(
+            f"Refined ID {int(refined[first])} overlaps remaining committed ID {int(result[first])} on "
+            f"{len(coordinates)} pixels; first conflict at coordinate {first}."
+        )
+    result[refined != 0] = refined[refined != 0]
+    return result
 
 
 def point_layer_to_prompts(

--- a/micro_sam/v1/prompt_based_segmentation.py
+++ b/micro_sam/v1/prompt_based_segmentation.py
@@ -241,6 +241,131 @@ def _tile_to_full_mask(mask, shape, tile):
     return full_mask
 
 
+def _prepare_tiled_mask_prompt_jobs(mask, shape, tile_shape, halo, box=None, points=None, labels=None):
+    """Prepare local prompts for refining one mask across all relevant embedding tiles."""
+    shape = tuple(shape)
+    mask = np.asarray(mask)
+    if mask.ndim != 2 or mask.shape != shape:
+        raise ValueError(f"The mask shape must match the tiled embedding shape {shape}, got {mask.shape}.")
+    mask = mask.astype(bool, copy=False)
+
+    if box is not None:
+        box = np.asarray(box)
+        if box.shape != (4,):
+            raise ValueError(f"The box must have shape (4,), got {box.shape}.")
+
+    if points is None:
+        if labels is not None:
+            raise ValueError("Point labels were passed without point prompts.")
+        points = np.empty((0, 2), dtype="float64")
+        labels = np.empty((0,), dtype="int64")
+    else:
+        points = np.asarray(points)
+        if points.ndim != 2 or points.shape[1] != 2:
+            raise ValueError(f"The points must have shape (N, 2), got {points.shape}.")
+        if labels is None:
+            raise ValueError("If points are passed you also need to pass labels.")
+        labels = np.asarray(labels)
+        if labels.ndim != 1 or len(labels) != len(points):
+            raise ValueError("The point labels must be a one-dimensional array matching the points.")
+        if len(points) > 0:
+            valid = (
+                (points[:, 0] >= 0) & (points[:, 0] < shape[0]) &
+                (points[:, 1] >= 0) & (points[:, 1] < shape[1])
+            )
+            if not valid.all():
+                raise ValueError("All point prompts must lie inside the tiled image.")
+
+    tiling = Blocking([0, 0], shape, tile_shape)
+    active_tile_ids = set()
+    for tile_id in range(tiling.number_of_blocks):
+        block = tiling.get_block_with_halo(tile_id, list(halo))
+        inner = block.inner_block
+        inner_bb = tuple(slice(beg, end) for beg, end in zip(inner.begin, inner.end))
+        if mask[inner_bb].any():
+            active_tile_ids.add(tile_id)
+
+        if box is not None:
+            y0, x0, y1, x1 = box
+            intersects_inner = not (
+                y1 <= inner.begin[0] or y0 >= inner.end[0] or
+                x1 <= inner.begin[1] or x0 >= inner.end[1]
+            )
+            if intersects_inner:
+                active_tile_ids.add(tile_id)
+
+    # Positive points may deliberately expand the target beyond its existing mask or box. Activate
+    # only the tile that owns the point; once active, a tile receives every sparse cue in its halo.
+    for point, label in zip(points, labels):
+        if label == 1:
+            coordinate = np.round(point).astype("int").tolist()
+            coordinate = [min(coord, sh - 1) for coord, sh in zip(coordinate, shape)]
+            active_tile_ids.add(tiling.coordinates_to_block_id(coordinate))
+
+    jobs = {}
+    for tile_id in sorted(active_tile_ids):
+        block = tiling.get_block_with_halo(tile_id, list(halo))
+        outer = block.outer_block
+        outer_bb = tuple(slice(beg, end) for beg, end in zip(outer.begin, outer.end))
+        local_mask = mask[outer_bb]
+
+        local_box = None
+        if box is not None:
+            y0, x0, y1, x1 = box
+            clipped_box = np.array([
+                max(y0, outer.begin[0]), max(x0, outer.begin[1]),
+                min(y1, outer.end[0]), min(x1, outer.end[1]),
+            ])
+            if clipped_box[0] < clipped_box[2] and clipped_box[1] < clipped_box[3]:
+                local_box = clipped_box - np.array([
+                    outer.begin[0], outer.begin[1], outer.begin[0], outer.begin[1]
+                ])
+
+        if len(points) == 0:
+            local_points, local_labels = None, None
+        else:
+            point_mask = (
+                (points[:, 0] >= outer.begin[0]) & (points[:, 0] < outer.end[0]) &
+                (points[:, 1] >= outer.begin[1]) & (points[:, 1] < outer.end[1])
+            )
+            local_points = points[point_mask] - np.asarray(outer.begin)
+            local_labels = labels[point_mask]
+            if len(local_points) == 0:
+                local_points, local_labels = None, None
+
+        has_positive_point = local_labels is not None and np.any(local_labels == 1)
+        if not (local_mask.any() or local_box is not None or has_positive_point):
+            continue
+
+        jobs[tile_id] = {
+            "block": block,
+            "mask": local_mask,
+            "box": local_box,
+            "points": local_points,
+            "labels": local_labels,
+        }
+
+    return tiling, jobs
+
+
+def _stitch_tiled_mask_predictions(predictions, shape):
+    """Stitch tile predictions through disjoint inner blocks."""
+    output = np.zeros((1,) + tuple(shape), dtype=bool)
+    for block, prediction in predictions:
+        prediction = np.asarray(prediction)
+        if prediction.ndim == 2:
+            prediction = prediction[None]
+        if prediction.shape[0] != 1:
+            raise ValueError(f"Expected one prediction per tile, got shape {prediction.shape}.")
+
+        local = tuple(
+            slice(beg, end) for beg, end in zip(block.inner_block_local.begin, block.inner_block_local.end)
+        )
+        glob = tuple(slice(beg, end) for beg, end in zip(block.inner_block.begin, block.inner_block.end))
+        output[(slice(None),) + glob] = prediction[(slice(None),) + local].astype(bool, copy=False)
+    return output
+
+
 #
 # functions for prompted segmentation:
 # - segment_from_points: use point prompts as input
@@ -407,6 +532,70 @@ def segment_from_mask(
         return mask, scores, logits
     else:
         return mask
+
+
+def segment_from_mask_tiled(
+    predictor: SamPredictor,
+    mask: np.ndarray,
+    image_embeddings: util.ImageEmbeddings,
+    i: Optional[int] = None,
+    box: Optional[np.ndarray] = None,
+    points: Optional[np.ndarray] = None,
+    labels: Optional[np.ndarray] = None,
+):
+    """Refine one binary mask target across all relevant tiled image embeddings.
+
+    Unlike :func:`segment_from_mask`, which routes all prompts to one tile, this function activates
+    every tile whose inner block intersects the dense mask or the optional enclosing box. A positive
+    point also activates its owning tile, so corrections can expand the target beyond the source
+    mask. Each prediction is restricted to the tile's disjoint inner block during stitching.
+
+    The box uses ``(y0, x0, y1, x1)`` coordinates and points use ``(y, x)`` coordinates, consistent
+    with the other tiled prompt routing helpers.
+
+    Args:
+        predictor: The segment anything predictor.
+        mask: The full-size binary mask prompt.
+        image_embeddings: Precomputed tiled image embeddings.
+        i: Index for a 3D image or time series.
+        box: Optional full-image enclosing box.
+        points: Optional full-image point corrections.
+        labels: Positive/negative labels corresponding to the point corrections.
+
+    Returns:
+        The full-size binary prediction with shape ``(1, H, W)``.
+    """
+    if image_embeddings is None or image_embeddings.get("input_size") is not None:
+        raise ValueError("segment_from_mask_tiled requires tiled image embeddings.")
+
+    features = image_embeddings["features"]
+    shape = tuple(features.attrs["shape"])
+    tile_shape = tuple(features.attrs["tile_shape"])
+    halo = tuple(features.attrs["halo"])
+    _, jobs = _prepare_tiled_mask_prompt_jobs(
+        mask, shape, tile_shape, halo, box=box, points=points, labels=labels
+    )
+
+    predictions = []
+    for tile_id, job in jobs.items():
+        set_precomputed(predictor, image_embeddings, i=i, tile_id=tile_id)
+        # ``segment_from_mask`` passes explicit point coordinates directly to SAM, which expects
+        # (x, y). Keep this public tiled helper consistent with napari and the other prompt helpers
+        # by routing in (y, x) above and swapping only at the untiled predictor boundary.
+        local_points = None if job["points"] is None else job["points"][:, ::-1]
+        prediction = segment_from_mask(
+            predictor,
+            job["mask"],
+            use_box=False,
+            use_mask=True,
+            use_points=False,
+            box=job["box"],
+            points=local_points,
+            labels=job["labels"],
+        )
+        predictions.append((job["block"], prediction))
+
+    return _stitch_tiled_mask_predictions(predictions, shape)
 
 
 def segment_from_box(

--- a/micro_sam/v2/prompt_based_segmentation.py
+++ b/micro_sam/v2/prompt_based_segmentation.py
@@ -108,6 +108,74 @@ def _crop_mask_to_tile(tiling, halo, tile_id, mask):
     return np.asarray(mask)[y0:y1, x0:x1]
 
 
+def _validate_pre_refined_masks(volume_shape, frame_ids, masks, object_id):
+    """Validate full-resolution masks before they are added to the persistent video state."""
+    if masks is None:
+        return []
+    if isinstance(masks, np.ndarray) and masks.ndim == 2:
+        masks = [masks]
+    else:
+        masks = list(masks)
+    if len(masks) == 0:
+        return []
+
+    def broadcast_ids(value, default, name):
+        value = default if value is None else value
+        if isinstance(value, (list, tuple, np.ndarray)):
+            values = np.asarray(value)
+            if values.ndim == 0:
+                values = [values.item()]
+            elif values.ndim == 1:
+                values = values.tolist()
+            else:
+                raise ValueError(f"'{name}' must be a scalar or one-dimensional sequence.")
+            if len(values) == 1:
+                values = values * len(masks)
+            if len(values) != len(masks):
+                raise ValueError(f"Expected 1 or {len(masks)} {name}, got {len(values)}.")
+        else:
+            values = [value] * len(masks)
+
+        if any(isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)) for value in values):
+            raise TypeError(f"'{name}' must contain integer IDs.")
+        return [int(value) for value in values]
+
+    frame_ids = broadcast_ids(frame_ids, None, "frame_ids")
+    object_ids = broadcast_ids(object_id, 1, "object_id")
+    depth, height, width = (int(size) for size in volume_shape)
+
+    prepared = []
+    keys = set()
+    for frame_id, mask, obj_id in zip(frame_ids, masks, object_ids):
+        if not 0 <= frame_id < depth:
+            raise ValueError(f"Frame ID {frame_id} is outside the valid range [0, {depth - 1}].")
+        if obj_id <= 0:
+            raise ValueError(f"Object ID must be positive, got {obj_id}.")
+
+        mask = np.asarray(mask)
+        if mask.ndim != 2 or mask.shape != (height, width):
+            raise ValueError(
+                f"Each pre-refined mask must have shape {(height, width)}, got {mask.shape}."
+            )
+        if not np.issubdtype(mask.dtype, np.bool_) and not np.issubdtype(mask.dtype, np.number):
+            raise TypeError("Pre-refined masks must have a boolean or numeric dtype.")
+        if not np.isin(mask, (0, 1)).all():
+            raise ValueError("Pre-refined masks must be binary (contain only 0 and 1).")
+        mask = mask.astype(bool, copy=False)
+        if not mask.any():
+            raise ValueError("Pre-refined masks must contain at least one foreground pixel.")
+
+        key = (obj_id, frame_id)
+        if key in keys:
+            raise ValueError(
+                f"Only one pre-refined mask can be supplied for object {obj_id} on frame {frame_id}."
+            )
+        keys.add(key)
+        prepared.append((frame_id, mask, obj_id))
+
+    return prepared
+
+
 def _clone_image_predictor(predictor, model: torch.nn.Module):
     """Copy an image predictor onto a replica model, with per-image state cleared."""
     from micro_sam.v2.util import configure_image_predictor
@@ -477,6 +545,7 @@ class PromptableSegmentation3D:
         self._pushed_points = {}  # (object_id, frame_id) -> set of (y, x, label)
         self._pushed_boxes = {}  # (object_id, frame_id) -> set of box corner tuples
         self._pushed_masks = {}  # (object_id, frame_id) -> set of mask content digests
+        self._pushed_pre_refined_masks = {}  # (object_id, frame_id) -> set of mask content digests
         # Signature of the prompt set of the previous round, see 'sync_prompt_state'.
         self._prompt_signatures = set()
         self._image_style_trafo = None  # lazily built resize-longest transform for per-slice mask refinement
@@ -493,6 +562,7 @@ class PromptableSegmentation3D:
         self._pushed_points = {}
         self._pushed_boxes = {}
         self._pushed_masks = {}
+        self._pushed_pre_refined_masks = {}
         self._prompt_signatures = set()
 
     def sync_prompt_state(self, signatures):
@@ -689,6 +759,43 @@ class PromptableSegmentation3D:
                 obj_id=obj_id,
                 mask=self._prepare_mask(refined),
             )
+
+    def add_pre_refined_masks(
+        self,
+        frame_ids: Union[int, List[int]],
+        masks: Optional[List[np.ndarray]] = None,
+        object_id: Optional[Union[int, List[int]]] = None,
+    ):
+        """Condition propagation directly on already-refined full-resolution binary masks.
+
+        Unlike :meth:`add_mask_prompts`, this method does not run the image-style SAM2 decoder.
+        The masks are assumed to be final seed-frame segmentations and are passed directly to the
+        video predictor's mask-conditioning path.
+        """
+        prepared = _validate_pre_refined_masks(self.volume.shape, frame_ids, masks, object_id)
+        if not prepared:
+            return
+
+        pending = []
+        for frame_id, mask, obj_id in prepared:
+            signature = hashlib.sha1(np.ascontiguousarray(mask).tobytes()).hexdigest()
+            if signature not in self._pushed_pre_refined_masks.get((obj_id, frame_id), set()):
+                pending.append((frame_id, mask, obj_id, signature))
+
+        try:
+            for frame_id, mask, obj_id, signature in pending:
+                self.predictor.add_new_mask(
+                    inference_state=self.inference_state,
+                    frame_idx=frame_id,
+                    obj_id=obj_id,
+                    mask=self._prepare_mask(mask),
+                )
+                self._pushed_pre_refined_masks.setdefault((obj_id, frame_id), set()).add(signature)
+        except Exception:
+            # A batch can fail after earlier masks have changed the persistent SAM2 state. Reset all
+            # state so bookkeeping and predictor conditioning cannot disagree on the next run.
+            self.reset_predictor()
+            raise
 
     def _propagate_in_direction(
         self, reverse, update_progress=None, early_stop_patience=None, z_range=None, seen_frames=None
@@ -1258,6 +1365,45 @@ class TiledPromptableSegmentation3D:
                     frame_ids=frame_ids, masks=[_crop_mask_to_tile(self.tiling, self.halo, tid, mask)],
                     object_id=obj_id,
                 )
+
+    def add_pre_refined_masks(self, frame_ids, masks=None, object_id=None):
+        """Condition active tile columns directly on already-refined full-resolution masks.
+
+        A tile is active only when foreground intersects its halo-free inner block. The full-plane
+        mask is cropped to that tile's outer block before it is forwarded with the original object
+        and frame IDs.
+        """
+        prepared = _validate_pre_refined_masks(self.shape, frame_ids, masks, object_id)
+        if not prepared:
+            return
+
+        tile_jobs = []
+        for frame_id, mask, obj_id in prepared:
+            for tile_id in range(self.tiling.number_of_blocks):
+                block = self.tiling.get_block_with_halo(tile_id, list(self.halo))
+                inner = block.inner_block
+                inner_slice = (
+                    slice(int(inner.begin[0]), int(inner.end[0])),
+                    slice(int(inner.begin[1]), int(inner.end[1])),
+                )
+                if not mask[inner_slice].any():
+                    continue
+                tile_jobs.append((
+                    tile_id,
+                    frame_id,
+                    _crop_mask_to_tile(self.tiling, self.halo, tile_id, mask),
+                    obj_id,
+                ))
+
+        try:
+            for tile_id, frame_id, local_mask, obj_id in tile_jobs:
+                self._get_segmenter(tile_id).add_pre_refined_masks(
+                    frame_ids=frame_id, masks=[local_mask], object_id=obj_id,
+                )
+        except Exception:
+            # Avoid retaining only a prefix of the tile-conditioning jobs.
+            self.reset_predictor()
+            raise
 
     def predict(self, update_progress=None, early_stop_patience=None, z_range=None):
         """Propagate the prompts in every active tile and stitch the results into the full volume.

--- a/test/test_sam_annotator/test_mask_input_widget.py
+++ b/test/test_sam_annotator/test_mask_input_widget.py
@@ -1,0 +1,266 @@
+import platform
+
+import numpy as np
+import pytest
+
+from qtpy.QtCore import Qt
+
+from micro_sam.sam_annotator import _widgets
+from micro_sam.sam_annotator._state import AnnotatorState
+from micro_sam.sam_annotator._widgets import _commit_impl
+from micro_sam.sam_annotator.annotator import Annotator
+
+
+pytestmark = [
+    pytest.mark.gui,
+    pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="GUI tests are not reliable on Windows.",
+    ),
+]
+
+
+def _item_for_layer(widget, layer):
+    """Return the checklist item for a layer without depending on its display name."""
+    for candidate, item in widget._mask_layer_items.values():
+        if candidate is layer or candidate.name == layer.name:
+            return item
+    raise AssertionError(f"No checklist item found for layer {layer.name!r}.")
+
+
+def _set_only_checked(widget, layer):
+    for candidate, item in widget._mask_layer_items.values():
+        is_target = candidate is layer or candidate.name == layer.name
+        item.setCheckState(Qt.Checked if is_target else Qt.Unchecked)
+
+
+def test_mask_layer_checklist_tracks_compatible_layers(make_napari_viewer_proxy):
+    viewer = make_napari_viewer_proxy()
+    image = viewer.add_image(np.zeros((16, 16), dtype="uint8"), name="image")
+    compatible = viewer.add_labels(
+        np.zeros(image.data.shape, dtype="uint32"),
+        name="cellpose",
+    )
+    incompatible_shape = viewer.add_labels(
+        np.zeros((8, 8), dtype="uint32"),
+        name="wrong shape",
+    )
+    incompatible_transform = viewer.add_labels(
+        np.zeros(image.data.shape, dtype="uint32"),
+        name="wrong transform",
+        translate=(1, 0),
+    )
+
+    annotator = Annotator(viewer)
+    widget = annotator._widgets["interactive"]
+
+    compatible_item = _item_for_layer(widget, compatible)
+    incompatible_shape_item = _item_for_layer(widget, incompatible_shape)
+    incompatible_transform_item = _item_for_layer(widget, incompatible_transform)
+    assert compatible_item.flags() & Qt.ItemIsEnabled
+    assert not incompatible_shape_item.flags() & Qt.ItemIsEnabled
+    assert not incompatible_transform_item.flags() & Qt.ItemIsEnabled
+    assert compatible_item.checkState() == Qt.Unchecked
+
+    compatible_item.setCheckState(Qt.Checked)
+    compatible.name = "renamed cellpose"
+    assert _item_for_layer(widget, compatible).checkState() == Qt.Checked
+
+    widget._set_all_mask_layers_checked(False)
+    assert all(
+        item.checkState() == Qt.Unchecked
+        for _, item in widget._mask_layer_items.values()
+    )
+    widget._set_all_mask_layers_checked(True)
+    assert _item_for_layer(widget, compatible).checkState() == Qt.Checked
+    assert _item_for_layer(widget, incompatible_shape).checkState() == Qt.Unchecked
+    assert _item_for_layer(widget, incompatible_transform).checkState() == Qt.Unchecked
+
+    viewer.close()
+
+
+def test_direct_commit_preserves_ids_unions_same_id_and_is_atomic(
+    make_napari_viewer_proxy,
+    monkeypatch,
+):
+    monkeypatch.setattr(_widgets, "_generate_message", lambda *args: True)
+    viewer = make_napari_viewer_proxy()
+    viewer.add_image(np.zeros((12, 12), dtype="uint8"), name="image")
+    annotator = Annotator(viewer)
+    widget = annotator._widgets["interactive"]
+
+    incoming = np.zeros((12, 12), dtype="uint32")
+    incoming[1:4, 1:4] = 7
+    incoming[7:9, 7:9] = 23
+    cellpose = viewer.add_labels(incoming, name="cellpose")
+    _set_only_checked(widget, cellpose)
+    widget._commit_selected_masks_unchanged()
+    np.testing.assert_array_equal(viewer.layers["committed_objects"].data, incoming)
+
+    same_id = np.zeros_like(incoming)
+    same_id[3:6, 3:6] = 7
+    extension = viewer.add_labels(same_id, name="cellpose extension")
+    _set_only_checked(widget, extension)
+    widget._commit_selected_masks_unchanged()
+    expected = incoming.copy()
+    expected[3:6, 3:6] = 7
+    np.testing.assert_array_equal(viewer.layers["committed_objects"].data, expected)
+
+    conflict = np.zeros_like(incoming)
+    conflict[2, 2] = 99
+    conflicting_layer = viewer.add_labels(conflict, name="conflict")
+    _set_only_checked(widget, conflicting_layer)
+    before = viewer.layers["committed_objects"].data.copy()
+    widget._commit_selected_masks_unchanged()
+    np.testing.assert_array_equal(viewer.layers["committed_objects"].data, before)
+
+    viewer.close()
+
+
+def test_direct_commit_keeps_the_selected_image_transform(make_napari_viewer_proxy):
+    viewer = make_napari_viewer_proxy()
+    image = viewer.add_image(
+        np.zeros((12, 12), dtype="uint8"),
+        name="image",
+        scale=(2, 3),
+        translate=(4, 5),
+    )
+    annotator = Annotator(viewer)
+    widget = annotator._widgets["interactive"]
+
+    labels = np.zeros((12, 12), dtype="uint32")
+    labels[2:5, 3:6] = 11
+    cellpose = viewer.add_labels(
+        labels,
+        name="cellpose",
+        scale=image.scale,
+        translate=image.translate,
+    )
+    _set_only_checked(widget, cellpose)
+    widget._commit_selected_masks_unchanged()
+
+    committed = viewer.layers["committed_objects"]
+    np.testing.assert_allclose(
+        committed.data_to_world((0, 0)),
+        image.data_to_world((0, 0)),
+    )
+    np.testing.assert_allclose(
+        committed.data_to_world((1, 1)),
+        image.data_to_world((1, 1)),
+    )
+
+    viewer.close()
+
+
+def test_direct_commit_survives_same_image_embedding_initialization(
+    make_napari_viewer_proxy,
+):
+    viewer = make_napari_viewer_proxy()
+    image = viewer.add_image(np.zeros((10, 10), dtype="uint8"), name="image")
+    annotator = Annotator(viewer)
+    widget = annotator._widgets["interactive"]
+
+    labels = np.zeros(image.data.shape, dtype="uint32")
+    labels[2:6, 3:7] = 17
+    cellpose = viewer.add_labels(labels, name="cellpose")
+    _set_only_checked(widget, cellpose)
+    widget._commit_selected_masks_unchanged()
+
+    state = AnnotatorState()
+    state.image_shape = image.data.shape
+    state.image_scale = image.scale
+    state.skip_recomputing_embeddings = False
+    annotator._update_image()
+
+    np.testing.assert_array_equal(
+        viewer.layers["committed_objects"].data,
+        labels,
+    )
+
+    viewer.close()
+
+
+def test_refined_commit_replaces_source_ids_without_offset(make_napari_viewer_proxy):
+    viewer = make_napari_viewer_proxy()
+    viewer.add_image(np.zeros((12, 12), dtype="uint8"), name="image")
+    Annotator(viewer)
+
+    committed = np.zeros((12, 12), dtype="uint32")
+    committed[1:4, 1:4] = 7
+    committed[8:10, 8:10] = 31
+    viewer.layers["committed_objects"].data = committed
+
+    refined = np.zeros_like(committed)
+    refined[4:7, 4:7] = 7
+    current = viewer.layers["current_object"]
+    current.data = refined
+    current.metadata["micro_sam_mask_refinement"] = {
+        "object_ids": (7,),
+        "source_layers": ("cellpose",),
+    }
+
+    _commit_impl(viewer, "current_object", "pixels", 0.75)
+    expected = np.zeros_like(committed)
+    expected[4:7, 4:7] = 7
+    expected[8:10, 8:10] = 31
+    np.testing.assert_array_equal(viewer.layers["committed_objects"].data, expected)
+
+    viewer.close()
+
+
+def test_3d_seed_uses_largest_cross_section_and_lowest_tie(make_napari_viewer_proxy):
+    viewer = make_napari_viewer_proxy()
+    image = viewer.add_image(np.zeros((5, 12, 12), dtype="uint8"), name="volume")
+    annotator = Annotator(viewer, ndim=3)
+    widget = annotator._widgets["interactive"]
+
+    labels = np.zeros(image.data.shape, dtype="uint32")
+    labels[1, 2:5, 2:5] = 13
+    labels[3, 6:9, 6:9] = 13
+    cellpose = viewer.add_labels(labels, name="cellpose")
+    _set_only_checked(widget, cellpose)
+    mask_inputs = widget._collect_mask_inputs()
+
+    assert widget._seed_slice(mask_inputs, 13) == 1
+    assert widget.mask_3d_strategy.currentText() == "Refine all occupied slices"
+
+    widget.mask_3d_strategy.setCurrentText("Propagate from seed slices")
+    assert not widget._propagation_settings.isHidden()
+
+    viewer.close()
+
+
+def test_refined_commit_conflict_keeps_result_prompts_and_provenance(
+    make_napari_viewer_proxy,
+    monkeypatch,
+):
+    monkeypatch.setattr(_widgets, "_generate_message", lambda *args: True)
+    viewer = make_napari_viewer_proxy()
+    viewer.add_image(np.zeros((12, 12), dtype="uint8"), name="image")
+    annotator = Annotator(viewer)
+
+    committed = np.zeros((12, 12), dtype="uint32")
+    committed[5:8, 5:8] = 31
+    viewer.layers["committed_objects"].data = committed
+
+    refined = np.zeros_like(committed)
+    refined[6:9, 6:9] = 7
+    current = viewer.layers["current_object"]
+    current.data = refined
+    provenance = {"object_ids": (7,), "source_layers": ("cellpose",)}
+    current.metadata["micro_sam_mask_refinement"] = provenance.copy()
+    viewer.layers["point_prompts"].add(np.array([[2, 2]]))
+
+    before_destination = viewer.layers["committed_objects"].data.copy()
+    before_result = current.data.copy()
+    annotator._widgets["commit"](viewer)
+
+    np.testing.assert_array_equal(
+        viewer.layers["committed_objects"].data,
+        before_destination,
+    )
+    np.testing.assert_array_equal(current.data, before_result)
+    assert current.metadata["micro_sam_mask_refinement"] == provenance
+    assert len(viewer.layers["point_prompts"].data) == 1
+
+    viewer.close()

--- a/test/test_sam_annotator/test_mask_input_widget.py
+++ b/test/test_sam_annotator/test_mask_input_widget.py
@@ -429,10 +429,72 @@ def test_3d_seed_uses_largest_cross_section_and_lowest_tie(make_napari_viewer_pr
     mask_inputs = widget._collect_mask_inputs()
 
     assert widget._seed_slice(mask_inputs, 13) == 1
-    assert widget.mask_3d_strategy.currentText() == "Refine all occupied slices"
+    assert widget.mask_3d_strategy.currentText() == "Refine existing slices only"
+    assert "z-extent is preserved" in widget.mask_3d_help.text()
+    assert not widget.batched_checkbox.isEnabled()
+    assert "already processed independently" in widget.batched_checkbox.toolTip()
+    assert "does not change mask refinement" in widget.apply_to_volume_checkbox.toolTip()
 
-    widget.mask_3d_strategy.setCurrentText("Propagate from seed slices")
+    widget.mask_3d_strategy.setCurrentText("Refine and extend through z")
+    assert "largest cross-section" in widget.mask_3d_help.text()
+    assert "not used as anchors" in widget.mask_3d_help.text()
     assert not widget._propagation_settings.isHidden()
+
+    widget._set_all_mask_layers_checked(False)
+    assert widget.batched_checkbox.isEnabled()
+    assert "Choose whether to segment" in widget.apply_to_volume_checkbox.toolTip()
+
+    viewer.close()
+
+
+def test_sam_v1_mask_propagation_respects_z_range(
+    make_napari_viewer_proxy,
+    monkeypatch,
+):
+    viewer = make_napari_viewer_proxy()
+    image = viewer.add_image(np.zeros((5, 12, 12), dtype="uint8"), name="volume")
+    annotator = Annotator(viewer, ndim=3)
+    widget = annotator._widgets["interactive"]
+
+    labels = np.zeros(image.data.shape, dtype="uint32")
+    labels[2, 3:7, 3:7] = 13
+    source = viewer.add_labels(labels, name="cellpose")
+    _set_only_checked(widget, source)
+    mask_inputs = widget._collect_mask_inputs()
+    widget._segment_widget.z_range = (1, 3)
+    monkeypatch.setattr(widget, "_refine_mask_slice", lambda mask, object_id, z: mask)
+
+    state = AnnotatorState()
+    monkeypatch.setattr(state, "is_sam2", False)
+    monkeypatch.setattr(state, "predictor", object())
+    monkeypatch.setattr(
+        state,
+        "image_embeddings",
+        {
+            "features": np.zeros((5, 1, 1, 1, 1), dtype="float32"),
+            "input_size": (12, 12),
+            "original_size": (12, 12),
+        },
+    )
+
+    def _fake_segment_mask_in_volume(
+        segmentation,
+        predictor,
+        image_embeddings,
+        segmented_slices,
+        **kwargs,
+    ):
+        assert segmentation.shape == (3, 12, 12)
+        assert image_embeddings["features"].shape[0] == 3
+        np.testing.assert_array_equal(segmented_slices, np.array([1]))
+        return segmentation, (1, 1)
+
+    monkeypatch.setattr(_widgets, "segment_mask_in_volume", _fake_segment_mask_in_volume)
+    candidates = widget._refine_masks_propagated(mask_inputs)
+
+    assert not candidates[13][0].any()
+    assert candidates[13][2].any()
+    assert not candidates[13][4].any()
 
     viewer.close()
 

--- a/test/test_sam_annotator/test_mask_input_widget.py
+++ b/test/test_sam_annotator/test_mask_input_widget.py
@@ -3,6 +3,7 @@ import platform
 import numpy as np
 import pytest
 
+from qtpy import QtWidgets
 from qtpy.QtCore import Qt
 
 from micro_sam.sam_annotator import _widgets
@@ -34,6 +35,10 @@ def _set_only_checked(widget, layer):
         item.setCheckState(Qt.Checked if is_target else Qt.Unchecked)
 
 
+def _listed_mask_layers(widget):
+    return [layer for layer, _ in widget._mask_layer_items.values()]
+
+
 def test_mask_layer_checklist_tracks_compatible_layers(make_napari_viewer_proxy):
     viewer = make_napari_viewer_proxy()
     image = viewer.add_image(np.zeros((16, 16), dtype="uint8"), name="image")
@@ -54,6 +59,14 @@ def test_mask_layer_checklist_tracks_compatible_layers(make_napari_viewer_proxy)
     annotator = Annotator(viewer)
     widget = annotator._widgets["interactive"]
 
+    listed_names = {layer.name for layer in _listed_mask_layers(widget)}
+    assert listed_names.isdisjoint(
+        {"auto_segmentation", "committed_objects", "current_object"}
+    )
+    internal_current_object = viewer.layers["current_object"]
+    internal_current_object.name = "renamed micro-sam output"
+    viewer.add_labels(np.zeros(image.data.shape, dtype="uint32"), name="trigger refresh")
+    assert internal_current_object not in _listed_mask_layers(widget)
     compatible_item = _item_for_layer(widget, compatible)
     incompatible_shape_item = _item_for_layer(widget, incompatible_shape)
     incompatible_transform_item = _item_for_layer(widget, incompatible_transform)
@@ -75,6 +88,77 @@ def test_mask_layer_checklist_tracks_compatible_layers(make_napari_viewer_proxy)
     assert _item_for_layer(widget, compatible).checkState() == Qt.Checked
     assert _item_for_layer(widget, incompatible_shape).checkState() == Qt.Unchecked
     assert _item_for_layer(widget, incompatible_transform).checkState() == Qt.Unchecked
+
+    viewer.close()
+
+
+def test_mask_layer_checklist_accepts_and_crops_napari_trailing_surplus(
+    make_napari_viewer_proxy,
+):
+    viewer = make_napari_viewer_proxy()
+    image = viewer.add_image(np.zeros((12, 12), dtype="uint8"), name="image")
+    annotator = Annotator(viewer)
+    widget = annotator._widgets["interactive"]
+
+    labels = np.zeros((13, 13), dtype="uint32")
+    labels[2:5, 3:6] = 11
+    labels[12, 12] = 99
+    napari_labels = viewer.add_labels(labels, name="Labels")
+
+    item = _item_for_layer(widget, napari_labels)
+    assert item.flags() & Qt.ItemIsEnabled
+    _set_only_checked(widget, napari_labels)
+
+    mask_inputs = widget._collect_mask_inputs()
+    assert mask_inputs.labels.shape == image.data.shape
+    assert mask_inputs.object_ids == (11,)
+    assert mask_inputs.cropped_source_names == ("Labels",)
+    assert "Cropped one trailing pixel on one or more axes" in widget.mask_input_summary.text()
+    assert "Labels" in widget.mask_input_summary.text()
+
+    widget._commit_selected_masks_unchanged()
+    committed = viewer.layers["committed_objects"].data
+    assert committed.shape == image.data.shape
+    assert set(np.unique(committed)) == {0, 11}
+
+    viewer.close()
+
+
+def test_segment_object_routes_selected_masks_to_refinement(
+    make_napari_viewer_proxy,
+    monkeypatch,
+):
+    viewer = make_napari_viewer_proxy()
+    viewer.add_image(np.zeros((12, 12), dtype="uint8"), name="image")
+    annotator = Annotator(viewer)
+    widget = annotator._widgets["interactive"]
+    calls = []
+
+    monkeypatch.setattr(
+        _widgets,
+        "_segment_object_2d",
+        lambda viewer, batched: calls.append(("prompts", batched)),
+    )
+    widget.segment()
+    assert calls == [("prompts", False)]
+
+    labels = np.zeros((12, 12), dtype="uint32")
+    labels[2:5, 3:6] = 11
+    cellpose = viewer.add_labels(labels, name="cellpose")
+    _set_only_checked(widget, cellpose)
+    monkeypatch.setattr(
+        widget,
+        "_refine_selected_masks",
+        lambda: calls.append(("masks", False)),
+    )
+    widget.segment()
+    assert calls[-1] == ("masks", False)
+
+    button_texts = {
+        button.text() for button in widget.findChildren(QtWidgets.QPushButton)
+    }
+    assert "Segment Object [S]" in button_texts
+    assert "Refine with SAM" not in button_texts
 
     viewer.close()
 

--- a/test/test_sam_annotator/test_mask_input_widget.py
+++ b/test/test_sam_annotator/test_mask_input_widget.py
@@ -163,6 +163,129 @@ def test_segment_object_routes_selected_masks_to_refinement(
     viewer.close()
 
 
+def test_prompt_targets_are_stored_per_point_and_shape(
+    make_napari_viewer_proxy,
+):
+    viewer = make_napari_viewer_proxy()
+    viewer.add_image(np.zeros((20, 20), dtype="uint8"), name="image")
+    annotator = Annotator(viewer)
+    widget = annotator._widgets["interactive"]
+
+    labels = np.zeros((20, 20), dtype="uint32")
+    labels[1:8, 1:8] = 7
+    labels[11:18, 11:18] = 19
+    input_layer = viewer.add_labels(labels, name="cellpose")
+    _set_only_checked(widget, input_layer)
+
+    assert not widget.correction_target_row.isHidden()
+    assert not widget.correction_target_help.isHidden()
+    assert widget.correction_target.currentIndex() == -1
+    assert [
+        widget.correction_target.itemData(index)
+        for index in range(widget.correction_target.count())
+    ] == [7, 19]
+
+    points = viewer.layers["point_prompts"]
+    shapes = viewer.layers["prompts"]
+    assert "object_id" in points.properties
+    assert "object_id" in shapes.properties
+
+    widget.correction_target.setCurrentIndex(widget.correction_target.findData(7))
+    points.add(np.array([[3.0, 3.0]]))
+    points.selected_data = set()
+    widget.correction_target.setCurrentIndex(widget.correction_target.findData(19))
+    points.add(np.array([[14.0, 14.0]]))
+    points.selected_data = set()
+    shapes.add_rectangles(np.array([[12.0, 12.0], [16.0, 16.0]]))
+
+    np.testing.assert_array_equal(points.properties["object_id"], ["7", "19"])
+    np.testing.assert_array_equal(shapes.properties["object_id"], ["19"])
+
+    _, _, prompts_7 = widget._collect_mask_prompts(labels == 7, object_id=7)
+    _, _, prompts_19 = widget._collect_mask_prompts(labels == 19, object_id=19)
+    np.testing.assert_array_equal(prompts_7.points, [[3.0, 3.0]])
+    np.testing.assert_array_equal(prompts_19.points, [[14.0, 14.0]])
+    assert len(prompts_7.boxes) == 0
+    assert len(prompts_19.boxes) == 1
+
+    points.selected_data = {0}
+    assert widget.correction_target.currentData() == 7
+    assert shapes.current_properties["object_id"][0] == "7"
+
+    points.selected_data = {0, 1}
+    assert widget.correction_target.currentIndex() == -1
+    assert widget.correction_target.placeholderText() == "Multiple target IDs"
+    points.selected_data = set()
+    assert widget.correction_target.currentData() == 7
+    assert points.current_properties["object_id"][0] == "7"
+    assert shapes.current_properties["object_id"][0] == "7"
+
+    points.selected_data = {0}
+    widget.correction_target.setCurrentIndex(widget.correction_target.findData(19))
+    np.testing.assert_array_equal(points.properties["object_id"], ["19", "19"])
+
+    widget._validate_prompt_target_ids(widget._collect_mask_inputs())
+
+    button_texts = {
+        button.text() for button in widget.findChildren(QtWidgets.QPushButton)
+    }
+    assert "Commit selected masks unchanged" in button_texts
+    assert "Commit input masks unchanged" not in button_texts
+    assert widget._prompt_widget[0].label == "Prompt type"
+
+    viewer.close()
+
+
+def test_single_mask_id_assignment_preserves_selected_prompt_types(
+    make_napari_viewer_proxy,
+):
+    viewer = make_napari_viewer_proxy()
+    viewer.add_image(np.zeros((12, 12), dtype="uint8"), name="image")
+    annotator = Annotator(viewer)
+    widget = annotator._widgets["interactive"]
+    points = viewer.layers["point_prompts"]
+    points.add(np.array([[2.0, 2.0], [8.0, 8.0]]))
+    properties = dict(points.properties)
+    properties["label"] = np.array(["positive", "negative"])
+    points.properties = properties
+    points.selected_data = {0, 1}
+
+    labels = np.zeros((12, 12), dtype="uint32")
+    labels[1:5, 1:5] = 7
+    input_layer = viewer.add_labels(labels, name="cellpose")
+    _set_only_checked(widget, input_layer)
+
+    np.testing.assert_array_equal(points.properties["label"], ["positive", "negative"])
+    np.testing.assert_array_equal(points.properties["object_id"], ["7", "7"])
+    assert points.selected_data == {0, 1}
+
+    viewer.close()
+
+
+def test_multiple_mask_ids_require_every_correction_to_have_a_target(
+    make_napari_viewer_proxy,
+):
+    viewer = make_napari_viewer_proxy()
+    viewer.add_image(np.zeros((12, 12), dtype="uint8"), name="image")
+    annotator = Annotator(viewer)
+    widget = annotator._widgets["interactive"]
+
+    labels = np.zeros((12, 12), dtype="uint32")
+    labels[1:4, 1:4] = 7
+    labels[7:10, 7:10] = 19
+    input_layer = viewer.add_labels(labels, name="cellpose")
+    _set_only_checked(widget, input_layer)
+    viewer.layers["point_prompts"].add(np.array([[2.0, 2.0]]))
+
+    with pytest.raises(ValueError, match="Invalid or unassigned targets"):
+        widget._validate_prompt_target_ids(widget._collect_mask_inputs())
+
+    widget.correction_target.setCurrentIndex(widget.correction_target.findData(7))
+    widget._validate_prompt_target_ids(widget._collect_mask_inputs())
+
+    viewer.close()
+
+
 def test_direct_commit_preserves_ids_unions_same_id_and_is_atomic(
     make_napari_viewer_proxy,
     monkeypatch,

--- a/test/test_sam_annotator/test_mask_inputs.py
+++ b/test/test_sam_annotator/test_mask_inputs.py
@@ -50,6 +50,7 @@ def test_collect_2d_inputs_unions_equal_ids_and_preserves_sparse_ids():
     assert inputs.labels.dtype == np.uint32
     assert inputs.object_ids == (3, 91)
     assert inputs.source_names == ("first", "second")
+    assert inputs.cropped_source_names == ()
     assert [layer.name for layer in inputs.source_layers] == ["first", "second"]
     assert inputs.occupied_slices == {}
     assert np.array_equal(inputs.labels == 3, (first == 3) | (second == 3))
@@ -133,6 +134,44 @@ def test_collect_rejects_shape_and_transform_mismatches():
     shifted = Layer(np.ones((3, 4), dtype="uint8"), "shifted", scale=(2, 3), translate=(4, 6))
     with pytest.raises(ValueError, match="data-to-world transforms differ"):
         collect_mask_inputs([shifted], image)
+
+
+@pytest.mark.parametrize(
+    ("image_shape", "labels_shape"),
+    [
+        ((3, 4), (4, 5)),
+        ((2, 3, 4), (3, 4, 5)),
+        ((2, 3, 4), (2, 4, 5)),
+    ],
+)
+def test_collect_crops_one_trailing_pixel_per_oversized_axis(image_shape, labels_shape):
+    image = Layer(np.zeros(image_shape), "image")
+    labels = np.zeros(labels_shape, dtype="uint16")
+    inside = tuple(slice(0, size) for size in image_shape)
+    labels[inside] = 17
+
+    # Foreground in the one-pixel trailing border is outside the selected image and must not
+    # become part of the prompt.
+    trailing_border_coordinate = tuple(
+        image_size if label_size == image_size + 1 else 0
+        for image_size, label_size in zip(image_shape, labels_shape)
+    )
+    labels[trailing_border_coordinate] = 91
+    inputs = collect_mask_inputs([Layer(labels, "napari labels")], image)
+
+    assert inputs.labels.shape == image_shape
+    assert inputs.object_ids == (17,)
+    assert inputs.cropped_source_names == ("napari labels",)
+    assert np.all(inputs.labels == 17)
+
+
+@pytest.mark.parametrize("labels_shape", [(2, 4), (3, 6), (5, 4)])
+def test_collect_rejects_smaller_or_more_than_one_pixel_larger_shapes(labels_shape):
+    image = Layer(np.zeros((3, 4)), "image")
+    labels = Layer(np.ones(labels_shape, dtype="uint8"), "wrong shape")
+
+    with pytest.raises(ValueError, match="has shape"):
+        collect_mask_inputs([labels], image)
 
 
 def test_collect_compares_full_affine_transform_and_rgb_spatial_shape():

--- a/test/test_sam_annotator/test_mask_inputs.py
+++ b/test/test_sam_annotator/test_mask_inputs.py
@@ -1,0 +1,282 @@
+from collections import OrderedDict
+
+import numpy as np
+import pytest
+
+from micro_sam.sam_annotator.util import (
+    collect_mask_inputs,
+    iter_mask_input_masks,
+    merge_labels_for_direct_commit,
+    merge_labels_for_refined_commit,
+    merge_refined_mask_candidates,
+)
+
+
+class Layer:
+    """Small layer-like object for testing the pure mask-input helpers."""
+
+    def __init__(self, data, name, scale=None, translate=None, rgb=False):
+        self.data = np.asarray(data)
+        self.name = name
+        self.rgb = rgb
+        ndim = self.data.ndim - int(rgb)
+        self.scale = np.ones(ndim) if scale is None else np.asarray(scale)
+        self.translate = np.zeros(ndim) if translate is None else np.asarray(translate)
+
+    def data_to_world(self, coordinate):
+        return np.asarray(coordinate) * self.scale + self.translate
+
+
+class AffineLayer(Layer):
+    def __init__(self, data, name, affine, rgb=False):
+        super().__init__(data, name, rgb=rgb)
+        self.affine = np.asarray(affine)
+
+    def data_to_world(self, coordinate):
+        homogeneous = np.concatenate([np.asarray(coordinate), [1.0]])
+        return (self.affine @ homogeneous)[:-1]
+
+
+def test_collect_2d_inputs_unions_equal_ids_and_preserves_sparse_ids():
+    image = Layer(np.zeros((5, 6)), "image")
+    first = np.zeros((5, 6), dtype="uint16")
+    second = np.zeros((5, 6), dtype="uint64")
+    first[1:3, 1:3] = 3
+    second[2:4, 2:4] = 3
+    second[0, 5] = 91
+
+    inputs = collect_mask_inputs([Layer(first, "first"), Layer(second, "second")], image)
+
+    assert inputs.labels.dtype == np.uint32
+    assert inputs.object_ids == (3, 91)
+    assert inputs.source_names == ("first", "second")
+    assert [layer.name for layer in inputs.source_layers] == ["first", "second"]
+    assert inputs.occupied_slices == {}
+    assert np.array_equal(inputs.labels == 3, (first == 3) | (second == 3))
+
+    masks = list(iter_mask_input_masks(inputs))
+    assert [(object_id, z, int(mask.sum())) for object_id, z, mask in masks] == [
+        (3, None, 7),
+        (91, None, 1),
+    ]
+
+
+def test_collect_boolean_input_maps_foreground_to_id_one():
+    image = Layer(np.zeros((3, 4)), "image")
+    mask = np.zeros((3, 4), dtype=bool)
+    mask[1, 2] = True
+
+    inputs = collect_mask_inputs([Layer(mask, "boolean")], image)
+
+    assert inputs.object_ids == (1,)
+    assert inputs.labels.dtype == np.uint32
+    assert inputs.labels[1, 2] == 1
+
+
+def test_collect_3d_inputs_and_occupied_slices():
+    image = Layer(np.zeros((4, 5, 6)), "volume", scale=(2, 1, 1), translate=(4, 0, 0))
+    labels = np.zeros((4, 5, 6), dtype="uint8")
+    labels[0, 1, 1] = 7
+    labels[2, 1:3, 1:3] = 7
+    labels[1, 4, 5] = 42
+    layer = Layer(labels, "cells", scale=(2, 1, 1), translate=(4, 0, 0))
+
+    inputs = collect_mask_inputs([layer], image)
+
+    assert inputs.object_ids == (7, 42)
+    assert inputs.occupied_slices == {7: (0, 2), 42: (1,)}
+    yielded = list(iter_mask_input_masks(inputs))
+    assert [(object_id, z, int(mask.sum())) for object_id, z, mask in yielded] == [
+        (7, 0, 1),
+        (7, 2, 4),
+        (42, 1, 1),
+    ]
+
+
+def test_empty_layers_allowed_but_global_foreground_required():
+    image = Layer(np.zeros((3, 3)), "image")
+    empty = Layer(np.zeros((3, 3), dtype="uint8"), "empty")
+    foreground = np.zeros((3, 3), dtype="uint8")
+    foreground[1, 1] = 8
+
+    inputs = collect_mask_inputs([empty, Layer(foreground, "foreground")], image)
+    assert inputs.object_ids == (8,)
+
+    with pytest.raises(ValueError, match="do not contain any nonzero"):
+        collect_mask_inputs([empty], image)
+
+
+def test_collect_requires_at_least_one_layer():
+    with pytest.raises(ValueError, match="at least one"):
+        collect_mask_inputs([], Layer(np.zeros((3, 3)), "image"))
+
+
+@pytest.mark.parametrize(
+    ("data", "message"),
+    [
+        (np.zeros((2, 3), dtype="float32"), "boolean or integer"),
+        (np.full((2, 3), -1, dtype="int16"), "negative label ID"),
+        (np.full((2, 3), 2**32, dtype="uint64"), "exceeds the uint32 limit"),
+    ],
+)
+def test_collect_rejects_invalid_label_dtype_or_range(data, message):
+    with pytest.raises(ValueError, match=message):
+        collect_mask_inputs([Layer(data, "bad")], Layer(np.zeros((2, 3)), "image"))
+
+
+def test_collect_rejects_shape_and_transform_mismatches():
+    image = Layer(np.zeros((3, 4)), "image", scale=(2, 3), translate=(4, 5))
+
+    with pytest.raises(ValueError, match="has shape.*not resampled"):
+        collect_mask_inputs([Layer(np.ones((4, 3), dtype="uint8"), "wrong shape")], image)
+
+    shifted = Layer(np.ones((3, 4), dtype="uint8"), "shifted", scale=(2, 3), translate=(4, 6))
+    with pytest.raises(ValueError, match="data-to-world transforms differ"):
+        collect_mask_inputs([shifted], image)
+
+
+def test_collect_compares_full_affine_transform_and_rgb_spatial_shape():
+    affine = np.array([[2.0, 0.3, 4.0], [0.2, 3.0, 5.0], [0.0, 0.0, 1.0]])
+    image = AffineLayer(np.zeros((3, 4, 3)), "rgb", affine, rgb=True)
+    labels = AffineLayer(np.ones((3, 4), dtype="uint8"), "labels", affine)
+    assert collect_mask_inputs([labels], image).labels.shape == (3, 4)
+
+    different = affine.copy()
+    different[0, 1] += 0.1
+    with pytest.raises(ValueError, match="data-to-world transforms differ"):
+        collect_mask_inputs(
+            [AffineLayer(np.ones((3, 4), dtype="uint8"), "sheared", different)],
+            image,
+        )
+
+
+def test_collect_conflict_error_has_layers_ids_count_and_coordinate():
+    image = Layer(np.zeros((4, 4)), "image")
+    first = np.zeros((4, 4), dtype="uint8")
+    second = np.zeros((4, 4), dtype="uint8")
+    first[1:3, 1:3] = 7
+    second[2:4, 2:4] = 19
+
+    with pytest.raises(ValueError) as error:
+        collect_mask_inputs([Layer(first, "cellpose"), Layer(second, "manual")], image)
+
+    message = str(error.value)
+    assert "'cellpose' (ID 7)" in message
+    assert "'manual' (ID 19)" in message
+    assert "1 pixels" in message
+    assert "(2, 2)" in message
+
+
+def test_deterministic_candidate_merge_prefers_owner_then_smallest_id():
+    original = np.zeros((3, 4), dtype="uint32")
+    original[1, 1] = 9
+    original[1, 2] = 4
+    candidate_4 = np.zeros_like(original, dtype=bool)
+    candidate_9 = np.zeros_like(original, dtype=bool)
+    candidate_4[1, 0:4] = True
+    candidate_9[1, 0:4] = True
+
+    forward = merge_refined_mask_candidates(
+        original, OrderedDict([(4, candidate_4), (9, candidate_9)])
+    )
+    reverse = merge_refined_mask_candidates(
+        original, OrderedDict([(9, candidate_9), (4, candidate_4)])
+    )
+
+    assert np.array_equal(forward, reverse)
+    # No source owner at the outer pixels: smallest candidate ID wins.
+    assert np.array_equal(forward[1], [4, 9, 4, 4])
+    assert set(np.unique(forward)) == {0, 4, 9}
+
+
+def test_candidate_merge_rejects_invalid_id_and_shape():
+    original = np.zeros((2, 3), dtype="uint8")
+    with pytest.raises(ValueError, match="valid uint32 foreground"):
+        merge_refined_mask_candidates(original, {0: np.ones_like(original)})
+    with pytest.raises(ValueError, match="has shape"):
+        merge_refined_mask_candidates(original, {1: np.ones((3, 2), dtype=bool)})
+
+
+def test_direct_commit_merges_background_and_matching_ids_without_mutation():
+    destination = np.zeros((4, 5), dtype="uint32")
+    destination[1:3, 1:3] = 7
+    incoming = np.zeros_like(destination)
+    incoming[2:4, 2:4] = 7
+    incoming[0, 4] = 31
+    destination_before = destination.copy()
+    incoming_before = incoming.copy()
+
+    result = merge_labels_for_direct_commit(destination, incoming)
+
+    assert np.array_equal(destination, destination_before)
+    assert np.array_equal(incoming, incoming_before)
+    assert np.array_equal(result == 7, (destination == 7) | (incoming == 7))
+    assert result[0, 4] == 31
+    assert result.dtype == np.uint32
+
+
+def test_direct_commit_conflict_is_atomic_and_actionable():
+    destination = np.zeros((3, 3), dtype="uint16")
+    incoming = np.zeros((3, 3), dtype="uint16")
+    destination[1, 1] = 7
+    incoming[1, 1] = 11
+    destination_before = destination.copy()
+    incoming_before = incoming.copy()
+
+    with pytest.raises(ValueError, match=r"Incoming ID 11.*committed ID 7.*\(1, 1\)"):
+        merge_labels_for_direct_commit(destination, incoming)
+
+    assert np.array_equal(destination, destination_before)
+    assert np.array_equal(incoming, incoming_before)
+
+
+def test_refined_commit_replaces_objects_inward_and_outward():
+    destination = np.zeros((6, 7), dtype="uint32")
+    destination[1:4, 1:4] = 7
+    destination[0, 6] = 99
+    refined = np.zeros_like(destination)
+    # Shrink ID 7 on one edge and expand it on another.
+    refined[2:5, 2:5] = 7
+
+    result = merge_labels_for_refined_commit(destination, refined, [7])
+
+    assert result[1, 1] == 0
+    assert result[4, 4] == 7
+    assert result[0, 6] == 99
+    assert np.array_equal(destination[1:4, 1:4], np.full((3, 3), 7))
+
+
+def test_refined_commit_supports_sparse_ids_and_rejects_id_mismatch():
+    destination = np.zeros((3, 4), dtype="uint32")
+    refined = np.zeros_like(destination)
+    refined[0, 0] = 4
+    refined[2, 3] = 81
+
+    result = merge_labels_for_refined_commit(destination, refined, [81, 4])
+    assert set(np.unique(result)) == {0, 4, 81}
+
+    refined_missing = refined.copy()
+    refined_missing[2, 3] = 0
+    with pytest.raises(ValueError, match=r"Missing IDs: \[81\]"):
+        merge_labels_for_refined_commit(destination, refined_missing, [4, 81])
+
+    refined_extra = refined.copy()
+    refined_extra[1, 1] = 12
+    with pytest.raises(ValueError, match=r"unexpected IDs: \[12\]"):
+        merge_labels_for_refined_commit(destination, refined_extra, [4, 81])
+
+
+def test_refined_commit_conflict_is_atomic():
+    destination = np.zeros((4, 4), dtype="uint32")
+    destination[0:2, 0:2] = 7
+    destination[2, 2] = 19
+    refined = np.zeros_like(destination)
+    refined[1:3, 1:3] = 7
+    destination_before = destination.copy()
+    refined_before = refined.copy()
+
+    with pytest.raises(ValueError, match=r"Refined ID 7.*committed ID 19.*\(2, 2\)"):
+        merge_labels_for_refined_commit(destination, refined, [7])
+
+    assert np.array_equal(destination, destination_before)
+    assert np.array_equal(refined, refined_before)

--- a/test/test_sam_annotator/test_scribble_prompts.py
+++ b/test/test_sam_annotator/test_scribble_prompts.py
@@ -230,6 +230,96 @@ def test_shared_layer_routes_closed_and_open_shapes_separately():
     np.testing.assert_array_equal(labels, np.zeros(len(points), dtype="int64"))
 
 
+def test_collect_frame_prompts_filters_every_prompt_type_by_object_id():
+    points = Points(
+        data=np.array([[2.0, 3.0], [12.0, 13.0]]),
+        properties={
+            "label": np.array(["positive", "negative"]),
+            "object_id": np.array(["7", "19"]),
+        },
+    )
+    shapes = Shapes(
+        data=[
+            np.array([[1.0, 1.0], [1.0, 8.0], [8.0, 8.0], [8.0, 1.0]]),
+            np.array([[10.0, 10.0], [14.0, 14.0]]),
+        ],
+        shape_type=["rectangle", "path"],
+        properties={
+            "label": np.array(["positive", "positive"]),
+            "object_id": np.array(["7", "19"]),
+        },
+    )
+
+    prompts_7 = annotator_util.collect_frame_prompts(
+        points, shapes, (20, 20), object_id=7, with_stop_annotation=False,
+    )
+    prompts_19 = annotator_util.collect_frame_prompts(
+        points, shapes, (20, 20), object_id=19, with_stop_annotation=False,
+    )
+
+    np.testing.assert_array_equal(prompts_7.points, [[2.0, 3.0]])
+    np.testing.assert_array_equal(prompts_7.labels, [1])
+    assert len(prompts_7.boxes) == 1 and not prompts_7.have_scribbles
+
+    assert len(prompts_19.points) > 1
+    assert np.count_nonzero(prompts_19.labels == 0) == 1
+    assert np.count_nonzero(prompts_19.labels == 1) >= 1
+    assert not prompts_19.boxes and prompts_19.have_scribbles
+
+
+def test_collect_frame_prompts_routes_3d_corrections_by_slice_and_object_id():
+    points = Points(
+        data=np.array([[1.0, 2.0, 3.0], [2.0, 12.0, 13.0]]),
+        properties={
+            "label": np.array(["positive", "negative"]),
+            "object_id": np.array(["7", "19"]),
+        },
+    )
+    shapes = Shapes(
+        data=[
+            np.array([
+                [1.0, 1.0, 1.0], [1.0, 1.0, 8.0],
+                [1.0, 8.0, 8.0], [1.0, 8.0, 1.0],
+            ]),
+            np.array([[2.0, 10.0, 10.0], [2.0, 14.0, 14.0]]),
+        ],
+        shape_type=["rectangle", "path"],
+        properties={
+            "label": np.array(["positive", "positive"]),
+            "object_id": np.array(["7", "19"]),
+        },
+    )
+
+    prompts_7 = annotator_util.collect_frame_prompts(
+        points, shapes, (20, 20), i=1, object_id=7, with_stop_annotation=False,
+    )
+    prompts_19 = annotator_util.collect_frame_prompts(
+        points, shapes, (20, 20), i=2, object_id=19, with_stop_annotation=False,
+    )
+
+    np.testing.assert_array_equal(prompts_7.points, [[2.0, 3.0]])
+    assert len(prompts_7.boxes) == 1 and not prompts_7.have_scribbles
+    assert len(prompts_19.points) > 1
+    assert np.count_nonzero(prompts_19.labels == 0) == 1
+    assert not prompts_19.boxes and prompts_19.have_scribbles
+
+
+def test_prompt_object_id_helpers_preserve_labels_and_edit_selected_prompts():
+    points = Points(
+        data=np.array([[2.0, 3.0], [4.0, 5.0]]),
+        properties={"label": np.array(["positive", "negative"])},
+    )
+    points.selected_data = {1}
+    before_labels = points.properties["label"].copy()
+
+    annotator_util.ensure_prompt_object_ids(points)
+    annotator_util.set_prompt_object_id(points, 23)
+
+    np.testing.assert_array_equal(points.properties["label"], before_labels)
+    np.testing.assert_array_equal(points.properties["object_id"], ["0", "23"])
+    assert points.current_properties["object_id"][0] == "23"
+
+
 def test_existing_point_and_box_prompt_conversion_in_2d_and_3d():
     point_layer_2d = Points(
         data=np.array([[2.0, 3.0], [4.0, 5.0]]),
@@ -351,6 +441,26 @@ def test_selected_scribble_is_relabelled_while_polyline_tool_is_active():
     np.testing.assert_allclose(layer.edge_color[0], [1, 0, 0, 1])
     _, labels = annotator_util.scribble_layer_to_prompts(layer, image_shape=(16, 16))
     np.testing.assert_array_equal(labels, np.zeros(len(labels), dtype="int64"))
+
+
+def test_prompt_type_keeps_selected_closed_shapes_positive():
+    layer = Shapes(
+        data=[
+            np.array([[1.0, 1.0], [1.0, 8.0], [8.0, 8.0], [8.0, 1.0]]),
+            np.array([[2.0, 2.0], [12.0, 12.0]]),
+        ],
+        shape_type=["rectangle", "path"],
+        properties={"label": np.array(["positive", "positive"])},
+        edge_color="label",
+        edge_color_cycle=annotator_util.LABEL_COLOR_CYCLE,
+    )
+    layer.edge_color_mode = "cycle"
+    layer.selected_data = {0, 1}
+
+    annotator_util.set_prompt_label(layer, "negative")
+
+    np.testing.assert_array_equal(layer.properties["label"], ["positive", "negative"])
+    assert layer.current_properties["label"][0] == "negative"
 
 
 def scribble_layer_with_one_positive_path():
@@ -479,6 +589,7 @@ def test_slice_segmentation_merges_3d_scribbles_with_points(monkeypatch):
     class _CurrentObject:
         def __init__(self):
             self.data = np.zeros((3, 32, 32), dtype="uint32")
+            self.metadata = {}
             self.refresh_count = 0
 
         def refresh(self):
@@ -593,6 +704,7 @@ def test_sam2_volume_propagation_merges_3d_scribbles_points_and_boxes(monkeypatc
     class _CurrentObject:
         def __init__(self):
             self.data = np.zeros((3, 32, 32), dtype="uint32")
+            self.metadata = {}
             self.refresh_count = 0
 
         def refresh(self):
@@ -763,6 +875,7 @@ def test_2d_segmentation_merges_scribbles_with_clicks(monkeypatch):
     class _Layer:
         def __init__(self, data):
             self.data = data
+            self.metadata = {}
             self.refresh_count = 0
 
         def refresh(self):
@@ -828,6 +941,7 @@ def test_point_and_box_only_segmentation_is_unchanged(monkeypatch, is_sam2):
     class _Layer:
         def __init__(self, data):
             self.data = data
+            self.metadata = {}
             self.refresh_count = 0
 
         def refresh(self):

--- a/test/test_tiled_mask_prompt.py
+++ b/test/test_tiled_mask_prompt.py
@@ -1,0 +1,140 @@
+import numpy as np
+
+from micro_sam.v1 import prompt_based_segmentation
+
+
+class _Features:
+    def __init__(self, shape, tile_shape, halo):
+        self.attrs = {"shape": shape, "tile_shape": tile_shape, "halo": halo}
+
+
+def _inner_origin(job):
+    return tuple(job["block"].inner_block.begin)
+
+
+def test_prepare_tiled_mask_prompt_jobs():
+    shape, tile_shape, halo = (8, 12), (4, 4), (1, 1)
+    mask = np.zeros(shape, dtype=bool)
+    mask[1:7, 3:6] = True
+    box = np.array([1, 3, 7, 6])
+    points = np.array([
+        [2, 7],   # A negative correction in the halo of a mask tile.
+        [1, 10],  # A negative correction that must not activate its tile.
+        [6, 10],  # A positive correction that expands into a new tile.
+    ])
+    labels = np.array([0, 0, 1])
+
+    _, jobs = prompt_based_segmentation._prepare_tiled_mask_prompt_jobs(
+        mask, shape, tile_shape, halo, box=box, points=points, labels=labels
+    )
+
+    assert {_inner_origin(job) for job in jobs.values()} == {
+        (0, 0), (0, 4), (4, 0), (4, 4), (4, 8)
+    }
+
+    seen_points = []
+    for job in jobs.values():
+        outer = job["block"].outer_block
+        outer_begin = np.asarray(outer.begin)
+        outer_end = np.asarray(outer.end)
+
+        expected_mask = mask[tuple(slice(beg, end) for beg, end in zip(outer_begin, outer_end))]
+        np.testing.assert_array_equal(job["mask"], expected_mask)
+
+        if job["box"] is not None:
+            global_box = job["box"] + np.tile(outer_begin, 2)
+            expected_box = np.array([
+                max(box[0], outer_begin[0]), max(box[1], outer_begin[1]),
+                min(box[2], outer_end[0]), min(box[3], outer_end[1]),
+            ])
+            np.testing.assert_array_equal(global_box, expected_box)
+
+        if job["points"] is not None:
+            global_points = job["points"] + outer_begin
+            seen_points.extend(map(tuple, global_points.tolist()))
+
+    assert (6, 10) in seen_points
+    assert (2, 7) in seen_points
+    assert (1, 10) not in seen_points
+
+    expansion_job = next(job for job in jobs.values() if _inner_origin(job) == (4, 8))
+    assert not expansion_job["mask"].any()
+    assert expansion_job["box"] is None
+    np.testing.assert_array_equal(expansion_job["points"], [[3, 3]])
+    np.testing.assert_array_equal(expansion_job["labels"], [1])
+
+
+def test_segment_from_mask_tiled_routes_and_stitches(monkeypatch):
+    shape, tile_shape, halo = (8, 12), (4, 4), (1, 1)
+    mask = np.zeros(shape, dtype=bool)
+    mask[1:7, 3:6] = True
+    box = np.array([1, 3, 7, 6])
+    points = np.array([[2, 7], [6, 10]])
+    labels = np.array([0, 1])
+    embeddings = {
+        "features": _Features(shape, tile_shape, halo),
+        "input_size": None,
+        "original_size": None,
+    }
+
+    predictor = object()
+    calls = []
+    current_tile = {}
+
+    def fake_set_precomputed(this_predictor, image_embeddings, i=None, tile_id=None):
+        assert this_predictor is predictor
+        assert image_embeddings is embeddings
+        assert i == 3
+        current_tile["id"] = tile_id
+
+    def fake_segment_from_mask(this_predictor, local_mask, **kwargs):
+        assert this_predictor is predictor
+        calls.append((current_tile["id"], local_mask.copy(), kwargs))
+        return np.ones((1,) + local_mask.shape, dtype=bool)
+
+    monkeypatch.setattr(prompt_based_segmentation, "set_precomputed", fake_set_precomputed)
+    monkeypatch.setattr(prompt_based_segmentation, "segment_from_mask", fake_segment_from_mask)
+
+    result = prompt_based_segmentation.segment_from_mask_tiled(
+        predictor, mask, embeddings, i=3, box=box, points=points, labels=labels
+    )
+
+    _, jobs = prompt_based_segmentation._prepare_tiled_mask_prompt_jobs(
+        mask, shape, tile_shape, halo, box=box, points=points, labels=labels
+    )
+    assert [tile_id for tile_id, _, _ in calls] == list(jobs)
+
+    expected = np.zeros((1,) + shape, dtype=bool)
+    for job in jobs.values():
+        inner = job["block"].inner_block
+        glob = tuple(slice(beg, end) for beg, end in zip(inner.begin, inner.end))
+        expected[(slice(None),) + glob] = True
+    np.testing.assert_array_equal(result, expected)
+
+    for tile_id, local_mask, kwargs in calls:
+        job = jobs[tile_id]
+        np.testing.assert_array_equal(local_mask, job["mask"])
+        np.testing.assert_array_equal(kwargs["box"], job["box"])
+        expected_points = None if job["points"] is None else job["points"][:, ::-1]
+        np.testing.assert_array_equal(kwargs["points"], expected_points)
+        np.testing.assert_array_equal(kwargs["labels"], job["labels"])
+        assert kwargs["use_mask"]
+        assert not kwargs["use_box"]
+
+
+def test_tiled_mask_inner_stitching_is_order_independent():
+    shape, tile_shape, halo = (8, 8), (4, 4), (1, 1)
+    mask = np.ones(shape, dtype=bool)
+    _, jobs = prompt_based_segmentation._prepare_tiled_mask_prompt_jobs(
+        mask, shape, tile_shape, halo
+    )
+
+    predictions = []
+    for index, job in enumerate(jobs.values()):
+        prediction = np.zeros((1,) + job["mask"].shape, dtype=bool)
+        prediction[:, index % 2::2, (index // 2) % 2::2] = True
+        predictions.append((job["block"], prediction))
+
+    forward = prompt_based_segmentation._stitch_tiled_mask_predictions(predictions, shape)
+    reverse = prompt_based_segmentation._stitch_tiled_mask_predictions(list(reversed(predictions)), shape)
+    np.testing.assert_array_equal(forward, reverse)

--- a/test/test_v2_prompt_based_segmentation.py
+++ b/test/test_v2_prompt_based_segmentation.py
@@ -13,11 +13,17 @@ from micro_sam.v2.prompt_based_segmentation import (
 
 
 class FakeTileSegmenter:
+    def __init__(self):
+        self.pre_refined_calls = []
+
     def add_point_prompts(self, **kwargs):
         pass
 
     def add_box_prompts(self, **kwargs):
         pass
+
+    def add_pre_refined_masks(self, **kwargs):
+        self.pre_refined_calls.append(kwargs)
 
 
 def test_promptable_segmentation_2d_normalizes_raw(monkeypatch):
@@ -232,6 +238,8 @@ class RecordingPredictor:
 
     def __init__(self):
         self.calls = []
+        self.mask_calls = []
+        self.image_size = 32
 
     def add_new_points_or_box(self, inference_state, frame_idx, obj_id, clear_old_points=False,
                               points=None, labels=None, box=None):
@@ -246,6 +254,12 @@ class RecordingPredictor:
     def reset_state(self, inference_state):
         pass
 
+    def add_new_mask(self, inference_state, frame_idx, obj_id, mask):
+        self.mask_calls.append({
+            "frame_idx": frame_idx, "obj_id": obj_id, "mask": np.asarray(mask).copy(),
+        })
+        return None, [obj_id], torch.zeros((1, 1, 32, 32))
+
 
 def make_recording_segmenter():
     segmenter = PromptableSegmentation3D.__new__(PromptableSegmentation3D)
@@ -255,6 +269,7 @@ def make_recording_segmenter():
     segmenter._pushed_points = {}
     segmenter._pushed_boxes = {}
     segmenter._pushed_masks = {}
+    segmenter._pushed_pre_refined_masks = {}
     segmenter._prompt_signatures = set()
     return segmenter
 
@@ -377,6 +392,95 @@ def test_sync_prompt_state_replays_after_a_point_is_relabelled():
 
     assert len(segmenter.predictor.calls) == 2
     assert segmenter.predictor.calls[-1]["labels"] == [0]
+
+
+def test_add_pre_refined_mask_conditions_without_decoding():
+    segmenter = make_recording_segmenter()
+    segmenter._image_style_predict = lambda *args, **kwargs: pytest.fail("The mask was decoded again.")
+    mask = np.zeros((32, 32), dtype=bool)
+    mask[5:12, 7:14] = True
+
+    segmenter.add_pre_refined_masks(frame_ids=3, masks=[mask], object_id=17)
+    segmenter.add_pre_refined_masks(frame_ids=3, masks=[mask], object_id=17)
+
+    assert len(segmenter.predictor.mask_calls) == 1
+    call = segmenter.predictor.mask_calls[0]
+    assert call["frame_idx"] == 3
+    assert call["obj_id"] == 17
+    np.testing.assert_array_equal(call["mask"], mask)
+
+
+def test_add_mask_prompts_still_decodes_before_conditioning():
+    segmenter = make_recording_segmenter()
+    raw_mask = np.zeros((32, 32), dtype=bool)
+    raw_mask[2:8, 3:9] = True
+    refined_mask = np.zeros_like(raw_mask)
+    refined_mask[10:20, 11:21] = True
+    decodes = []
+
+    def image_style_predict(frame_id, **kwargs):
+        decodes.append((frame_id, kwargs))
+        return refined_mask
+
+    segmenter._image_style_predict = image_style_predict
+    segmenter.add_mask_prompts(frame_ids=4, masks=[raw_mask], object_id=23)
+
+    assert len(decodes) == 1
+    assert decodes[0][0] == 4
+    np.testing.assert_array_equal(decodes[0][1]["mask"], raw_mask)
+    assert len(segmenter.predictor.mask_calls) == 1
+    assert segmenter.predictor.mask_calls[0]["obj_id"] == 23
+    np.testing.assert_array_equal(segmenter.predictor.mask_calls[0]["mask"], refined_mask)
+
+
+@pytest.mark.parametrize(
+    "frame_id, object_id, mask, error",
+    [
+        (8, 1, np.ones((32, 32), dtype=bool), "outside the valid range"),
+        (1, 0, np.ones((32, 32), dtype=bool), "must be positive"),
+        (1, 1, np.ones((16, 32), dtype=bool), "must have shape"),
+        (1, 1, np.zeros((32, 32), dtype=bool), "foreground pixel"),
+        (1, 1, np.full((32, 32), 2, dtype=np.uint8), "must be binary"),
+    ],
+)
+def test_add_pre_refined_masks_validates_before_conditioning(frame_id, object_id, mask, error):
+    segmenter = make_recording_segmenter()
+
+    with pytest.raises(ValueError, match=error):
+        segmenter.add_pre_refined_masks(frame_ids=frame_id, masks=[mask], object_id=object_id)
+
+    assert segmenter.predictor.mask_calls == []
+
+
+def test_tiled_add_pre_refined_masks_routes_exact_active_tiles_and_crops():
+    segmenter = make_tiled_segmenter()
+    mask = np.zeros((16, 16), dtype=bool)
+    mask[1:3, 2:5] = True
+    mask[11:14, 12:15] = True
+
+    segmenter.add_pre_refined_masks(frame_ids=6, masks=[mask], object_id=31)
+
+    assert set(segmenter._segmenters) == {0, 3}
+    for tile_id, expected in ((0, mask[:8, :8]), (3, mask[8:, 8:])):
+        calls = segmenter._segmenters[tile_id].pre_refined_calls
+        assert len(calls) == 1
+        assert calls[0]["frame_ids"] == 6
+        assert calls[0]["object_id"] == 31
+        np.testing.assert_array_equal(calls[0]["masks"][0], expected)
+
+
+def test_tiled_add_pre_refined_masks_validates_all_inputs_before_creating_tiles():
+    segmenter = make_tiled_segmenter()
+    valid = np.zeros((16, 16), dtype=bool)
+    valid[1:3, 1:3] = True
+    invalid = np.zeros((16, 16), dtype=bool)
+
+    with pytest.raises(ValueError, match="foreground pixel"):
+        segmenter.add_pre_refined_masks(
+            frame_ids=[1, 2], masks=[valid, invalid], object_id=[7, 8],
+        )
+
+    assert segmenter._segmenters == {}
 
 
 def test_segment_slice_clears_the_pushed_prompt_bookkeeping():


### PR DESCRIPTION
## Summary

- Add compatible napari Labels layers as mask inputs for interactive segmentation.
- Treat every nonzero label ID as an independent SAM mask prompt and preserve IDs in the merged result.
- Assign point, scribble and shape corrections per input object, so different objects can receive different corrections in one Segment Object operation.
- Let users commit satisfactory input masks unchanged, without running SAM or computing embeddings.

## Motivation

This enables segmentations created by Cellpose or other napari tools to become first-class inputs to micro-sam.
Users can combine an existing mask with positive or negative corrections when refinement is useful, while masks that are already satisfactory can bypass SAM entirely.

Addresses #768.
Related to #383 and #731.

## User-facing behavior

The annotator includes an **Existing Segmentation Inputs** checklist with **Select all** and **Unselect all** controls.
Internal `current_object`, `auto_segmentation` and `committed_objects` layers are excluded so they cannot be selected accidentally; users can duplicate such a layer in napari if they intentionally want to reuse it.

When at least one Labels layer is selected, **Segment Object [S]** uses every selected object as a separate SAM mask prompt and writes the merged result to `current_object`.
With no selected mask input, the action retains the existing point and shape prompt behavior.
This replaces an earlier separate refinement button because manual UX testing showed that two overlapping segmentation actions were confusing.

The **Target object ID** control is populated from the IDs in the selected Labels layers.
Each point or shape stores its own target ID; selecting prompts updates the control, changing the control updates all selected prompts, and mixed selections are shown explicitly.
If the inputs contain only one ID, all current and future corrections are assigned to it automatically.
Every correction must target an ID present in the selected mask inputs.

The point prompt selector is now grouped under **Point and scribble prompts** and is labeled **Prompt type**, with `Positive (include)` and `Negative (exclude)` choices.
It updates selected or future points and scribbles.
Rectangles, ellipses and polygons remain positive because SAM box and dense shape prompts do not have negative semantics.

**Commit selected masks unchanged** copies the selected masks directly into `committed_objects` without computing image embeddings.
This is useful when an external segmentation is already correct or when SAM mask-prompt downsampling would remove fine structures.

## Label and geometry semantics

- Every nonzero label value is an object ID.
- Equal IDs from multiple selected layers are unioned.
- Overlapping different IDs are rejected with an actionable error.
- Source Labels layers are never modified.
- Input and image transforms must match; masks are not resampled.
- A trailing one-pixel surplus is cropped per spatial axis to accommodate the size mismatch produced by newly created napari Labels layers.
- Other shape mismatches remain errors.
- Direct and refined commits preserve sparse IDs and reject collisions atomically.

## 2D and 3D behavior

Each object is sent to SAM independently as its own binary mask prompt, together with only the point, scribble and closed-shape corrections assigned to that object.
This retains object identity and prevents one object from becoming a foreground hint for another.

For 3D inputs, **Refine all occupied slices** performs 2D mask refinement on each occupied slice and keeps the existing z extent.
**Propagate from seed slices** selects the largest cross-section for each object, refines that seed plus any assigned correction anchors, and propagates it through the volume.
SAM-v1 uses slice-to-slice projection, while SAM2 conditions its video predictor with the refined seeds.
Tiled prompt paths are supported for both model generations.

The prompt-based segmentation helpers route mask prompts through SAM-v1, tiled SAM-v1, image-style SAM2 and SAM2 video propagation.
Prompt collection can filter every prompt type by object ID and, for 3D data, by slice.

## Limitation

SAM converts each 2D mask prompt to its 256 × 256 low-resolution representation.
Fine structures may therefore be lost during refinement.
The UI warns users before refinement and the unchanged-commit action provides a lossless alternative.

## Development progression

1. Added Labels-layer collection, validation, per-ID mask extraction and direct unchanged commits.
2. Unified mask refinement with the existing Segment Object action, excluded micro-sam output layers, and added the safe one-pixel crop for new napari Labels layers.
3. Reorganized the controls and replaced the single global correction target with per-prompt object IDs after manual workflow testing and review.
4. Added selection synchronization and regression coverage for mixed targets, cross-layer defaults, prompt polarity preservation and 3D routing.

## Documentation and tests

The annotation documentation explains layer selection, ID merging, geometry validation, per-prompt correction routing, unchanged commits, the 256 × 256 warning, and both 3D modes.

Tests cover input collection and validation, deterministic overlap handling, atomic commits, checklist behavior, per-object 2D and 3D prompt routing, mixed prompt selections, napari trailing-pixel cropping, tiled SAM-v1 prompts, SAM2 mask conditioning and 3D seed propagation.

Local validation:

- Consolidated focused suite: 78 tests passed.
- Additional 3D per-object routing regression: passed.
- Python compilation: passed.
- Ruff checks, excluding the repository's existing long-line style: passed.
- `git diff --check`: passed.
- Manual napari smoke test of the complete mask-input workflow: passed.

The GitHub test matrix requires a maintainer to approve workflows from the fork.
