### PR TITLE
Invalidate cached image embeddings when forward() receives a different image

### DIFF
--- a/micro_sam/bioimageio/predictor_adaptor.py
+++ b/micro_sam/bioimageio/predictor_adaptor.py
@@ -39,6 +39,10 @@ class PredictorAdaptor(nn.Module):
         self.sam_model = sam_model_registry[model_type]()
         self.sam = SamPredictor(self.sam_model)
         self.decoder = None
+        # The image the current self.sam embeddings were computed for (or that
+        # externally passed embeddings were declared for). Used to invalidate
+        # the embedding cache when forward() is called with a different image.
+        self._input_image = None
 
     def load_state_dict(self, state, **kwargs):
         # Finetuning checkpoints store SAM and decoder weights separately.
@@ -123,8 +127,17 @@ class PredictorAdaptor(nn.Module):
         # only supports floating-point dtypes on MPS (Apple Silicon).
         image_float = image.float() if not image.is_floating_point() else image
 
-        # We have image embeddings set and image embeddings were not passed.
-        if self.sam.is_image_set and embeddings is None:
+        # We have image embeddings set for this exact image and no new image
+        # embeddings were passed. Comparing against the cached image is required
+        # for correctness: reusing embeddings of a previous, different image
+        # would silently return segmentations in the old image's geometry.
+        if (
+            self.sam.is_image_set
+            and embeddings is None
+            and self._input_image is not None
+            and image.shape == self._input_image.shape
+            and torch.equal(image, self._input_image)
+        ):
             pass  # do nothing
 
         # The embeddings are passed, so we set them.
@@ -133,13 +146,16 @@ class PredictorAdaptor(nn.Module):
             self.sam.orig_h, self.sam.orig_w = image.shape[2:]
             self.sam.input_h, self.sam.input_w = self.sam.transform.apply_image_torch(image_float).shape[2:]
             self.sam.is_image_set = True
+            self._input_image = image.detach().clone()
 
-        # We don't have image embeddings set and they were not passed.
-        elif not self.sam.is_image_set:
+        # No embeddings were passed and we don't have embeddings for this image,
+        # so we compute them.
+        else:
             input_ = self.sam.transform.apply_image_torch(image_float)
             self.sam.set_torch_image(input_, original_image_size=image.shape[2:])
             self.sam.orig_h, self.sam.orig_w = self.sam.original_size
             self.sam.input_h, self.sam.input_w = self.sam.input_size
+            self._input_image = image.detach().clone()
 
         assert self.sam.is_image_set, "The predictor has not yet been initialized."
 

--- a/micro_sam/bioimageio/predictor_adaptor.py
+++ b/micro_sam/bioimageio/predictor_adaptor.py
@@ -39,10 +39,9 @@ class PredictorAdaptor(nn.Module):
         self.sam_model = sam_model_registry[model_type]()
         self.sam = SamPredictor(self.sam_model)
         self.decoder = None
-        # The image the current self.sam embeddings were computed for (or that
-        # externally passed embeddings were declared for). Used to invalidate
-        # the embedding cache when forward() is called with a different image.
-        self._input_image = None
+        # Cache the bounded SAM input and original size for invalidation.
+        self._cached_input = None
+        self._cached_original_size = None
 
     def load_state_dict(self, state, **kwargs):
         # Finetuning checkpoints store SAM and decoder weights separately.
@@ -126,36 +125,37 @@ class PredictorAdaptor(nn.Module):
         # Cast to float for MPS compatibility: F.interpolate with antialias=True
         # only supports floating-point dtypes on MPS (Apple Silicon).
         image_float = image.float() if not image.is_floating_point() else image
+        input_ = self.sam.transform.apply_image_torch(image_float)
+        original_image_size = tuple(image.shape[2:])
 
-        # We have image embeddings set for this exact image and no new image
-        # embeddings were passed. Comparing against the cached image is required
-        # for correctness: reusing embeddings of a previous, different image
-        # would silently return segmentations in the old image's geometry.
+        # Reuse embeddings only when their input and output geometry match.
         if (
             self.sam.is_image_set
             and embeddings is None
-            and self._input_image is not None
-            and image.shape == self._input_image.shape
-            and torch.equal(image, self._input_image)
+            and self._cached_input is not None
+            and self._cached_original_size == original_image_size
+            and input_.shape == self._cached_input.shape
+            and torch.equal(input_, self._cached_input)
         ):
             pass  # do nothing
 
         # The embeddings are passed, so we set them.
         elif embeddings is not None:
             self.sam.features = embeddings
-            self.sam.orig_h, self.sam.orig_w = image.shape[2:]
-            self.sam.input_h, self.sam.input_w = self.sam.transform.apply_image_torch(image_float).shape[2:]
+            self.sam.orig_h, self.sam.orig_w = original_image_size
+            self.sam.input_h, self.sam.input_w = input_.shape[2:]
             self.sam.is_image_set = True
-            self._input_image = image.detach().clone()
+            self._cached_input = input_.detach().clone()
+            self._cached_original_size = original_image_size
 
         # No embeddings were passed and we don't have embeddings for this image,
         # so we compute them.
         else:
-            input_ = self.sam.transform.apply_image_torch(image_float)
-            self.sam.set_torch_image(input_, original_image_size=image.shape[2:])
+            self.sam.set_torch_image(input_, original_image_size=original_image_size)
             self.sam.orig_h, self.sam.orig_w = self.sam.original_size
             self.sam.input_h, self.sam.input_w = self.sam.input_size
-            self._input_image = image.detach().clone()
+            self._cached_input = input_.detach().clone()
+            self._cached_original_size = original_image_size
 
         assert self.sam.is_image_set, "The predictor has not yet been initialized."
 

--- a/test/test_bioimageio/test_model_export.py
+++ b/test/test_bioimageio/test_model_export.py
@@ -82,6 +82,9 @@ class TestModelExportRegressions(unittest.TestCase):
         torch.nn.Module.__init__(adaptor)
         adaptor.sam = sam
         adaptor.decoder = None
+        # The embedding cache is keyed on the input image: embeddings are only
+        # reused when the incoming image matches the recorded one.
+        adaptor._input_image = image
         adaptor._automatic_instance_segmentation = MagicMock(
             side_effect=AssertionError("AIS must not be called without a decoder")
         )

--- a/test/test_bioimageio/test_model_export.py
+++ b/test/test_bioimageio/test_model_export.py
@@ -71,6 +71,7 @@ class TestModelExportRegressions(unittest.TestCase):
         sam.is_image_set = True
         sam.orig_h = sam.orig_w = 8
         sam.input_h = sam.input_w = 8
+        sam.transform.apply_image_torch.return_value = image.float()
         sam.predict_torch.return_value = (
             torch.zeros((1, 1, 8, 8), dtype=torch.bool),
             torch.zeros((1, 1), dtype=torch.float32),
@@ -82,9 +83,9 @@ class TestModelExportRegressions(unittest.TestCase):
         torch.nn.Module.__init__(adaptor)
         adaptor.sam = sam
         adaptor.decoder = None
-        # The embedding cache is keyed on the input image: embeddings are only
-        # reused when the incoming image matches the recorded one.
-        adaptor._input_image = image
+        # Cache identity includes the transformed input and original size.
+        adaptor._cached_input = image.float()
+        adaptor._cached_original_size = (8, 8)
         adaptor._automatic_instance_segmentation = MagicMock(
             side_effect=AssertionError("AIS must not be called without a decoder")
         )
@@ -96,6 +97,57 @@ class TestModelExportRegressions(unittest.TestCase):
         self.assertEqual(masks.shape, (1, 1, 1, 8, 8))
         self.assertEqual(scores.shape, (1, 1, 1))
         self.assertIs(output_embeddings, embeddings)
+
+    def test_embedding_cache_uses_bounded_transformed_input(self):
+        from micro_sam.bioimageio.predictor_adaptor import PredictorAdaptor
+
+        embeddings = torch.zeros((1, 256, 64, 64), dtype=torch.float32)
+        sam = MagicMock()
+        sam.is_image_set = False
+        sam.transform.apply_image_torch.side_effect = lambda image: image[..., :4, :4]
+
+        def set_torch_image(input_, original_image_size):
+            sam.is_image_set = True
+            sam.original_size = tuple(original_image_size)
+            sam.input_size = tuple(input_.shape[2:])
+
+        def predict_torch(**kwargs):
+            height, width = sam.original_size
+            return (
+                torch.zeros((1, 1, height, width), dtype=torch.bool),
+                torch.zeros((1, 1), dtype=torch.float32),
+                torch.empty(0),
+            )
+
+        sam.set_torch_image.side_effect = set_torch_image
+        sam.predict_torch.side_effect = predict_torch
+        sam.get_image_embedding.return_value = embeddings
+
+        adaptor = PredictorAdaptor.__new__(PredictorAdaptor)
+        torch.nn.Module.__init__(adaptor)
+        adaptor.sam = sam
+        adaptor.decoder = None
+        adaptor._cached_input = None
+        adaptor._cached_original_size = None
+
+        image = torch.zeros((1, 3, 8, 8), dtype=torch.uint8)
+        adaptor(image)
+        adaptor(image.clone())
+
+        # The second call reuses the embeddings for the same image.
+        self.assertEqual(sam.set_torch_image.call_count, 1)
+        self.assertEqual(adaptor._cached_input.shape, (1, 3, 4, 4))
+        self.assertEqual(adaptor._cached_original_size, (8, 8))
+
+        # Different transformed content invalidates the embeddings.
+        adaptor(torch.ones_like(image))
+        self.assertEqual(sam.set_torch_image.call_count, 2)
+
+        # A different original size invalidates identical transformed content.
+        adaptor(torch.ones((1, 3, 16, 8), dtype=torch.uint8))
+        self.assertEqual(sam.set_torch_image.call_count, 3)
+        self.assertEqual(adaptor._cached_input.shape, (1, 3, 4, 4))
+        self.assertEqual(adaptor._cached_original_size, (16, 8))
 
     def test_model_check_accepts_empty_automatic_segmentation(self):
         from micro_sam.bioimageio import model_export


### PR DESCRIPTION
The `PredictorAdaptor` computes image embeddings on the first prompt-free `forward()` call and then never recomputes them: `is_image_set` stays true, so every later call with a *different* image silently reuses the first image's embeddings and returns masks in the first image's geometry. The bug is masked whenever the `embeddings` input is passed (that branch overwrites the cache on every call), which is why `bioimageio.core.test_model` does not catch it for exports that declare the prompt/embeddings inputs. It does affect any consumer that keeps one model instance alive across images, e.g. `bioimageio.core` prediction pipelines and model servers, and it makes prompt-free (AIS-only) exports fail `test_model`'s parametrized-size probes, which reuse a single pipeline for the n=0, 1, 2 input sizes.

This change keys the embedding cache on the actual input: the adaptor records the image tensor the current embeddings belong to and reuses them only when the incoming image is equal to it. Passing `embeddings` explicitly still overrides the cache as before, and repeated calls with the same image still skip recomputation, so interactive prompt iteration on one image is unaffected.

Validated on the six bioimage.io zoo SAM models: `bioimageio.core.test_model` passes with the patched adaptor for image-only (AIS) packages, including the parametrized-size probes at three different input sizes, both locally and in clean conda environments created from the exported `environment.yaml`. Sequential `forward()` calls with different image sizes now return correctly sized outputs where they previously returned the first call's geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)