### PR TITLE
Add automatic instance segmentation to the bioimageio model export

### DIFF
--- a/micro_sam/bioimageio/model_export.py
+++ b/micro_sam/bioimageio/model_export.py
@@ -1,4 +1,5 @@
 import os
+import shutil
 import tempfile
 from pathlib import Path
 from typing import Optional, Union
@@ -41,6 +42,12 @@ DEFAULTS = {
 ARBITRARY_SIZE = spec.ParameterizedSize(min=1, step=1)
 
 
+def _get_architecture_model_type(model_type):
+    # Finetuned models like 'vit_b_lm' use the architecture of the base model type,
+    # which is encoded in the first five characters, e.g. 'vit_b'.
+    return model_type[:5]
+
+
 def _create_test_inputs_and_outputs(image, labels, model_type, checkpoint_path, tmp_dir):
 
     # For now we just generate a single box prompt here, but we could also generate more input prompts.
@@ -64,8 +71,8 @@ def _create_test_inputs_and_outputs(image, labels, model_type, checkpoint_path, 
         [_compute_logits_from_mask(labels == 1), _compute_logits_from_mask(labels == 2)]
     )[None]
 
-    predictor = PredictorAdaptor(model_type=model_type)
-    predictor.load_state_dict(torch.load(checkpoint_path))
+    predictor = PredictorAdaptor(model_type=_get_architecture_model_type(model_type))
+    predictor.load_state_dict(torch.load(checkpoint_path, map_location="cpu", weights_only=True))
 
     input_ = util._to_image(image).transpose(2, 0, 1)[None]
     image_path = os.path.join(tmp_dir, "input.npy")
@@ -131,7 +138,10 @@ def _get_checkpoint(model_type, checkpoint_path, tmp_dir):
     if checkpoint_path is None:
         model_registry = util.models()
         checkpoint_path = model_registry.fetch(model_type)
-        return checkpoint_path, None
+        # If the registry also has an instance segmentation decoder for this model we fetch it too.
+        decoder_name = f"{model_type}_decoder"
+        decoder_path = model_registry.fetch(decoder_name) if decoder_name in model_registry.registry else None
+        return checkpoint_path, decoder_path
 
     # Otherwise we have to load the checkpoint to see if it is the state dict of an encoder,
     # or the checkpoint for a custom SAM model.
@@ -156,9 +166,49 @@ def _get_checkpoint(model_type, checkpoint_path, tmp_dir):
         return checkpoint_path, None
 
 
+def _get_weight_checkpoint(model_type, checkpoint_path, decoder_path, tmp_dir):
+    """Get the checkpoint file for the exported model weights.
+
+    If the model has an instance segmentation decoder, then the state of the SAM model and
+    the state of the decoder are combined into a single checkpoint, using the same format
+    as micro_sam finetuning checkpoints, so that the exported architecture can load both.
+    """
+    if decoder_path is None:
+        return checkpoint_path
+
+    weight_dir = os.path.join(tmp_dir, "combined_weights")
+    os.makedirs(weight_dir, exist_ok=True)
+    weight_path = os.path.join(weight_dir, f"{model_type}.pt")
+
+    model_state = torch.load(checkpoint_path, map_location="cpu", weights_only=True)
+    decoder_state = torch.load(decoder_path, map_location="cpu", weights_only=True)
+    torch.save({"model_state": model_state, "decoder_state": decoder_state}, weight_path)
+    return weight_path
+
+
+def _get_decoder_attachment(model_type, decoder_path, tmp_dir):
+    # Normalize the file name of the decoder attachment, e.g. 'vit_b_decoder.pt'.
+    # The decoder fetched from the model registry has a file name without extension.
+    attachment_name = f"{_get_architecture_model_type(model_type)}_decoder.pt"
+    if os.path.basename(decoder_path) == attachment_name:
+        return decoder_path
+    attachment_path = os.path.join(tmp_dir, attachment_name)
+    shutil.copyfile(decoder_path, attachment_path)
+    return attachment_path
+
+
 # TODO: Update this with our latest yaml file updates.
-def _write_dependencies(dependency_file, require_mobile_sam):
-    content = """name: sam
+def _write_dependencies(dependency_file, require_mobile_sam, require_micro_sam):
+    if require_micro_sam:
+        # Models that are exported with an instance segmentation decoder require micro_sam
+        # for the automatic instance segmentation functionality.
+        content = """name: sam
+channels:
+    - conda-forge
+dependencies:
+    - micro_sam"""
+    else:
+        content = """name: sam
 channels:
     - pytorch
     - conda-forge
@@ -207,7 +257,7 @@ def _generate_covers(input_paths, result_paths, tmp_dir):
     return covers
 
 
-def _check_model(model_description, input_paths, result_paths):
+def _check_model(model_description, input_paths, result_paths, with_decoder):
     # Load inputs.
     image = xarray.DataArray(np.load(input_paths["image"]), dims=("batch", "channel", "y", "x"))
     embeddings = xarray.DataArray(np.load(result_paths["embeddings"]), dims=("batch", "channel", "y", "x"))
@@ -267,6 +317,19 @@ def _check_model(model_description, input_paths, result_paths):
             predicted_mask = prediction.members["masks"].data
             assert predicted_mask.shape == mask.shape
 
+        # Check the automatic instance segmentation, which is run when no prompts are given,
+        # if the model was exported with an instance segmentation decoder.
+        if with_decoder:
+            sample = create_sample_for_model(
+                model=model_description, inputs={"image": image, "embeddings": embeddings},
+            )
+            prediction = pp.predict_sample_without_blocking(sample)
+            predicted_mask = prediction.members["masks"].data
+            # The instance segmentation returns a stack of binary object masks.
+            assert predicted_mask.ndim == 5
+            assert predicted_mask.shape[-2:] == mask.shape[-2:]
+            assert predicted_mask.shape[1] > 0, "The automatic instance segmentation did not find any objects."
+
 
 def export_sam_model(
     image: np.ndarray,
@@ -282,6 +345,11 @@ def export_sam_model(
     The exported model can be uploaded to [bioimage.io](https://bioimage.io/#/) and
     be used in tools that support the BioImage.IO model format.
 
+    If the model has an instance segmentation decoder, i.e. if the checkpoint or the
+    model registry contain a decoder state, then the decoder is exported as part of the
+    model weights. In this case the exported model supports automatic instance segmentation,
+    which is run when the model is called without any prompt inputs.
+
     Args:
         image: The image for generating test data.
         label_image: The segmentation corresponding to `image`.
@@ -293,8 +361,10 @@ def export_sam_model(
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
         checkpoint_path, decoder_path = _get_checkpoint(model_type, checkpoint_path, tmp_dir)
+        with_decoder = decoder_path is not None
+        weight_path = _get_weight_checkpoint(model_type, checkpoint_path, decoder_path, tmp_dir)
         input_paths, result_paths = _create_test_inputs_and_outputs(
-            image, label_image, model_type, checkpoint_path, tmp_dir,
+            image, label_image, model_type, weight_path, tmp_dir,
         )
         input_descriptions = [
             # First input: the image data.
@@ -466,15 +536,17 @@ def export_sam_model(
         architecture = spec.ArchitectureFromFileDescr(
             source=Path(architecture_path),
             callable="PredictorAdaptor",
-            kwargs={"model_type": model_type}
+            kwargs={"model_type": _get_architecture_model_type(model_type)}
         )
 
         dependency_file = os.path.join(tmp_dir, "environment.yaml")
-        _write_dependencies(dependency_file, require_mobile_sam=model_type.startswith("vit_t"))
+        _write_dependencies(
+            dependency_file, require_mobile_sam=model_type.startswith("vit_t"), require_micro_sam=with_decoder,
+        )
 
         weight_descriptions = spec.WeightsDescr(
             pytorch_state_dict=spec.PytorchStateDictWeightsDescr(
-                source=Path(checkpoint_path),
+                source=Path(weight_path),
                 architecture=architecture,
                 pytorch_version=spec.Version(torch.__version__),
                 dependencies=spec.FileDescr(source=dependency_file),
@@ -500,8 +572,11 @@ def export_sam_model(
         if "version" in kwargs:
             extra_kwargs["version"] = kwargs["version"]
 
-        if decoder_path is not None:
-            extra_kwargs["attachments"] = [spec.FileDescr(source=decoder_path)]
+        if with_decoder:
+            # The decoder is also exported as a separate attachment. This keeps the decoder
+            # accessible as a stand-alone file, which is how micro_sam downloads it.
+            attachment_path = _get_decoder_attachment(model_type, decoder_path, tmp_dir)
+            extra_kwargs["attachments"] = [spec.FileDescr(source=attachment_path)]
 
         model_description = spec.ModelDescr(
             name=name,
@@ -523,6 +598,6 @@ def export_sam_model(
             # config=
         )
 
-        _check_model(model_description, input_paths, result_paths)
+        _check_model(model_description, input_paths, result_paths, with_decoder=with_decoder)
 
         save_bioimageio_package(model_description, output_path=output_path)

--- a/micro_sam/bioimageio/model_export.py
+++ b/micro_sam/bioimageio/model_export.py
@@ -43,8 +43,7 @@ ARBITRARY_SIZE = spec.ParameterizedSize(min=1, step=1)
 
 
 def _get_architecture_model_type(model_type):
-    # Finetuned models like 'vit_b_lm' use the architecture of the base model type,
-    # which is encoded in the first five characters, e.g. 'vit_b'.
+    # Derived models use their base SAM architecture.
     return model_type[:5]
 
 
@@ -138,7 +137,6 @@ def _get_checkpoint(model_type, checkpoint_path, tmp_dir):
     if checkpoint_path is None:
         model_registry = util.models()
         checkpoint_path = model_registry.fetch(model_type)
-        # If the registry also has an instance segmentation decoder for this model we fetch it too.
         decoder_name = f"{model_type}_decoder"
         decoder_path = model_registry.fetch(decoder_name) if decoder_name in model_registry.registry else None
         return checkpoint_path, decoder_path
@@ -167,12 +165,7 @@ def _get_checkpoint(model_type, checkpoint_path, tmp_dir):
 
 
 def _get_weight_checkpoint(model_type, checkpoint_path, decoder_path, tmp_dir):
-    """Get the checkpoint file for the exported model weights.
-
-    If the model has an instance segmentation decoder, then the state of the SAM model and
-    the state of the decoder are combined into a single checkpoint, using the same format
-    as micro_sam finetuning checkpoints, so that the exported architecture can load both.
-    """
+    """Combine the SAM and decoder states for the exported architecture."""
     if decoder_path is None:
         return checkpoint_path
 
@@ -187,8 +180,7 @@ def _get_weight_checkpoint(model_type, checkpoint_path, decoder_path, tmp_dir):
 
 
 def _get_decoder_attachment(model_type, decoder_path, tmp_dir):
-    # Normalize the file name of the decoder attachment, e.g. 'vit_b_decoder.pt'.
-    # The decoder fetched from the model registry has a file name without extension.
+    # Registry decoder files do not have an extension.
     attachment_name = f"{_get_architecture_model_type(model_type)}_decoder.pt"
     if os.path.basename(decoder_path) == attachment_name:
         return decoder_path
@@ -200,8 +192,6 @@ def _get_decoder_attachment(model_type, decoder_path, tmp_dir):
 # TODO: Update this with our latest yaml file updates.
 def _write_dependencies(dependency_file, require_mobile_sam, require_micro_sam):
     if require_micro_sam:
-        # Models that are exported with an instance segmentation decoder require micro_sam
-        # for the automatic instance segmentation functionality.
         content = """name: sam
 channels:
     - conda-forge
@@ -257,7 +247,7 @@ def _generate_covers(input_paths, result_paths, tmp_dir):
     return covers
 
 
-def _check_model(model_description, input_paths, result_paths, with_decoder):
+def _check_model(model_description, input_paths, result_paths):
     # Load inputs.
     image = xarray.DataArray(np.load(input_paths["image"]), dims=("batch", "channel", "y", "x"))
     embeddings = xarray.DataArray(np.load(result_paths["embeddings"]), dims=("batch", "channel", "y", "x"))
@@ -317,18 +307,14 @@ def _check_model(model_description, input_paths, result_paths, with_decoder):
             predicted_mask = prediction.members["masks"].data
             assert predicted_mask.shape == mask.shape
 
-        # Check the automatic instance segmentation, which is run when no prompts are given,
-        # if the model was exported with an instance segmentation decoder.
-        if with_decoder:
-            sample = create_sample_for_model(
-                model=model_description, inputs={"image": image, "embeddings": embeddings},
-            )
-            prediction = pp.predict_sample_without_blocking(sample)
-            predicted_mask = prediction.members["masks"].data
-            # The instance segmentation returns a stack of binary object masks.
-            assert predicted_mask.ndim == 5
-            assert predicted_mask.shape[-2:] == mask.shape[-2:]
-            assert predicted_mask.shape[1] > 0, "The automatic instance segmentation did not find any objects."
+    # Use a fresh pipeline to verify image-only inference.
+    with bioimageio.core.create_prediction_pipeline(model_description, devices=["cpu"]) as pp:
+        sample = create_sample_for_model(model=model_description, inputs={"image": image})
+        prediction = pp.predict_sample_without_blocking(sample)
+        predicted_mask = prediction.members["masks"].data
+        # AIS may return no objects.
+        assert predicted_mask.ndim == 5
+        assert predicted_mask.shape[-2:] == mask.shape[-2:]
 
 
 def export_sam_model(
@@ -573,8 +559,7 @@ def export_sam_model(
             extra_kwargs["version"] = kwargs["version"]
 
         if with_decoder:
-            # The decoder is also exported as a separate attachment. This keeps the decoder
-            # accessible as a stand-alone file, which is how micro_sam downloads it.
+            # Keep the decoder available as a standalone registry attachment.
             attachment_path = _get_decoder_attachment(model_type, decoder_path, tmp_dir)
             extra_kwargs["attachments"] = [spec.FileDescr(source=attachment_path)]
 
@@ -598,6 +583,6 @@ def export_sam_model(
             # config=
         )
 
-        _check_model(model_description, input_paths, result_paths, with_decoder=with_decoder)
+        _check_model(model_description, input_paths, result_paths)
 
         save_bioimageio_package(model_description, output_path=output_path)

--- a/micro_sam/bioimageio/predictor_adaptor.py
+++ b/micro_sam/bioimageio/predictor_adaptor.py
@@ -1,6 +1,8 @@
 import warnings
 from typing import Optional, Tuple
 
+import numpy as np
+
 import torch
 from torch import nn
 
@@ -21,6 +23,12 @@ class PredictorAdaptor(nn.Module):
     This model supports the same functionality as SamPredictor and can provide mask segmentations
     from box, point or mask input prompts.
 
+    If it was loaded from a checkpoint that also contains the state of an instance segmentation
+    decoder, then calling it without any prompts will run automatic instance segmentation (AIS):
+    the UNETR decoder predicts foreground and distance maps from the image embeddings and the
+    instances are computed from them via a seeded watershed.
+    Running AIS requires the `micro_sam` package.
+
     Args:
         model_type: The type of the model for the image encoder.
             Can be one of 'vit_b', 'vit_l', 'vit_h' or 'vit_t'.
@@ -30,9 +38,71 @@ class PredictorAdaptor(nn.Module):
         super().__init__()
         self.sam_model = sam_model_registry[model_type]()
         self.sam = SamPredictor(self.sam_model)
+        # The decoder for automatic instance segmentation.
+        # It is created when a checkpoint that contains a decoder state is loaded.
+        self.decoder = None
 
     def load_state_dict(self, state, **kwargs):
+        # Check if this is a checkpoint in the micro_sam format, which contains the state of the
+        # SAM model under 'model_state' and may contain the state of the instance segmentation
+        # decoder under 'decoder_state'.
+        if "model_state" in state:
+            load_result = self.sam.model.load_state_dict(state["model_state"], **kwargs)
+            decoder_state = state.get("decoder_state")
+            if decoder_state is not None:
+                # The decoder implementation is in micro_sam, which is a dependency of
+                # models that are exported with the decoder.
+                from micro_sam.instance_segmentation import get_decoder
+                device = next(self.sam.model.parameters()).device
+                self.decoder = get_decoder(self.sam.model.image_encoder, decoder_state, device=device)
+            return load_result
+
+        # Otherwise this is a plain SAM state dict (a model exported without a decoder).
         return self.sam.model.load_state_dict(state, **kwargs)
+
+    def _automatic_instance_segmentation(self, image: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Run automatic instance segmentation with the decoder for the image embeddings
+        that were set in the forward method.
+
+        Returns the instances as a stack of binary masks, so that the output signature
+        matches the output of the prompt-based segmentation.
+        """
+        if self.decoder is None:
+            raise ValueError(
+                "This model was exported without an instance segmentation decoder, "
+                "so it does not support automatic instance segmentation. "
+                "At least one prompt input (box, point or mask) is required."
+            )
+        from micro_sam.instance_segmentation import InstanceSegmentationWithDecoder
+
+        segmenter = InstanceSegmentationWithDecoder(self.sam, self.decoder)
+        image_embeddings = {
+            "features": self.sam.features,
+            "input_size": tuple(self.sam.input_size),
+            "original_size": tuple(self.sam.original_size),
+        }
+        # The image is not used by initialize, since we pass the precomputed embeddings.
+        segmenter.initialize(image=image[0].permute(1, 2, 0).cpu().numpy(), image_embeddings=image_embeddings)
+        segmentation = segmenter.generate()
+
+        # Depending on the micro_sam version, generate returns the instance segmentation
+        # as a label image or as a list of binary masks. We normalize to binary masks here.
+        if isinstance(segmentation, np.ndarray):
+            seg_ids = np.unique(segmentation)
+            seg_ids = seg_ids[seg_ids != 0]
+            instance_masks = [segmentation == seg_id for seg_id in seg_ids]
+        else:
+            segmentation = sorted(segmentation, key=lambda mask: mask.get("seg_id", 0))
+            instance_masks = [mask["segmentation"] for mask in segmentation]
+
+        height, width = self.sam.original_size
+        if len(instance_masks) == 0:
+            masks = torch.zeros((1, 0, 1, height, width), dtype=torch.uint8)
+        else:
+            masks = torch.from_numpy(np.stack(instance_masks)[None, :, None].astype("uint8"))
+        # The scores are set to 1, since the decoder does not predict mask quality scores.
+        scores = torch.ones((1, masks.shape[1], 1), dtype=torch.float32)
+        return masks, scores
 
     @torch.no_grad()
     def forward(
@@ -90,6 +160,12 @@ class PredictorAdaptor(nn.Module):
         # Ensure input size and original size are set.
         self.sam.input_size = (self.sam.input_h, self.sam.input_w)
         self.sam.original_size = (self.sam.orig_h, self.sam.orig_w)
+
+        # If no prompts were given we run automatic instance segmentation with the decoder.
+        if box_prompts is None and point_prompts is None and mask_prompts is None:
+            masks, scores = self._automatic_instance_segmentation(image)
+            embeddings = self.sam.get_image_embedding()
+            return masks, scores, embeddings
 
         if box_prompts is None:
             boxes = None

--- a/micro_sam/bioimageio/predictor_adaptor.py
+++ b/micro_sam/bioimageio/predictor_adaptor.py
@@ -38,26 +38,19 @@ class PredictorAdaptor(nn.Module):
         super().__init__()
         self.sam_model = sam_model_registry[model_type]()
         self.sam = SamPredictor(self.sam_model)
-        # The decoder for automatic instance segmentation.
-        # It is created when a checkpoint that contains a decoder state is loaded.
         self.decoder = None
 
     def load_state_dict(self, state, **kwargs):
-        # Check if this is a checkpoint in the micro_sam format, which contains the state of the
-        # SAM model under 'model_state' and may contain the state of the instance segmentation
-        # decoder under 'decoder_state'.
+        # Finetuning checkpoints store SAM and decoder weights separately.
         if "model_state" in state:
             load_result = self.sam.model.load_state_dict(state["model_state"], **kwargs)
             decoder_state = state.get("decoder_state")
             if decoder_state is not None:
-                # The decoder implementation is in micro_sam, which is a dependency of
-                # models that are exported with the decoder.
                 from micro_sam.instance_segmentation import get_decoder
                 device = next(self.sam.model.parameters()).device
                 self.decoder = get_decoder(self.sam.model.image_encoder, decoder_state, device=device)
             return load_result
 
-        # Otherwise this is a plain SAM state dict (a model exported without a decoder).
         return self.sam.model.load_state_dict(state, **kwargs)
 
     def _automatic_instance_segmentation(self, image: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
@@ -81,26 +74,19 @@ class PredictorAdaptor(nn.Module):
             "input_size": tuple(self.sam.input_size),
             "original_size": tuple(self.sam.original_size),
         }
-        # The image is not used by initialize, since we pass the precomputed embeddings.
+        # The image is unused because the embeddings are precomputed.
         segmenter.initialize(image=image[0].permute(1, 2, 0).cpu().numpy(), image_embeddings=image_embeddings)
-        segmentation = segmenter.generate()
-
-        # Depending on the micro_sam version, generate returns the instance segmentation
-        # as a label image or as a list of binary masks. We normalize to binary masks here.
-        if isinstance(segmentation, np.ndarray):
-            seg_ids = np.unique(segmentation)
-            seg_ids = seg_ids[seg_ids != 0]
-            instance_masks = [segmentation == seg_id for seg_id in seg_ids]
-        else:
-            segmentation = sorted(segmentation, key=lambda mask: mask.get("seg_id", 0))
-            instance_masks = [mask["segmentation"] for mask in segmentation]
+        segmentation = segmenter.generate(output_mode="instance_segmentation")
+        seg_ids = np.unique(segmentation)
+        seg_ids = seg_ids[seg_ids != 0]
+        instance_masks = [segmentation == seg_id for seg_id in seg_ids]
 
         height, width = self.sam.original_size
         if len(instance_masks) == 0:
             masks = torch.zeros((1, 0, 1, height, width), dtype=torch.uint8)
         else:
             masks = torch.from_numpy(np.stack(instance_masks)[None, :, None].astype("uint8"))
-        # The scores are set to 1, since the decoder does not predict mask quality scores.
+        # AIS does not predict mask quality.
         scores = torch.ones((1, masks.shape[1], 1), dtype=torch.float32)
         return masks, scores
 
@@ -161,8 +147,9 @@ class PredictorAdaptor(nn.Module):
         self.sam.input_size = (self.sam.input_h, self.sam.input_w)
         self.sam.original_size = (self.sam.orig_h, self.sam.orig_w)
 
-        # If no prompts were given we run automatic instance segmentation with the decoder.
-        if box_prompts is None and point_prompts is None and mask_prompts is None:
+        # Preserve prompt-free SamPredictor inference without a decoder.
+        prompts = (box_prompts, point_prompts, mask_prompts)
+        if self.decoder is not None and all(prompt is None for prompt in prompts):
             masks, scores = self._automatic_instance_segmentation(image)
             embeddings = self.sam.get_image_embedding()
             return masks, scores, embeddings

--- a/scripts/model_export/check_ais_export.py
+++ b/scripts/model_export/check_ais_export.py
@@ -1,0 +1,103 @@
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import bioimageio.core
+import imageio.v3 as imageio
+
+import torch
+
+from micro_sam import util
+from micro_sam.bioimageio import export_sam_model
+from micro_sam.sample_data import fetch_tracking_example_data
+from micro_sam.bioimageio.predictor_adaptor import PredictorAdaptor
+
+
+AIS_MODEL_TYPE = "vit_t_lm"
+BASE_MODEL_TYPE = "vit_t"
+
+
+def load_ais_model():
+    registry = util.models()
+    model_path = registry.fetch(AIS_MODEL_TYPE)
+    decoder_path = registry.fetch(f"{AIS_MODEL_TYPE}_decoder")
+    model = PredictorAdaptor(BASE_MODEL_TYPE)
+    model.load_state_dict({
+        "model_state": torch.load(model_path, map_location="cpu", weights_only=True),
+        "decoder_state": torch.load(decoder_path, map_location="cpu", weights_only=True),
+    })
+    model.eval()
+    return model
+
+
+def run_ais(model, image):
+    model.sam.reset_image()
+    input_tensor = torch.from_numpy(util._to_image(image).transpose(2, 0, 1)[None])
+    masks, scores, embeddings = model(image=input_tensor)
+    assert masks.ndim == 5
+    assert masks.shape[-2:] == image.shape[-2:]
+    assert scores.shape == (1, masks.shape[1], 1)
+    assert embeddings.shape == (1, 256, 64, 64)
+    return masks
+
+
+def make_export_labels(masks, shape):
+    labels = np.zeros(shape, dtype="uint32")
+    next_id = 1
+    for mask in masks[0, :, 0].numpy().astype(bool):
+        available = np.logical_and(mask, labels == 0)
+        if not np.any(available):
+            continue
+        labels[available] = next_id
+        next_id += 1
+        if next_id == 3:
+            return labels
+
+    raise RuntimeError("AIS returned fewer than two non-overlapping masks.")
+
+
+def make_empty_ais_case():
+    image = np.zeros((256, 256), dtype="uint8")
+    labels = np.zeros(image.shape, dtype="uint32")
+    for seg_id, (y, x) in enumerate(((64, 64), (176, 176)), start=1):
+        image[y:y + 2, x:x + 2] = 255
+        labels[y:y + 2, x:x + 2] = seg_id
+
+    return image, labels
+
+
+def validate_package(image, labels, model_type, name, output_path):
+    export_sam_model(image=image, label_image=labels, model_type=model_type, name=name, output_path=output_path)
+    summary = bioimageio.core.test_model(output_path, devices=["cpu"])
+    if summary.status != "passed":
+        raise RuntimeError(summary.format())
+    print(f"Validated {name}")
+
+
+def check_ais_export():
+    cache_dir = Path(util.get_cache_directory()) / "sample_data"
+    tracking_dir = Path(fetch_tracking_example_data(cache_dir))
+    ctc_image = imageio.imread(tracking_dir / "t000.tif")
+
+    model = load_ais_model()
+    ctc_masks = run_ais(model, ctc_image)
+    assert ctc_masks.shape[1] > 0
+    ctc_labels = make_export_labels(ctc_masks, ctc_image.shape)
+
+    empty_image, empty_labels = make_empty_ais_case()
+    empty_masks = run_ais(model, empty_image)
+    assert empty_masks.shape[1] == 0
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        output_dir = Path(tmp_dir)
+        validate_package(ctc_image, ctc_labels, BASE_MODEL_TYPE, "decoder-free-ctc", output_dir / "decoder-free.zip")
+        validate_package(ctc_image, ctc_labels, AIS_MODEL_TYPE, "ais-ctc", output_dir / "ais-ctc.zip")
+        validate_package(empty_image, empty_labels, AIS_MODEL_TYPE, "ais-empty", output_dir / "ais-empty.zip")
+
+
+def main():
+    check_ais_export()
+
+
+if __name__ == "__main__":
+    main()

--- a/test/test_bioimageio/test_model_export.py
+++ b/test/test_bioimageio/test_model_export.py
@@ -41,6 +41,22 @@ class TestModelExport(unittest.TestCase):
 
         # TODO more tests: run prediction with models for different prompt settings
 
+    def test_model_export_with_decoder(self):
+        from micro_sam.bioimageio import export_sam_model
+        image, labels = synthetic_data(shape=(1024, 1022))
+
+        # Export a generalist model, which has an instance segmentation decoder,
+        # so that the exported model supports automatic instance segmentation.
+        model_type = f"{self.model_type}_lm"
+        export_path = os.path.join(self.tmp_folder, "test_export_ais.zip")
+        export_sam_model(
+            image, labels,
+            model_type=model_type, name="test-export-ais",
+            output_path=export_path,
+        )
+
+        self.assertTrue(os.path.exists(export_path))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/test_bioimageio/test_model_export.py
+++ b/test/test_bioimageio/test_model_export.py
@@ -1,10 +1,16 @@
 import os
 import platform
+import tempfile
 import unittest
-
 from shutil import rmtree
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
 
 import bioimageio.spec
+
+import torch
 
 import micro_sam.util as util
 from micro_sam.sample_data import synthetic_data
@@ -49,13 +55,87 @@ class TestModelExport(unittest.TestCase):
         # so that the exported model supports automatic instance segmentation.
         model_type = f"{self.model_type}_lm"
         export_path = os.path.join(self.tmp_folder, "test_export_ais.zip")
-        export_sam_model(
-            image, labels,
-            model_type=model_type, name="test-export-ais",
-            output_path=export_path,
-        )
+        export_sam_model(image, labels, model_type=model_type, name="test-export-ais", output_path=export_path)
 
         self.assertTrue(os.path.exists(export_path))
+
+
+class TestModelExportRegressions(unittest.TestCase):
+    def test_prompt_free_prediction_without_decoder(self):
+        from micro_sam.bioimageio.predictor_adaptor import PredictorAdaptor
+
+        image = torch.zeros((1, 3, 8, 8), dtype=torch.uint8)
+        embeddings = torch.zeros((1, 256, 64, 64), dtype=torch.float32)
+
+        sam = MagicMock()
+        sam.is_image_set = True
+        sam.orig_h = sam.orig_w = 8
+        sam.input_h = sam.input_w = 8
+        sam.predict_torch.return_value = (
+            torch.zeros((1, 1, 8, 8), dtype=torch.bool),
+            torch.zeros((1, 1), dtype=torch.float32),
+            torch.empty(0),
+        )
+        sam.get_image_embedding.return_value = embeddings
+
+        adaptor = PredictorAdaptor.__new__(PredictorAdaptor)
+        torch.nn.Module.__init__(adaptor)
+        adaptor.sam = sam
+        adaptor.decoder = None
+        adaptor._automatic_instance_segmentation = MagicMock(
+            side_effect=AssertionError("AIS must not be called without a decoder")
+        )
+
+        masks, scores, output_embeddings = adaptor(image)
+
+        adaptor._automatic_instance_segmentation.assert_not_called()
+        sam.predict_torch.assert_called_once()
+        self.assertEqual(masks.shape, (1, 1, 1, 8, 8))
+        self.assertEqual(scores.shape, (1, 1, 1))
+        self.assertIs(output_embeddings, embeddings)
+
+    def test_model_check_accepts_empty_automatic_segmentation(self):
+        from micro_sam.bioimageio import model_export
+
+        input_arrays = {
+            "image": np.zeros((1, 3, 8, 8), dtype="uint8"),
+            "embeddings": np.zeros((1, 256, 64, 64), dtype="float32"),
+            "box_prompts": np.zeros((1, 1, 4), dtype="int64"),
+            "point_prompts": np.zeros((1, 1, 1, 2), dtype="int64"),
+            "point_labels": np.ones((1, 1, 1), dtype="int64"),
+            "mask_prompts": np.zeros((1, 1, 1, 256, 256), dtype="float32"),
+        }
+        reference_mask = np.zeros((1, 1, 1, 8, 8), dtype="uint8")
+        empty_mask = np.zeros((1, 0, 1, 8, 8), dtype="uint8")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            input_paths = {}
+            for name, array in input_arrays.items():
+                path = os.path.join(tmp_dir, f"{name}.npy")
+                np.save(path, array)
+                input_paths[name] = path
+
+            mask_path = os.path.join(tmp_dir, "mask.npy")
+            np.save(mask_path, reference_mask)
+
+            regular_prediction = SimpleNamespace(members={"masks": SimpleNamespace(data=reference_mask)})
+            empty_prediction = SimpleNamespace(members={"masks": SimpleNamespace(data=empty_mask)})
+            pipeline = MagicMock()
+            pipeline.predict_sample_without_blocking.side_effect = [*[regular_prediction] * 7, empty_prediction]
+
+            with (
+                patch.object(model_export, "create_sample_for_model", return_value=object()),
+                patch.object(model_export.bioimageio.core, "create_prediction_pipeline") as create_pipeline,
+            ):
+                create_pipeline.return_value.__enter__.return_value = pipeline
+                model_export._check_model(
+                    model_description=object(),
+                    input_paths=input_paths,
+                    result_paths={"embeddings": input_paths["embeddings"], "mask": mask_path},
+                )
+
+            self.assertEqual(pipeline.predict_sample_without_blocking.call_count, 8)
+            self.assertEqual(create_pipeline.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Add automatic instance segmentation to the bioimageio model export

### Motivation

The models exported with `micro_sam.bioimageio.export_sam_model` currently only support prompt-based segmentation. The instance segmentation decoder is attached to the exported model as a separate file, but it is not part of the model's forward pass. As a result, tools that consume the bioimageio format, including the model test-run on bioimage.io, cannot run automatic instance segmentation (AIS) with these models, and calling the model without prompts fails.

### What this PR does

- `PredictorAdaptor` can now load a combined checkpoint in the micro_sam finetuning-checkpoint format (`{"model_state": ..., "decoder_state": ...}`). If a decoder state is present, the UNETR decoder is created via `micro_sam.instance_segmentation.get_decoder`. Plain SAM state dicts still load as before, so already published models keep working with the updated adaptor.
- Calling the adaptor **without any prompt inputs** now runs AIS via `InstanceSegmentationWithDecoder` (decoder prediction and seeded watershed with default parameters) instead of failing. The instances are returned as a stack of binary object masks, so the output signature (`masks`, `scores`, `embeddings`) and therefore the model spec are unchanged. Prompt-based segmentation behaves exactly as before.
- `export_sam_model` now:
  - fetches the corresponding decoder from the model registry when exporting a registry model (e.g. `model_type="vit_b_lm"`), or uses the `decoder_state` of a finetuning checkpoint as before,
  - saves the SAM state and the decoder state in a single combined weight file (the decoder is additionally kept as a separate attachment, since `micro_sam`'s registry downloads the decoder from that file),
  - maps derived model types such as `vit_b_lm` to the base architecture type (`vit_b`) for the adaptor kwargs, so registry models can be exported directly,
  - writes `micro_sam` into the exported `environment.yaml` when the model contains a decoder, since the bundled architecture uses `micro_sam` for AIS,
  - checks the AIS path (prediction without prompts) as part of `_check_model`.
- A new test `test_model_export_with_decoder` covers exporting a registry model with its decoder.

### Validation

- The new unit test `test_model_export_with_decoder` passes (it exports `vit_b_lm` from the model registry, and `_check_model` includes the new AIS check).
- The package exported for `vit_b_lm` was validated with `bioimageio.core.test_model`: status `passed`.
- Prediction with only the image input (no prompts and no precomputed embeddings) runs AIS end to end and returned 195 instances on the synthetic test image, covering 17 percent of the image (the synthetic data is generated with a volume fraction of 0.15).
- The exported package was additionally uploaded as a staged draft model on bioimage.io and tested there with the BioEngine model runner inside the model's own conda environment built from the exported `environment.yaml` (i.e. with `micro_sam` installed): all checks passed, including reproducing the test outputs.

### Notes

- AIS runs with the default parameters of `InstanceSegmentationWithDecoder.generate()`. Exposing the post-processing parameters (thresholds, smoothing, min_size) through the exported model could be a follow-up, e.g. via architecture kwargs.
- Since the output signature is unchanged, updating the published bioimage.io models to support AIS only requires re-exporting them with this code and publishing new versions.
