### PR TITLE
Support bioimageio.spec >=0.5.11 in model export scripts

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -3,7 +3,7 @@ channels:
     - conda-forge
 dependencies:
     - bioimage-cpp >=0.3
-    - bioimageio.core
+    - bioimageio.core >=0.11
     - imagecodecs
     - magicgui
     - napari >=0.7.1

--- a/micro_sam/bioimageio/model_export.py
+++ b/micro_sam/bioimageio/model_export.py
@@ -512,10 +512,10 @@ def export_sam_model(
             authors=kwargs.get("authors", DEFAULTS["authors"]),
             cite=kwargs.get("cite", DEFAULTS["cite"]),
             license=spec.LicenseId("CC-BY-4.0"),
-            documentation=Path(doc_path),
+            documentation=spec.FileDescr(source=Path(doc_path)),
             git_repo=spec.HttpUrl("https://github.com/computational-cell-analytics/micro-sam"),
             tags=kwargs.get("tags", DEFAULTS["tags"]),
-            covers=covers,
+            covers=[spec.FileDescr(source=Path(cover)) for cover in covers],
             **extra_kwargs,
             # TODO write specific settings in the config
             # dict with yaml values, key must be a str

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,8 @@ package_dir =
     = .
 install_requires =
     bioimage-cpp>=0.3
-    bioimageio.core
+    # model_export passes FileDescr for covers and documentation, which needs spec >=0.5.11.
+    bioimageio.core>=0.11
     h5py
     imagecodecs
     imageio


### PR DESCRIPTION
We need https://github.com/conda-forge/bioimageio.core-feedstock/pull/75 merged first before the CIs pass here!