### PR TITLE
Fix segment anything installation from pip

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
     python-elf>=0.9
     scikit-image
     scikit-learn
-    segment-anything
+    segment-anything-py>=1.0.1
     superqt
     timm
     torch>=2.5

--- a/test/test_dependencies.py
+++ b/test/test_dependencies.py
@@ -1,0 +1,15 @@
+import unittest
+
+import torch
+
+from segment_anything.utils.transforms import ResizeLongestSide
+
+
+class TestDependencies(unittest.TestCase):
+    def test_resize_longest_side_torch(self):
+        transform = ResizeLongestSide(16)
+        image = torch.zeros((1, 3, 5, 7))
+
+        resized = transform.apply_image_torch(image)
+
+        self.assertEqual(tuple(resized.shape), (1, 3, 11, 16))


### PR DESCRIPTION
Okay over `micro_sam-feedstock` -- we use the `segment-anything` package from this feedstock: https://github.com/conda-forge/segment-anything-feedstock.

And the same author has pypi wheels at https://pypi.org/project/segment-anything-py/. And they've had the parallel versions of adopting the fixes around. So I think it's better to go with theirs, knowing the issue reported by @nilsmechtel (thanks once again for reporting 🥳)

I'll go ahead, merge this and then make a new release to fix it!